### PR TITLE
[ODE] Show user groups in the communication view

### DIFF
--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -445,7 +445,21 @@
     "user.communication.title": "Communication de {{ lastName }} {{ firstName }}",
     "user.communication.back-to-user-details": "Retour à la fiche",
     "user.communication.help": "Un droit de communication s'acquière par l'appartenance à un groupe. On affiche donc la liste des groupes de l'utilisateur et les groupes qui sont visibles. Cliquez sur un groupe pour voir les droits qui lui sont associés.",
-    
+    "user.communication.groups-of-user": "Groupes de l'utlisateur",
+
+    "group.card.add-communication-button": "Ajouter un droit de communication",
+
+    "group.card.structure.Personnel": "Personnels de {{name}}",
+    "group.card.structure.Relative": "Parents de {{name}}",
+    "group.card.structure.Student": "Élèves de {{name}}",
+    "group.card.structure.Teacher": "Enseignants de {{name}}",
+    "group.card.structure.Guest": "Invités de {{name}}",
+    "group.card.class.Personnel": "Personnels de la classe {{name}}",
+    "group.card.class.Relative": "Parents de la classe {{name}}",
+    "group.card.class.Student": "Élèves de la classe {{name}}",
+    "group.card.class.Teacher": "Enseignants de la classe {{name}}",
+    "group.card.class.Guest": "Invités de la classe {{name}}",
+
     "quota.byte": "Octet(s)",
     "quota.kilobyte": "KiloOctet(s)",
     "quota.megabyte": "MegaOctet(s)",

--- a/admin/src/main/ts/app/core/store/models/group.model.ts
+++ b/admin/src/main/ts/app/core/store/models/group.model.ts
@@ -1,6 +1,7 @@
 import { Model } from 'entcore-toolkit';
 import { UserModel } from './user.model';
-import { InternalCommunicationRule } from '../../../groups/details/group-internal-communication-rule.resolver';
+
+export type InternalCommunicationRule = 'BOTH' | 'INCOMING' | 'OUTGOING' | 'NONE';
 
 export class GroupModel extends Model<GroupModel> {
 

--- a/admin/src/main/ts/app/core/store/models/group.model.ts
+++ b/admin/src/main/ts/app/core/store/models/group.model.ts
@@ -1,42 +1,46 @@
-import { Model } from 'entcore-toolkit'
-import { UserModel } from './user.model'
+import { Model } from 'entcore-toolkit';
+import { UserModel } from './user.model';
+import { InternalCommunicationRule } from '../../../groups/details/group-internal-communication-rule.resolver';
 
 export class GroupModel extends Model<GroupModel> {
 
-    id?: string
-    name?: string
-    displayName?: string
-    type?: string
-    subType?: string
-    classes?: {id: string, name: string}[]
-    structureId?: string
-    users: UserModel[]
+    id?: string;
+    name?: string;
+    displayName?: string;
+    type?: string;
+    subType?: string;
+    classes?: { id: string, name: string }[];
+    structures?: { id: string, name: string }[];
+    filter?: string;
+    structureId?: string;
+    users: UserModel[];
+    internalCommunicationRule?: InternalCommunicationRule;
 
     constructor() {
         super({
             create: '/directory/group'
-        })
-        this.users = new Array<UserModel>()
+        });
+        this.users = new Array<UserModel>();
     }
 
     syncUsers() {
         return this.http.get(`/directory/user/admin/list?groupId=${this.id}`).then(res => {
-            this.users = res.data
-        })
+            this.users = res.data;
+        });
     }
 
     addUsers(users: UserModel[]) {
-        return this.http.put(`/directory/group/${this.id}/users/add`, {"userIds": users.map(u => u.id)})
+        return this.http.put(`/directory/group/${this.id}/users/add`, {"userIds": users.map(u => u.id)});
     }
 
     removeUsers(users: UserModel[]) {
-        return this.http.put(`/directory/group/${this.id}/users/delete`, {"userIds": users.map(u => u.id)})
+        return this.http.put(`/directory/group/${this.id}/users/delete`, {"userIds": users.map(u => u.id)});
     }
 
     toJSON() {
         return {
             name: this.name,
             structureId: this.structureId
-        }
+        };
     }
 }

--- a/admin/src/main/ts/app/groups/details/group-details.component.spec.ts
+++ b/admin/src/main/ts/app/groups/details/group-details.component.spec.ts
@@ -4,36 +4,13 @@ import { ActivatedRoute } from '@angular/router';
 import { ChangeDetectorRef, Component, EventEmitter, Input, Output } from '@angular/core';
 import { SijilModule } from 'sijil';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import 'rxjs/add/observable/of';
-
 import { UxModule } from '../../shared/ux/ux.module';
 import { GroupsStore } from '../groups.store';
 import { GroupDetails } from './group-details.component';
 import { GroupModel, StructureModel } from '../../core/store/models';
 import { GroupCollection } from '../../core/store/collections';
 import { GroupIdAndInternalCommunicationRule } from './group-internal-communication-rule.resolver';
-
-@Component({
-    selector: 'group-manage-users',
-    template: ''
-})
-class MockGroupManageUsers {
-    @Output() close: EventEmitter<void> = new EventEmitter<void>();
-}
-
-@Component({
-    selector: 'group-users-list',
-    template: '<ng-content></ng-content>'
-})
-class MockGroupUsersList {
-    @Input() users;
-}
-
-function generateMockGroupModel(id: string, type: string): GroupModel {
-    const groupModel: GroupModel = {id, type} as GroupModel;
-    groupModel.users = [];
-    return groupModel;
-}
+import 'rxjs/add/observable/of';
 
 describe('GroupDetails', () => {
     let component: GroupDetails;
@@ -190,3 +167,25 @@ describe('GroupDetails', () => {
         expect(component.internalCommunicationRule).toBe('BOTH');
     });
 });
+
+@Component({
+    selector: 'group-manage-users',
+    template: ''
+})
+class MockGroupManageUsers {
+    @Output() close: EventEmitter<void> = new EventEmitter<void>();
+}
+
+@Component({
+    selector: 'group-users-list',
+    template: '<ng-content></ng-content>'
+})
+class MockGroupUsersList {
+    @Input() users;
+}
+
+function generateMockGroupModel(id: string, type: string): GroupModel {
+    const groupModel: GroupModel = {id, type} as GroupModel;
+    groupModel.users = [];
+    return groupModel;
+}

--- a/admin/src/main/ts/app/groups/details/group-details.component.ts
+++ b/admin/src/main/ts/app/groups/details/group-details.component.ts
@@ -6,15 +6,12 @@ import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/do';
-import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/observable/merge';
 
 import { GroupsStore } from '../groups.store';
-import {
-    GroupIdAndInternalCommunicationRule,
-    InternalCommunicationRule
-} from './group-internal-communication-rule.resolver';
+import { GroupIdAndInternalCommunicationRule } from './group-internal-communication-rule.resolver';
+import { InternalCommunicationRule } from '../../core/store/models';
 
 @Component({
     selector: 'group-detail',

--- a/admin/src/main/ts/app/groups/details/group-internal-communication-rule.resolver.spec.ts
+++ b/admin/src/main/ts/app/groups/details/group-internal-communication-rule.resolver.spec.ts
@@ -1,12 +1,11 @@
 import { ActivatedRouteSnapshot, convertToParamMap, RouterStateSnapshot } from '@angular/router';
 import { async, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-
 import {
-CommunicationGroupResponse,
-GroupInternalCommunicationRuleResolver,
-InternalCommunicationRule
+    CommunicationGroupResponse,
+    GroupInternalCommunicationRuleResolver
 } from './group-internal-communication-rule.resolver';
+import { InternalCommunicationRule } from '../../core/store/models';
 
 describe('GroupInternalCommunicationRuleResolver', () => {
     let service: GroupInternalCommunicationRuleResolver;

--- a/admin/src/main/ts/app/groups/details/group-internal-communication-rule.resolver.ts
+++ b/admin/src/main/ts/app/groups/details/group-internal-communication-rule.resolver.ts
@@ -3,8 +3,7 @@ import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/r
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 import { HttpClient } from '@angular/common/http';
-
-export type InternalCommunicationRule = 'BOTH' | 'INCOMING' | 'OUTGOING' | 'NONE';
+import { InternalCommunicationRule } from '../../core/store/models';
 
 export interface CommunicationGroupResponse {
     groupDisplayName: string;

--- a/admin/src/main/ts/app/users/communication/communication-rules.component.spec.ts
+++ b/admin/src/main/ts/app/users/communication/communication-rules.component.spec.ts
@@ -8,7 +8,7 @@ import {
     CommunicationRulesComponent,
     communicationRulesLocators as locators
 } from './communication-rules.component';
-import { generateGroup } from './user-communication.component.spec';
+import { generateGroup } from './communication-test-utils';
 import { GroupModel } from '../../core/store/models';
 
 describe('CommunicationRulesComponent', () => {

--- a/admin/src/main/ts/app/users/communication/communication-rules.component.spec.ts
+++ b/admin/src/main/ts/app/users/communication/communication-rules.component.spec.ts
@@ -1,0 +1,76 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { BundlesService, SijilModule } from 'sijil';
+import { Component, DebugElement, Input } from '@angular/core';
+import { UxModule } from '../../shared/ux/ux.module';
+import {
+    CommunicationRule,
+    CommunicationRulesComponent,
+    communicationRulesLocators as locators
+} from './communication-rules.component';
+import { generateGroup } from './user-communication.component.spec';
+import { GroupModel } from '../../core/store/models';
+
+describe('CommunicationRulesComponent', () => {
+    let component: CommunicationRulesComponent;
+    let fixture: ComponentFixture<CommunicationRulesComponent>;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [
+                CommunicationRulesComponent,
+                MockGroupCard
+            ],
+            providers: [],
+            imports: [
+                SijilModule.forRoot(),
+                UxModule.forRoot(null)
+            ]
+
+        }).compileComponents();
+        const bundlesService = TestBed.get(BundlesService);
+        bundlesService.addToBundle({
+            "user.communication.groups-of-user": "Groupes de l'utlisateur"
+        });
+        fixture = TestBed.createComponent(CommunicationRulesComponent);
+        component = fixture.debugElement.componentInstance;
+        component.communicationRules = [
+            generateCommunicationRule('c1'),
+            generateCommunicationRule('groupf1'),
+            generateCommunicationRule('groupf2'),
+            generateCommunicationRule('groupm1')
+        ];
+        fixture.detectChanges();
+    }));
+
+    it('should create the UserCommunicationComponent component', async(() => {
+        expect(component).toBeTruthy();
+    }));
+
+    it('should display the user groups (c1, groupf1, groupf2, groupm1) given user belonging to c1, groupf1, groupf2 and groupm1', () => {
+        expect(getGroups(fixture).length).toBe(4);
+    });
+
+    it('should display the user groups (c1) given user belonging to c1', () => {
+        component.communicationRules = [generateCommunicationRule('c1')];
+        fixture.detectChanges();
+        expect(getGroups(fixture).length).toBe(1);
+    });
+});
+
+function getGroups(fixture: ComponentFixture<CommunicationRulesComponent>): DebugElement[] {
+    return fixture.debugElement.queryAll(By.css(locators.group));
+}
+
+function generateCommunicationRule(groupName: string): CommunicationRule {
+    return {sender: generateGroup(groupName), receivers: []}
+}
+
+@Component({
+    selector: 'group-card',
+    template: ''
+})
+class MockGroupCard {
+    @Input()
+    group: GroupModel;
+}

--- a/admin/src/main/ts/app/users/communication/communication-rules.component.ts
+++ b/admin/src/main/ts/app/users/communication/communication-rules.component.ts
@@ -18,7 +18,7 @@ export const communicationRulesLocators = {
         </div>`,
     styles: [`
         .title {
-            color: #00a4d3;
+            color: #2a9cc8;
             font-size: 20px;
         }`]
 })

--- a/admin/src/main/ts/app/users/communication/communication-rules.component.ts
+++ b/admin/src/main/ts/app/users/communication/communication-rules.component.ts
@@ -1,0 +1,42 @@
+import { Component, Input } from '@angular/core';
+import { GroupModel } from '../../core/store/models';
+
+const css = {
+    group: 'lct-user-communication-group'
+};
+
+export const communicationRulesLocators = {
+    group: `.${css.group}`
+};
+
+@Component({
+    selector: 'communication-rules',
+    template: `
+        <span class="title">{{ 'user.communication.groups-of-user' | translate }}</span>
+        <div class="group ${css.group}" *ngFor="let sender of getSenders(); trackBy: trackByGroupId">
+            <group-card [group]="sender"></group-card>
+        </div>`,
+    styles: [`
+        .title {
+            color: #00a4d3;
+            font-size: 20px;
+        }`]
+})
+export class CommunicationRulesComponent {
+
+    @Input()
+    communicationRules: CommunicationRule[];
+
+    public getSenders(): GroupModel[] {
+        return this.communicationRules.map(rule => rule.sender);
+    }
+
+    public trackByGroupId(index: number, group: GroupModel): string {
+        return group.id;
+    }
+}
+
+export interface CommunicationRule {
+    sender: GroupModel,
+    receivers: GroupModel[]
+}

--- a/admin/src/main/ts/app/users/communication/communication-rules.service.spec.ts
+++ b/admin/src/main/ts/app/users/communication/communication-rules.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { CommunicationRulesService } from './communication-rules.service';
 import { CommunicationRule } from './communication-rules.component';
-import { generateGroup } from './user-communication.component.spec';
+import { generateGroup } from './communication-test-utils';
 import { GroupModel } from '../../core/store/models';
 import 'rxjs/add/operator/skip';
 

--- a/admin/src/main/ts/app/users/communication/communication-rules.service.spec.ts
+++ b/admin/src/main/ts/app/users/communication/communication-rules.service.spec.ts
@@ -1,0 +1,99 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { CommunicationRulesService } from './communication-rules.service';
+import { CommunicationRule } from './communication-rules.component';
+import { generateGroup } from './user-communication.component.spec';
+import { GroupModel } from '../../core/store/models';
+import 'rxjs/add/operator/skip';
+
+describe('CommunicationRulesService', () => {
+    let communicationRulesService: CommunicationRulesService;
+    let httpController: HttpTestingController;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                CommunicationRulesService
+            ],
+            imports: [
+                HttpClientTestingModule
+            ]
+        });
+        communicationRulesService = TestBed.get(CommunicationRulesService);
+        httpController = TestBed.get(HttpTestingController);
+    });
+
+    it('should emit new communication rules when giving a list of groups', () => {
+        let rules: CommunicationRule[] = [];
+        communicationRulesService
+            .changes()
+            .subscribe(cr => rules = cr);
+        communicationRulesService.setGroups([generateGroup('group1'), generateGroup('group2')]);
+        expect(rules.length).toBe(2);
+    });
+
+    describe('toggleInternalCommunicationRule', () => {
+        it(`should call the backend DELETE /communication/group/myGroupId with direction BOTH given group id 'myGroupId' and internal communication rule 'BOTH'`, () => {
+            const group: GroupModel = generateGroup('myGroupId', 'BOTH');
+            communicationRulesService.toggleInternalCommunicationRule(group).subscribe();
+            const communicationGroupRequest = httpController.expectOne('/communication/group/myGroupId');
+            expect(communicationGroupRequest.request.method).toBe('DELETE');
+            expect(communicationGroupRequest.request.body).toEqual({
+                direction: 'BOTH'
+            });
+        });
+
+        it(`should call the backend /communication/group/myGroupId with direction BOTH given group id 'myGroupId' and internal communication rule 'NONE'`, () => {
+            const group: GroupModel = generateGroup('myGroupId', 'NONE');
+            communicationRulesService.toggleInternalCommunicationRule(group).subscribe();
+            expect(httpController.expectOne('/communication/group/myGroupId').request.body).toEqual({
+                direction: 'BOTH'
+            });
+        });
+
+        it(`should call the backend /communication/group/myGroupId with direction BOTH given group id 'myGroupId' and internal communication rule 'INCOMING'`, () => {
+            const group: GroupModel = generateGroup('myGroupId', 'INCOMING');
+            communicationRulesService.toggleInternalCommunicationRule(group).subscribe();
+            expect(httpController.expectOne('/communication/group/myGroupId').request.body).toEqual({
+                direction: 'BOTH'
+            });
+        });
+
+        it(`should call the backend /communication/group/myGroupId with direction BOTH given group id 'myGroupId' and internal communication rule 'OUTGOING'`, () => {
+            const group: GroupModel = generateGroup('myGroupId', 'OUTGOING');
+            communicationRulesService.toggleInternalCommunicationRule(group).subscribe();
+            expect(httpController.expectOne('/communication/group/myGroupId').request.body).toEqual({
+                direction: 'BOTH'
+            });
+        });
+
+        it(`should emit a new communication rules if the given group is part of the current communication rules`, () => {
+            const group1: GroupModel = generateGroup('group1', 'BOTH');
+            const group2: GroupModel = generateGroup('group2', 'BOTH');
+            let rules: CommunicationRule[] = [];
+            communicationRulesService
+                .changes()
+                .skip(1)
+                .subscribe(cr => rules = cr);
+            communicationRulesService.setGroups([group1, group2]);
+            communicationRulesService.toggleInternalCommunicationRule(group1).subscribe();
+            httpController.expectOne('/communication/group/group1').flush('');
+            expect(rules[0].sender.internalCommunicationRule).toBe('NONE');
+        });
+
+        it(`should not emit a new communication rules if the given group is not part of the current communication rules`, () => {
+            const group1: GroupModel = generateGroup('group1', 'BOTH');
+            const group2: GroupModel = generateGroup('group2', 'BOTH');
+            const group3: GroupModel = generateGroup('group3', 'BOTH');
+            let emitted: boolean = false;
+            communicationRulesService
+                .changes()
+                .skip(1)
+                .subscribe(() => emitted = true);
+            communicationRulesService.setGroups([group1, group2]);
+            communicationRulesService.toggleInternalCommunicationRule(group3).subscribe();
+            httpController.expectOne('/communication/group/group3').flush('');
+            expect(emitted).toBe(false);
+        });
+    });
+});

--- a/admin/src/main/ts/app/users/communication/communication-rules.service.ts
+++ b/admin/src/main/ts/app/users/communication/communication-rules.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+import { CommunicationRule } from './communication-rules.component';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/do';
+import 'rxjs/add/observable/forkJoin';
+import { GroupModel } from '../../core/store/models';
+import { InternalCommunicationRule } from '../../groups/details/group-internal-communication-rule.resolver';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable()
+export class CommunicationRulesService {
+
+    private rulesSubject: Subject<CommunicationRule[]> = new Subject<CommunicationRule[]>();
+    private rulesObservable: Observable<CommunicationRule[]> = this.rulesSubject.asObservable();
+    private currentRules: CommunicationRule[];
+
+    constructor(private http: HttpClient) {
+        this.rulesObservable.subscribe(cr => this.currentRules = cr);
+    }
+
+    public changes(): Observable<CommunicationRule[]> {
+        return this.rulesObservable;
+    }
+
+    public setGroups(groups: GroupModel[]) {
+        Observable.forkJoin(...groups.map(group => this.getCommunicationRulesOfGroup(group)))
+            .subscribe((communicationRules: CommunicationRule[]) => this.rulesSubject.next(communicationRules));
+    }
+
+    public toggleInternalCommunicationRule(group: GroupModel): Observable<void> {
+        let request: Observable<void>;
+        const direction: InternalCommunicationRule = group.internalCommunicationRule === 'BOTH' ? 'NONE' : 'BOTH';
+
+        if (direction === 'BOTH') {
+            request = this.http.post<void>(`/communication/group/${group.id}`, {direction});
+        } else {
+            request = this.http.request<void>('delete', `/communication/group/${group.id}`, {body: {direction: 'BOTH'}});
+        }
+
+        return request.do(() => {
+            const groupInCommunicationRules = this.findGroup(this.currentRules, group.id);
+            if (!!groupInCommunicationRules) {
+                groupInCommunicationRules.internalCommunicationRule = direction;
+                this.rulesSubject.next(this.clone(this.currentRules));
+            }
+        });
+    }
+
+    private getCommunicationRulesOfGroup(sender: GroupModel): Observable<CommunicationRule> {
+        return Observable.of({sender, receivers: []});
+    }
+
+    private findGroup(communicationRules: CommunicationRule[], groupId: string): GroupModel {
+        return communicationRules.map(rule => rule.sender).find(sender => sender.id === groupId);
+    }
+
+    private clone(communicationRules: CommunicationRule[]): CommunicationRule[] {
+        return communicationRules.map(cr => ({
+            sender: Object.assign({}, cr.sender),
+            receivers: cr.receivers.map(re => Object.assign({}, re))
+        }));
+    }
+}

--- a/admin/src/main/ts/app/users/communication/communication-rules.service.ts
+++ b/admin/src/main/ts/app/users/communication/communication-rules.service.ts
@@ -6,8 +6,7 @@ import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/observable/forkJoin';
-import { GroupModel } from '../../core/store/models';
-import { InternalCommunicationRule } from '../../groups/details/group-internal-communication-rule.resolver';
+import { GroupModel, InternalCommunicationRule } from '../../core/store/models';
 import { HttpClient } from '@angular/common/http';
 
 @Injectable()

--- a/admin/src/main/ts/app/users/communication/communication-test-utils.ts
+++ b/admin/src/main/ts/app/users/communication/communication-test-utils.ts
@@ -1,0 +1,18 @@
+import { DebugElement } from '@angular/core';
+import { GroupModel, InternalCommunicationRule } from '../../core/store/models';
+
+export function getText(el: DebugElement): string {
+    return el.nativeElement.textContent;
+}
+
+export function clickOn(el: DebugElement): void {
+    return el.triggerEventHandler('click', null);
+}
+export function generateGroup(name: string,
+                              internalCommunicationRule: InternalCommunicationRule = 'BOTH',
+                              type: string = null, subType: string = null,
+                              classes: { id: string, name: string }[] = null,
+                              structures: { id: string, name: string }[] = null,
+                              filter: string = null): GroupModel {
+    return {name, id: name, internalCommunicationRule, type, subType, classes, structures, filter} as GroupModel;
+}

--- a/admin/src/main/ts/app/users/communication/group-card.component.spec.ts
+++ b/admin/src/main/ts/app/users/communication/group-card.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { UxModule } from '../../shared/ux/ux.module';
 import { GroupCardComponent, groupCardLocators as locators } from './group-card.component';
 import { BundlesService, SijilModule } from 'sijil';
-import { clickOn, generateGroup, getText } from './user-communication.component.spec';
+import { clickOn, generateGroup, getText } from './communication-test-utils';
 import { DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { CommunicationRulesService } from './communication-rules.service';

--- a/admin/src/main/ts/app/users/communication/group-card.component.spec.ts
+++ b/admin/src/main/ts/app/users/communication/group-card.component.spec.ts
@@ -1,0 +1,98 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { UxModule } from '../../shared/ux/ux.module';
+import { GroupCardComponent, groupCardLocators as locators } from './group-card.component';
+import { BundlesService, SijilModule } from 'sijil';
+import { clickOn, generateGroup, getText } from './user-communication.component.spec';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { CommunicationRulesService } from './communication-rules.service';
+
+describe('GroupCardComponent', () => {
+    let component: GroupCardComponent;
+    let communicationRulesService: CommunicationRulesService;
+    let fixture: ComponentFixture<GroupCardComponent>;
+
+    beforeEach(async(() => {
+        communicationRulesService = jasmine.createSpyObj('CommunicationRulesService', ['toggleInternalCommunicationRule']);
+        TestBed.configureTestingModule({
+            declarations: [
+                GroupCardComponent
+            ],
+            providers: [{useValue: communicationRulesService, provide: CommunicationRulesService}],
+            imports: [
+                SijilModule.forRoot(),
+                UxModule.forRoot(null)
+            ]
+        }).compileComponents();
+        fixture = TestBed.createComponent(GroupCardComponent);
+        component = fixture.debugElement.componentInstance;
+        const bundlesService = TestBed.get(BundlesService);
+        bundlesService.addToBundle({
+            "group.card.structure.Personnel": "Personnels de {{name}}",
+            "group.card.structure.Relative": "Parents de {{name}}",
+            "group.card.structure.Student": "Élèves de {{name}}",
+            "group.card.structure.Teacher": "Enseignants de {{name}}",
+            "group.card.structure.Guest": "Invités de {{name}}",
+            "group.card.class.Personnel": "Personnels de la classe {{name}}",
+            "group.card.class.Relative": "Parents de la classe {{name}}",
+            "group.card.class.Student": "Élèves de la classe {{name}}",
+            "group.card.class.Teacher": "Enseignants de la classe {{name}}",
+            "group.card.class.Guest": "Invités de la classe {{name}}"
+        });
+        component.group = generateGroup('Elèves du Lycée Paul Martin');
+        fixture.detectChanges();
+    }));
+
+    it('should create the GroupCardComponent component', async(() => {
+        expect(component).toBeTruthy();
+    }));
+
+    it('should display the name of the given group "Elèves du Lycée Paul Martin"', async(() => {
+        expect(getText(getTitle(fixture))).toBe('Elèves du Lycée Paul Martin');
+    }));
+
+    it('should display the name of the given group "test"', async(() => {
+        component.group = generateGroup('test');
+        fixture.detectChanges();
+        expect(getText(getTitle(fixture))).toBe('test');
+    }));
+
+    it('should call the communicationRulesService.toggleInternalCommunicationRule when clicking on the communication rules switch', async(() => {
+        component.group = generateGroup('test');
+        fixture.detectChanges();
+        clickOn(getInternalCommunicationSwitch(fixture));
+        expect(communicationRulesService.toggleInternalCommunicationRule).toHaveBeenCalled();
+    }));
+
+    describe('getGroupName', () => {
+        it(`should return 'test' if the group is a manual group named 'test'`, () => {
+            expect(component.getGroupName(generateGroup('test', 'BOTH', 'ManualGroup'))).toBe('test');
+        });
+
+        it('should return a nice label for a ProfileGroup of a class (6emeA)', () => {
+            expect(component.getGroupName(generateGroup('test', 'BOTH',
+                'ProfileGroup', null,
+                [{
+                    id: '6A',
+                    name: '6emeA'
+                }], null, 'Student'))).toBe('Élèves de la classe 6emeA');
+        });
+
+        it('should return a nice label for a ProfileGroup of a structure (Emile Zola)', () => {
+            expect(component.getGroupName(generateGroup('test', 'BOTH',
+                'ProfileGroup', 'StructureGroup',
+                null, [{
+                    id: 'emilezola',
+                    name: 'Emile Zola'
+                }], 'Student'))).toBe('Élèves de Emile Zola');
+        });
+    });
+});
+
+function getTitle(fixture: ComponentFixture<GroupCardComponent>): DebugElement {
+    return fixture.debugElement.query(By.css(locators.title));
+}
+
+function getInternalCommunicationSwitch(fixture: ComponentFixture<GroupCardComponent>): DebugElement {
+    return fixture.debugElement.query(By.css(locators.internalCommunicationSwitch));
+}

--- a/admin/src/main/ts/app/users/communication/group-card.component.ts
+++ b/admin/src/main/ts/app/users/communication/group-card.component.ts
@@ -40,7 +40,7 @@ export const groupCardLocators = {
         </div>`,
     styles: [`
         .group-card {
-            background-color: #00a4d3;
+            background-color: #2a9cc8;
             font-size: 14px;
             padding: 10px;
             margin: 10px 0;

--- a/admin/src/main/ts/app/users/communication/group-card.component.ts
+++ b/admin/src/main/ts/app/users/communication/group-card.component.ts
@@ -1,0 +1,136 @@
+import { Component, Input } from '@angular/core';
+import { GroupModel } from '../../core/store/models';
+import { CommunicationRulesService } from './communication-rules.service';
+import { BundlesService } from "sijil";
+
+const css = {
+    title: 'lct-group-card-title',
+    addCommunicationButton: 'lct-group-card-add-communicaiton-button',
+    internalCommunicationSwitch: 'lct-group-card-internal-communication-switch'
+};
+
+export const groupCardLocators = {
+    title: `.${css.title}`,
+    addCommunicationButton: `.${css.addCommunicationButton}`,
+    internalCommunicationSwitch: `.${css.internalCommunicationSwitch}`
+};
+
+@Component({
+    selector: 'group-card',
+    template: `
+        <div class="group-card">
+            <div class="group-card__title ${css.title}">{{getGroupName(group)}}</div>
+            <div class="group-card__actions">
+                <button class="group-card__action-add-communication ${css.addCommunicationButton}">{{ 'group.card.add-communication-button' | translate }} <i class="fa fa-plus"></i></button>
+            </div>
+            <hr class="group-card__separator"/>
+            <span class="group-card__actions-on-self group-card__actions-on-self--can-communicate"
+                      *ngIf="group.internalCommunicationRule === 'BOTH'; else cannotCommunicateTogether;">
+                <s5l class="group-card__switch-label">group.details.members.can.communicate</s5l> <i
+                    class="${css.internalCommunicationSwitch} group-card__switch fa fa-toggle-on"
+                    (click)="toggleInternalCommunicationRule()"></i>
+            </span>
+            <ng-template #cannotCommunicateTogether>
+                <span class="group-card__actions-on-self group-card__actions-on-self--cannot-communicate">
+                    <s5l class="group-card__switch-label">group.details.members.cannot.communicate</s5l> <i
+                        class="${css.internalCommunicationSwitch} group-card__switch fa fa-toggle-off"
+                        (click)="toggleInternalCommunicationRule()"></i>
+                </span>
+            </ng-template>
+        </div>`,
+    styles: [`
+        .group-card {
+            background-color: #00a4d3;
+            font-size: 14px;
+            padding: 10px;
+            margin: 10px 0;
+            width: 340px;
+            color: white;
+            box-sizing: border-box;
+            box-shadow: 1px 1px 5px #AAA;
+        }
+    `, `
+        .group-card__title {
+            font-size: 16px;
+            margin-bottom: 15px;
+        }
+    `, `
+        .group-card__actions {
+        }
+    `, `
+        .group-card__action-add-communication {
+            background: #ff6624;
+            height: 34px;
+            line-height: 34px;
+            padding: 0 10px;
+            border-radius: 0;
+            border: 0;
+            color: white;
+        }
+    `, `
+        .group-card__action-add-communication i {
+            float: none;
+        }
+    `, `
+        .group-card__separator {
+            color: white;
+            border-style: solid;
+            margin: 15px 0;
+        }
+    `, `
+        .group-card__switch {
+            font-size: 22px;
+            padding-right: 15px;
+            cursor: pointer;
+        }
+    `, `
+        .group-card__actions-on-self {
+            display: flex;
+            align-items: center;
+            padding-bottom: 10px;
+        }
+    `, `
+        .group-card__actions-on-self.group-card__actions-on-self--can-communicate .group-card__switch {
+            color: green;
+        }
+    `, `
+        .group-card__actions-on-self.group-card__actions-on-self--cannot-communicate .group-card__switch {
+            color: red;
+        }
+    `]
+})
+export class GroupCardComponent {
+
+    @Input()
+    group: GroupModel;
+
+    constructor(private communicationRulesService: CommunicationRulesService, private bundlesService: BundlesService) {
+    }
+
+    public toggleInternalCommunicationRule() {
+        this.communicationRulesService
+            .toggleInternalCommunicationRule(this.group)
+            .subscribe();
+    }
+
+    public getGroupName(group: GroupModel): string {
+        if (group.type === 'ManualGroup') {
+            return group.name;
+        }
+
+        if (group.type === 'ProfileGroup') {
+            if (group.filter && group.classes && group.classes.length > 0) {
+                return this.bundlesService.translate(`group.card.class.${group.filter}`, {name: group.classes[0].name});
+            } else if (group.filter && group.structures && group.structures.length > 0) {
+                return this.bundlesService.translate(`group.card.structure.${group.filter}`, {name: group.structures[0].name});
+            }
+        }
+
+        // Defaulting to the console v1 behaviour
+        const indexOfSeparation = group.name.lastIndexOf('-');
+        if (indexOfSeparation < 0) {
+            return group.name;
+        }
+        return `${this.bundlesService.translate(group.name.slice(0, indexOfSeparation))}-${this.bundlesService.translate(group.name.slice(indexOfSeparation + 1))}`;
+    }
+}

--- a/admin/src/main/ts/app/users/communication/smart-user-communication.component.ts
+++ b/admin/src/main/ts/app/users/communication/smart-user-communication.component.ts
@@ -19,6 +19,7 @@ export class SmartUserCommunicationComponent implements OnInit, OnDestroy {
     public user: UserModel;
     public userSendingCommunicationRules: CommunicationRule[];
 
+    private communicationRulesChangesSubscription: Subscription;
     private routeSubscription: Subscription;
 
     constructor(
@@ -31,7 +32,7 @@ export class SmartUserCommunicationComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
-        this.communicationRulesService.changes().subscribe(rules => {
+        this.communicationRulesChangesSubscription = this.communicationRulesService.changes().subscribe(rules => {
             this.userSendingCommunicationRules = rules;
             this.changeDetector.markForCheck();
         });
@@ -46,6 +47,7 @@ export class SmartUserCommunicationComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy(): void {
+        this.communicationRulesChangesSubscription.unsubscribe();
         this.routeSubscription.unsubscribe();
     }
 }

--- a/admin/src/main/ts/app/users/communication/user-communication.component.spec.ts
+++ b/admin/src/main/ts/app/users/communication/user-communication.component.spec.ts
@@ -1,19 +1,24 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { UserCommunicationComponent, userCommunicationLocators as locators } from './user-communication.component';
-import { UserDetailsModel } from '../../core/store/models';
+import { GroupModel, UserDetailsModel, UserModel } from '../../core/store/models';
 import { By } from '@angular/platform-browser';
 import { BundlesService, SijilModule } from 'sijil';
-import { DebugElement } from '@angular/core';
+import { Component, DebugElement, Input } from '@angular/core';
 import { UxModule } from '../../shared/ux/ux.module';
+import { CommunicationRule } from './communication-rules.component';
+import { InternalCommunicationRule } from '../../groups/details/group-internal-communication-rule.resolver';
 
 describe('UserCommunicationComponent', () => {
     let component: UserCommunicationComponent;
     let fixture: ComponentFixture<UserCommunicationComponent>;
+    let axellePotier: UserCommunicationTestingData;
+    let harryPotter: UserCommunicationTestingData;
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             declarations: [
-                UserCommunicationComponent
+                UserCommunicationComponent,
+                MockCommunicationRulesComponent
             ],
             providers: [],
             imports: [
@@ -30,7 +35,11 @@ describe('UserCommunicationComponent', () => {
             "user.communication.title": "Communication de {{ lastName }} {{ firstName }}"
         });
 
-        component.user = generateUser('Axelle', 'Potier');
+        axellePotier = generateTestingData('Axelle', 'Potier', [generateGroup('c1')], [generateGroup('groupf1'), generateGroup('groupf2')], [generateGroup('groupm1')]);
+        harryPotter = generateTestingData('Harry', 'Potter', [generateGroup('c1')], null, null);
+
+        component.user = axellePotier.user;
+        component.userSendingCommunicationRules = axellePotier.communicationRules;
         fixture.detectChanges();
     }));
 
@@ -43,7 +52,8 @@ describe('UserCommunicationComponent', () => {
     }));
 
     it('should have the title "Communication de POTTER Harry" given user Harry Potter', async(() => {
-        component.user = generateUser('Harry', 'Potter');
+        component.user = harryPotter.user;
+        component.userSendingCommunicationRules = harryPotter.communicationRules;
         fixture.detectChanges();
         expect(getText(getTitle(fixture))).toBe('Communication de POTTER Harry');
     }));
@@ -56,8 +66,33 @@ describe('UserCommunicationComponent', () => {
     }));
 });
 
-function generateUser(firstName: string, lastName: string): UserDetailsModel {
-    return {firstName, lastName} as UserDetailsModel;
+interface UserCommunicationTestingData {
+    user: UserModel,
+    communicationRules: CommunicationRule[]
+}
+
+function generateTestingData(firstName: string, lastName: string, classes: GroupModel[], functionalGroups: GroupModel[], manualGroups: GroupModel[]): UserCommunicationTestingData {
+    const userDetails: UserDetailsModel = {functionalGroups, manualGroups} as UserDetailsModel;
+    const user: UserModel = {
+        firstName,
+        lastName,
+        userDetails
+    } as UserModel;
+    const groups = [];
+    groups.push(...classes);
+    groups.push(...functionalGroups);
+    groups.push(...manualGroups);
+    const communicationRules: CommunicationRule[] = groups.map(mg => ({sender: mg, receivers: []}));
+    return {user, communicationRules};
+}
+
+export function generateGroup(name: string,
+                              internalCommunicationRule: InternalCommunicationRule = 'BOTH',
+                              type: string = null, subType: string = null,
+                              classes: { id: string, name: string }[] = null,
+                              structures: { id: string, name: string }[] = null,
+                              filter: string = null): GroupModel {
+    return {name, id: name, internalCommunicationRule, type, subType, classes, structures, filter} as GroupModel;
 }
 
 function getTitle(fixture: ComponentFixture<UserCommunicationComponent>): DebugElement {
@@ -68,10 +103,19 @@ function getBackButton(fixture: ComponentFixture<UserCommunicationComponent>): D
     return fixture.debugElement.query(By.css(locators.backButton));
 }
 
-function getText(el: DebugElement): string {
+export function getText(el: DebugElement): string {
     return el.nativeElement.textContent;
 }
 
-function clickOn(el: DebugElement): void {
+export function clickOn(el: DebugElement): void {
     return el.triggerEventHandler('click', null);
+}
+
+@Component({
+    selector: 'communication-rules',
+    template: ''
+})
+class MockCommunicationRulesComponent {
+    @Input()
+    communicationRules: CommunicationRule[];
 }

--- a/admin/src/main/ts/app/users/communication/user-communication.component.spec.ts
+++ b/admin/src/main/ts/app/users/communication/user-communication.component.spec.ts
@@ -6,7 +6,7 @@ import { BundlesService, SijilModule } from 'sijil';
 import { Component, DebugElement, Input } from '@angular/core';
 import { UxModule } from '../../shared/ux/ux.module';
 import { CommunicationRule } from './communication-rules.component';
-import { InternalCommunicationRule } from '../../groups/details/group-internal-communication-rule.resolver';
+import { clickOn, generateGroup, getText } from './communication-test-utils';
 
 describe('UserCommunicationComponent', () => {
     let component: UserCommunicationComponent;
@@ -35,8 +35,18 @@ describe('UserCommunicationComponent', () => {
             "user.communication.title": "Communication de {{ lastName }} {{ firstName }}"
         });
 
-        axellePotier = generateTestingData('Axelle', 'Potier', [generateGroup('c1')], [generateGroup('groupf1'), generateGroup('groupf2')], [generateGroup('groupm1')]);
-        harryPotter = generateTestingData('Harry', 'Potter', [generateGroup('c1')], null, null);
+        axellePotier = generateTestingData(
+            'Axelle',
+            'Potier',
+            [generateGroup('c1')],
+            [generateGroup('groupf1'), generateGroup('groupf2')],
+            [generateGroup('groupm1')]);
+        harryPotter = generateTestingData(
+            'Harry',
+            'Potter',
+            [generateGroup('c1')],
+            null,
+            null);
 
         component.user = axellePotier.user;
         component.userSendingCommunicationRules = axellePotier.communicationRules;
@@ -86,29 +96,12 @@ function generateTestingData(firstName: string, lastName: string, classes: Group
     return {user, communicationRules};
 }
 
-export function generateGroup(name: string,
-                              internalCommunicationRule: InternalCommunicationRule = 'BOTH',
-                              type: string = null, subType: string = null,
-                              classes: { id: string, name: string }[] = null,
-                              structures: { id: string, name: string }[] = null,
-                              filter: string = null): GroupModel {
-    return {name, id: name, internalCommunicationRule, type, subType, classes, structures, filter} as GroupModel;
-}
-
 function getTitle(fixture: ComponentFixture<UserCommunicationComponent>): DebugElement {
     return fixture.debugElement.query(By.css(locators.title));
 }
 
 function getBackButton(fixture: ComponentFixture<UserCommunicationComponent>): DebugElement {
     return fixture.debugElement.query(By.css(locators.backButton));
-}
-
-export function getText(el: DebugElement): string {
-    return el.nativeElement.textContent;
-}
-
-export function clickOn(el: DebugElement): void {
-    return el.triggerEventHandler('click', null);
 }
 
 @Component({

--- a/admin/src/main/ts/app/users/communication/user-communication.component.ts
+++ b/admin/src/main/ts/app/users/communication/user-communication.component.ts
@@ -1,9 +1,10 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { UserDetailsModel } from '../../core/store/models';
+import { UserModel } from '../../core/store/models';
+import { CommunicationRule } from './communication-rules.component';
 
 const css = {
-    title: 'lct-title',
-    backButton: 'lct-back-button'
+    title: 'lct-user-communication-title',
+    backButton: 'lct-user-communication-back-button'
 };
 
 export const userCommunicationLocators = {
@@ -24,6 +25,9 @@ export const userCommunicationLocators = {
                 <span class="${css.title} user-displayname">{{ 'user.communication.title' | translate:{firstName: user.firstName, lastName: user.lastName.toUpperCase()} }}</span>
                 <message-sticker class="is-pulled-right" [type]="'info'" [messages]="['user.communication.help']"></message-sticker>
             </div>
+        </div>
+        <div class="user-communication__content">
+            <communication-rules [communicationRules]="userSendingCommunicationRules"></communication-rules>
         </div>`,
     styles: [`
         .button.button--back {
@@ -31,21 +35,30 @@ export const userCommunicationLocators = {
             border: 0;
             padding: 5px;
         }
+    `, `
         .button.button--back:hover, .button.button--back:hover i {
             color: #ff5e1f;
         }
-        `, `
+    `, `
         .button.button--back i {
             float: none;
             padding-left: 0;
             transition: background 0.25s, color 0.25s, border 0.25s;
         }
-        `]
+    `, `
+        .user-communication__content {
+            padding: 10px 15px;
+        }
+    `]
 })
 export class UserCommunicationComponent {
+
     @Input()
-    public user: UserDetailsModel;
+    public user: UserModel;
+
+    @Input()
+    public userSendingCommunicationRules: CommunicationRule[];
 
     @Output()
-    public close: EventEmitter<void> = new EventEmitter<void>()
+    public close: EventEmitter<void> = new EventEmitter<void>();
 }

--- a/admin/src/main/ts/app/users/communication/user-groups.resolver.spec.ts
+++ b/admin/src/main/ts/app/users/communication/user-groups.resolver.spec.ts
@@ -1,0 +1,31 @@
+import { UserGroupsResolver } from './user-groups.resolver';
+import { ActivatedRouteSnapshot, convertToParamMap } from '@angular/router';
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+describe('UserGroupsResolver', () => {
+    let userGroupsResolver: UserGroupsResolver;
+    let httpController: HttpTestingController;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                UserGroupsResolver
+            ],
+            imports: [
+                HttpClientTestingModule
+            ]
+        });
+        userGroupsResolver = TestBed.get(UserGroupsResolver);
+        httpController = TestBed.get(HttpTestingController);
+    });
+
+    it('should call the backend API for listing groups of a user', () => {
+        userGroupsResolver.resolve(generateActivatedRouteSnapshot('myUser')).subscribe();
+        httpController.expectOne('/directory/user/myUser/groups');
+    });
+});
+
+function generateActivatedRouteSnapshot(userId?: string): ActivatedRouteSnapshot {
+    return {paramMap: convertToParamMap({userId})} as ActivatedRouteSnapshot;
+}

--- a/admin/src/main/ts/app/users/communication/user-groups.resolver.ts
+++ b/admin/src/main/ts/app/users/communication/user-groups.resolver.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+import { GroupModel } from '../../core/store/models';
+import { Observable } from 'rxjs/Observable';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable()
+export class UserGroupsResolver implements Resolve<GroupModel[]> {
+
+    constructor(private http: HttpClient) {
+    }
+
+    resolve(route: ActivatedRouteSnapshot): Observable<GroupModel[]> {
+        const userId = route.paramMap.get('userId');
+        return this.http.get<GroupModel[]>(`/directory/user/${userId}/groups`);
+    }
+}

--- a/admin/src/main/ts/app/users/users.module.ts
+++ b/admin/src/main/ts/app/users/users.module.ts
@@ -34,6 +34,9 @@ import { HttpClientModule } from '@angular/common/http';
 import { globalStoreProvider } from '../core/store';
 import { UserCommunicationComponent } from './communication/user-communication.component';
 import { SmartUserCommunicationComponent } from './communication/smart-user-communication.component';
+import { GroupCardComponent } from './communication/group-card.component';
+import { CommunicationRulesComponent } from './communication/communication-rules.component';
+import { UserGroupsResolver } from './communication/user-groups.resolver';
 
 @NgModule({
     imports: [
@@ -63,12 +66,15 @@ import { SmartUserCommunicationComponent } from './communication/smart-user-comm
         UserFunctionalGroupsSection,
         UserCommunicationComponent,
         SmartUserCommunicationComponent,
-        UserQuotaSection
+        UserQuotaSection,
+        GroupCardComponent,
+        CommunicationRulesComponent
     ],
     providers: [
         ConfigResolver,
         UserDetailsResolver,
         UsersResolver,
+        UserGroupsResolver,
         UserlistFiltersService,
         UserInfoService,
         globalStoreProvider

--- a/admin/src/main/ts/app/users/users.routing.ts
+++ b/admin/src/main/ts/app/users/users.routing.ts
@@ -1,14 +1,13 @@
 import { Routes } from '@angular/router';
-
 import { UsersResolver } from './users.resolver';
 import { UserDetailsResolver } from './details/user-details.resolver';
-
 import { UsersComponent } from './users.component';
 import { UserCreate } from './create/user-create.component';
 import { UserFilters } from './filters/user-filters.component';
 import { UserDetails } from './details/user-details.component';
 import { ConfigResolver } from './details/config.resolver';
 import { SmartUserCommunicationComponent } from './communication/smart-user-communication.component';
+import { UserGroupsResolver } from './communication/user-groups.resolver';
 
 export let routes: Routes = [
     {
@@ -24,7 +23,8 @@ export let routes: Routes = [
             },
             {
                 path: ':userId/communication', component: SmartUserCommunicationComponent, resolve: {
-                    user: UserDetailsResolver
+                    user: UserDetailsResolver,
+                    groups: UserGroupsResolver
                 }
             }
         ]

--- a/directory/src/main/java/org/entcore/directory/controllers/UserController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/UserController.java
@@ -166,6 +166,14 @@ public class UserController extends BaseController {
 		}
 	}
 
+	@Get("/user/:userId/groups")
+	@ResourceFilter(UserAccessOrVisible.class)
+	@SecuredAction(value = "", type = ActionType.RESOURCE)
+	public void getGroups(final HttpServerRequest request) {
+		String userId = request.params().get("userId");
+		userService.getGroups(userId, arrayResponseHandler(request));
+	}
+
 	@Get("/myinfos")
 	@SecuredAction(value = "auth.user.info", type = ActionType.AUTHENTICATED)
 	public void myinfos(final HttpServerRequest request) {

--- a/directory/src/main/java/org/entcore/directory/services/UserService.java
+++ b/directory/src/main/java/org/entcore/directory/services/UserService.java
@@ -43,6 +43,8 @@ public interface UserService {
 
 	void get(String id, boolean getManualGroups, JsonArray filterAttributes, Handler<Either<String, JsonObject>> result);
 
+	void getGroups(String id, Handler<Either<String, JsonArray>> results);
+
 	void list(String structureId, String classId, JsonArray expectedProfiles, Handler<Either<String, JsonArray>> results);
 
 	void list(String profileGroupId, boolean itSelf, String userId, Handler<Either<String, JsonArray>> handler);

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
@@ -186,7 +186,7 @@ public class DefaultUserService implements UserService {
     @Override
     public void getGroups(String id, Handler<Either<String, JsonArray>> results) {
         String query = ""
-				+ "MATCH (g:Group)<-[:IN]-(u:User { id: {id} }) WHERE exists(g.id) "
+				+ "MATCH (g:Group)<-[:IN]-(u:User { id: {id} }) "
 				+ "OPTIONAL MATCH (c:Class)<-[:DEPENDS]-(g) "
 				+ "OPTIONAL MATCH (s:Structure)<-[:DEPENDS]-(g) "
 				+ "WITH g, collect( distinct {name: c.name, id: c.id}) as classes, collect( distinct {name: s.name, id: s.id}) as structures, "

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
@@ -20,17 +20,11 @@
 package org.entcore.directory.services.impl;
 
 import fr.wseduc.webutils.Either;
-
 import fr.wseduc.webutils.Utils;
 import fr.wseduc.webutils.email.EmailSender;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.eventbus.DeliveryOptions;
-import org.entcore.common.neo4j.Neo4j;
-import org.entcore.common.user.UserInfos;
-import org.entcore.common.validation.StringValidation;
-import org.entcore.directory.Directory;
-import org.entcore.directory.services.UserService;
 import io.vertx.core.Handler;
+import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.http.HttpServerRequest;
@@ -38,17 +32,19 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import org.entcore.common.neo4j.Neo4j;
+import org.entcore.common.user.UserInfos;
+import org.entcore.common.validation.StringValidation;
+import org.entcore.directory.Directory;
+import org.entcore.directory.services.UserService;
 
 import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
-import static fr.wseduc.webutils.Utils.getOrElse;
 import static fr.wseduc.webutils.Utils.handlerToAsyncHandler;
 import static org.entcore.common.neo4j.Neo4jResult.*;
-import static org.entcore.common.user.DefaultFunctions.ADMIN_LOCAL;
-import static org.entcore.common.user.DefaultFunctions.CLASS_ADMIN;
-import static org.entcore.common.user.DefaultFunctions.SUPER_ADMIN;
+import static org.entcore.common.user.DefaultFunctions.*;
 
 public class DefaultUserService implements UserService {
 
@@ -148,7 +144,7 @@ public class DefaultUserService implements UserService {
 
 	@Override
 	public void get(String id, boolean getManualGroups, JsonArray filterAttributes, Handler<Either<String, JsonObject>> result) {
-		
+
 		String getMgroups = "";
 		String resultMgroups = "";
 		if (getManualGroups) {
@@ -186,6 +182,28 @@ public class DefaultUserService implements UserService {
 		};
 		neo.execute(query, new JsonObject().put("id", id), fullNodeMergeHandler("u", filterResultHandler, "structureNodes"));
 	}
+
+    @Override
+    public void getGroups(String id, Handler<Either<String, JsonArray>> results) {
+        String query = ""
+				+ "MATCH (g:Group)<-[:IN]-(u:User { id: {id} }) WHERE exists(g.id) "
+				+ "OPTIONAL MATCH (c:Class)<-[:DEPENDS]-(g) "
+				+ "OPTIONAL MATCH (s:Structure)<-[:DEPENDS]-(g) "
+				+ "WITH g, collect( distinct {name: c.name, id: c.id}) as classes, collect( distinct {name: s.name, id: s.id}) as structures, "
+				+ "HEAD(filter(x IN labels(g) WHERE x <> 'Visible' AND x <> 'Group')) as type "
+				+ "RETURN DISTINCT "
+				+ "g.id as id, "
+				+ "g.name as name, "
+				+ "g.filter as filter, "
+				+ "g.displayName as displayName, "
+				+ "g.users as internalCommunicationRule, "
+				+ "type, "
+				+ "CASE WHEN any(x in classes where x <> {name: null, id: null}) THEN classes END as classes, "
+				+ "CASE WHEN any(x in structures where x <> {name: null, id: null}) THEN structures END as structures, "
+				+ "CASE WHEN (g: ProfileGroup)-[:DEPENDS]-(:Structure) THEN 'StructureGroup' END as subType";
+        JsonObject params = new JsonObject().put("id", id);
+        neo.execute(query, params, validResultHandler(results));
+    }
 
 	@Override
 	public void list(String structureId, String classId, JsonArray expectedProfiles,
@@ -313,7 +331,7 @@ public class DefaultUserService implements UserService {
 				"MATCH " + filter + "(u:User) " +
 				functionMatch + filterProfile + condition + optionalMatch +
 				"RETURN DISTINCT u.id as id, p.name as type, u.externalId as externalId, " +
-				"u.activationCode as code, " + 
+				"u.activationCode as code, " +
 				"CASE WHEN u.loginAlias IS NOT NULL THEN u.loginAlias ELSE u.login END as login, " +
 				"u.login as originalLogin, " +
 				"u.firstName as firstName, " +
@@ -408,7 +426,7 @@ public class DefaultUserService implements UserService {
 
 	public void listFunctions(String userId, Handler<Either<String, JsonArray>> result) {
 		String query =
-				"MATCH (u:User{id: {userId}})-[rf:HAS_FUNCTION]->fg-[:CONTAINS_FUNCTION*0..1]->(f:Function) " + 
+				"MATCH (u:User{id: {userId}})-[rf:HAS_FUNCTION]->fg-[:CONTAINS_FUNCTION*0..1]->(f:Function) " +
 				"RETURN COLLECT(distinct [f.externalId, rf.scope]) as functions";
 		JsonObject params = new JsonObject();
 		params.put("userId", userId);


### PR DESCRIPTION
related to CAV2-379: https://opendigitaleducation.atlassian.net/browse/CAV2-379

This PR:
- adds internal communication rule to the frontend GroupModel model and
restyle code of this file
- expose an backend endpoint to get the user groups and display them on
the frontend

How it works:
- before landing on the communication view the resolvers retrieve the user
and its groups
- smart component loads the groups in the communication rules
service (= store), subscribe to changes in the communication rules store
and make communication rules flow in its children components
- user communication component display the view
- communication rules component display a communication rule table
- group card component display a single group