### PR TITLE
[ODE] highlight related groups in the communication view

### DIFF
--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -449,6 +449,7 @@
     "user.communication.groups-that-user-can-communicate-with": "Groupes que l'utilisateur peut voir",
 
     "group.card.add-communication-button": "Ajouter un droit de communication",
+    "group.card.remove-communication-button": "Supprimer le droit de communication",
 
     "group.card.structure.Personnel": "Personnels de {{name}}",
     "group.card.structure.Relative": "Parents de {{name}}",

--- a/admin/src/main/ts/app/users/communication/communication-rules.component.spec.ts
+++ b/admin/src/main/ts/app/users/communication/communication-rules.component.spec.ts
@@ -58,6 +58,146 @@ describe('CommunicationRulesComponent', () => {
         expect(getSendingGroups(fixture).length).toBe(1);
         expect(getReceivingGroups(fixture).length).toBe(2);
     });
+
+    describe('resetHighlight', () => {
+        it('should unset the highlighted cell', () => {
+            component.highlighted = {column: 'sending', group: generateGroup('group1')};
+            component.resetHighlight();
+            expect(component.highlighted).toBeNull();
+        });
+    });
+
+    describe('select', () => {
+        it('should set the selected cell and call resetHighlight', () => {
+            spyOn(component, 'resetHighlight');
+            component.select('receiving', generateGroup('group2'));
+            expect(component.selected.column).toBe('receiving');
+            expect(component.selected.group.id).toBe('group2');
+            expect(component.resetHighlight).toHaveBeenCalled();
+        });
+    });
+
+    describe('highlight', () => {
+        it('should set the highlighted cell if the selected and highlighted cells are different', () => {
+            component.highlight('receiving', generateGroup('group1'),
+                {column: 'sending', group: generateGroup('group2')});
+            expect(component.highlighted.column).toBe('receiving');
+            expect(component.highlighted.group.id).toBe('group1');
+        });
+
+        it('should not set the highlighted cell if the selected and highlighted cells are the same', () => {
+            component.highlighted = {column: 'sending', group: generateGroup('group2')};
+            component.highlight('receiving', generateGroup('group1'),
+                {column: 'receiving', group: generateGroup('group1')});
+            expect(component.highlighted.column).toBe('sending');
+            expect(component.highlighted.group.id).toBe('group2');
+        });
+    });
+
+    describe('isSelected', () => {
+        it('should return true if the given cell is the one selected', () => {
+            expect(component.isSelected(
+                'receiving',
+                generateGroup('group1'),
+                {column: 'receiving', group: generateGroup('group1')}
+            )).toBe(true);
+        });
+
+        it('should return false if the given cell is not the one selected (different id)', () => {
+            expect(component.isSelected(
+                'receiving',
+                generateGroup('group1'),
+                {column: 'receiving', group: generateGroup('group2')}
+            )).toBe(false);
+        });
+
+        it('should return false if the given cell is not the one selected (different column)', () => {
+            expect(component.isSelected(
+                'receiving',
+                generateGroup('group1'),
+                {column: 'sending', group: generateGroup('group1')}
+            )).toBe(false);
+        });
+    });
+
+    describe('isRelatedWithCell', () => {
+        it('should return false if the given related cell is null', () => {
+            expect(component.isRelatedWithCell(
+                'receiving',
+                generateGroup('group1'),
+                null,
+                [
+                    generateCommunicationRule('group1', ['group2', 'group3'])
+                ])
+            ).toBe(false);
+        });
+
+        it('should return false if they both are in the same column but with different ids', () => {
+            expect(component.isRelatedWithCell(
+                'receiving',
+                generateGroup('group1'),
+                {column: 'receiving', group: generateGroup('group2')},
+                [
+                    generateCommunicationRule('group1', ['group2', 'group3'])
+                ])
+            ).toBe(false);
+        });
+
+        it('should return true if the cells are the same', () => {
+            expect(component.isRelatedWithCell(
+                'receiving',
+                generateGroup('group1'),
+                {column: 'receiving', group: generateGroup('group1')},
+                [
+                    generateCommunicationRule('group1', ['group2', 'group3'])
+                ])
+            ).toBe(true);
+        });
+
+        it('should return true if the column and group match a sending group of the related receiving cell communication rules', () => {
+            expect(component.isRelatedWithCell(
+                'sending',
+                generateGroup('group1'),
+                {column: 'receiving', group: generateGroup('group2')},
+                [
+                    generateCommunicationRule('group1', ['group2'])
+                ])
+            ).toBe(true);
+        });
+
+        it('should return false if the column and group does not match a sending group of the related receiving cell communication rules', () => {
+            expect(component.isRelatedWithCell(
+                'sending',
+                generateGroup('group1'),
+                {column: 'receiving', group: generateGroup('group2')},
+                [
+                    generateCommunicationRule('group3', ['group2'])
+                ])
+            ).toBe(false);
+        });
+
+        it('should return true if the column and group match a receiving group of the related sending cell communication rules', () => {
+            expect(component.isRelatedWithCell(
+                'receiving',
+                generateGroup('group1'),
+                {column: 'sending', group: generateGroup('group2')},
+                [
+                    generateCommunicationRule('group2', ['group3', 'group1'])
+                ])
+            ).toBe(true);
+        });
+
+        it('should return false if the column and group does not match a receiving group of the related sending cell communication rules', () => {
+            expect(component.isRelatedWithCell(
+                'receiving',
+                generateGroup('group1'),
+                {column: 'sending', group: generateGroup('group2')},
+                [
+                    generateCommunicationRule('group2', ['group3'])
+                ])
+            ).toBe(false);
+        });
+    });
 });
 
 describe('uniqueGroups', () => {
@@ -89,4 +229,13 @@ function generateCommunicationRule(senderName: string, receiversName: string[] =
 class MockGroupCard {
     @Input()
     group: GroupModel;
+
+    @Input()
+    active: boolean = false;
+
+    @Input()
+    selected: boolean = false;
+
+    @Input()
+    highlighted: boolean = false;
 }

--- a/admin/src/main/ts/app/users/communication/communication-rules.component.ts
+++ b/admin/src/main/ts/app/users/communication/communication-rules.component.ts
@@ -23,13 +23,27 @@ export const communicationRulesLocators = {
         </div>
         <div class="communication-rules__columns">
             <div class="communication-rules__column ${css.sendingColumn}">
-                <div class="group ${css.group}" *ngFor="let sender of getSenders(); trackBy: trackByGroupId">
-                    <group-card [group]="sender"></group-card>
+                <div class="group ${css.group}" *ngFor="let group of getSenders(); trackBy: trackByGroupId">
+                    <group-card
+                    (click)="select('sending', group)"
+                    (mouseenter)="highlight('sending', group, selected)"
+                    (mouseleave)="resetHighlight()"
+                    [group]="group"
+                    [selected]="isSelected('sending', group, selected)"
+                    [highlighted]="isRelatedWithCell('sending', group, highlighted, communicationRules)"
+                    [active]="isRelatedWithCell('sending', group, selected, communicationRules)"></group-card>
                 </div>
             </div>
             <div class="communication-rules__column ${css.receivingColumn}">
-                <div class="group ${css.group}" *ngFor="let receiver of getReceivers(); trackBy: trackByGroupId">
-                    <group-card [group]="receiver"></group-card>
+                <div class="group ${css.group}" *ngFor="let group of getReceivers(); trackBy: trackByGroupId">
+                    <group-card
+                    (click)="select('receiving', group)"
+                    (mouseenter)="highlight('receiving', group, selected)"
+                    (mouseleave)="resetHighlight()"
+                    [group]="group"
+                    [selected]="isSelected('receiving', group, selected)"
+                    [highlighted]="isRelatedWithCell('receiving', group, highlighted, communicationRules)"
+                    [active]="isRelatedWithCell('receiving', group, selected, communicationRules)"></group-card>
                 </div>
             </div>
         </div>`,
@@ -37,14 +51,19 @@ export const communicationRulesLocators = {
         .communication-rules__header {
             color: #2a9cc8;
             font-size: 20px;
-        }`, `
+        }
+    `, `
         .communication-rules__headers, .communication-rules__columns {
             display: flex;
-            align-items: center;
-        }`, `
+        }
+    `, `
         .communication-rules__header, .communication-rules__column {
             flex-grow: 1;
             flex-basis: 0;
+        }
+    `, `
+        group-card {
+            display: inline-block;
         }
     `]
 })
@@ -52,6 +71,24 @@ export class CommunicationRulesComponent {
 
     @Input()
     communicationRules: CommunicationRule[];
+
+    selected: Cell;
+    highlighted: Cell;
+
+    public select(column: Column, group: GroupModel): void {
+        this.selected = {column, group};
+        this.resetHighlight();
+    }
+
+    public highlight(column: Column, group: GroupModel, selected: Cell): void {
+        if (column !== selected.column || group.id !== selected.group.id) {
+            this.highlighted = {column, group};
+        }
+    }
+
+    public resetHighlight(): void {
+        this.highlighted = null;
+    }
 
     public getSenders(): GroupModel[] {
         return this.communicationRules.map(rule => rule.sender);
@@ -65,6 +102,28 @@ export class CommunicationRulesComponent {
 
     public trackByGroupId(index: number, group: GroupModel): string {
         return group.id;
+    }
+
+    public isSelected(column: Column, group: GroupModel, selected: Cell) {
+        if (!selected) {
+            return false;
+        }
+
+        return group.id === selected.group.id && column === selected.column;
+    }
+
+    public isRelatedWithCell(column: Column, group: GroupModel, cell: Cell, communicationRules: CommunicationRule[]): boolean {
+        if (!cell) {
+            return false;
+        }
+
+        if (column === cell.column) {
+            return group.id === cell.group.id;
+        }
+
+        return communicationRules
+            .filter(cr => (cr.sender.id === cell.group.id) || cr.receivers.some(g => g.id === cell.group.id))
+            .some(cr => (cr.sender.id === group.id) || cr.receivers.some(g => g.id === group.id));
     }
 }
 
@@ -81,4 +140,11 @@ export function uniqueGroups(groups: GroupModel[]): GroupModel[] {
         }
     });
     return uniqGroups;
+}
+
+type Column = 'sending' | 'receiving';
+
+interface Cell {
+    column: Column;
+    group: GroupModel;
 }

--- a/admin/src/main/ts/app/users/communication/communication-rules.service.ts
+++ b/admin/src/main/ts/app/users/communication/communication-rules.service.ts
@@ -55,7 +55,10 @@ export class CommunicationRulesService {
     }
 
     private findGroup(communicationRules: CommunicationRule[], groupId: string): GroupModel {
-        return communicationRules.map(rule => rule.sender).find(sender => sender.id === groupId);
+        return communicationRules.reduce(
+            (arrayOfGroups: GroupModel[], communicationRule: CommunicationRule): GroupModel[] =>
+                [...arrayOfGroups, communicationRule.sender, ...communicationRule.receivers], [])
+            .find(group => group.id === groupId);
     }
 
     private clone(communicationRules: CommunicationRule[]): CommunicationRule[] {

--- a/admin/src/main/ts/app/users/communication/group-card.component.spec.ts
+++ b/admin/src/main/ts/app/users/communication/group-card.component.spec.ts
@@ -40,6 +40,7 @@ describe('GroupCardComponent', () => {
             "group.card.class.Guest": "Invités de la classe {{name}}"
         });
         component.group = generateGroup('Elèves du Lycée Paul Martin');
+        component.active = true;
         fixture.detectChanges();
     }));
 

--- a/admin/src/main/ts/app/users/communication/group-card.component.ts
+++ b/admin/src/main/ts/app/users/communication/group-card.component.ts
@@ -6,59 +6,98 @@ import { BundlesService } from "sijil";
 const css = {
     title: 'lct-group-card-title',
     addCommunicationButton: 'lct-group-card-add-communicaiton-button',
+    removeCommunicationButton: 'lct-group-card-remove-communicaiton-button',
     internalCommunicationSwitch: 'lct-group-card-internal-communication-switch'
 };
 
 export const groupCardLocators = {
     title: `.${css.title}`,
     addCommunicationButton: `.${css.addCommunicationButton}`,
+    removeCommunicationButton: `.${css.removeCommunicationButton}`,
     internalCommunicationSwitch: `.${css.internalCommunicationSwitch}`
 };
 
 @Component({
     selector: 'group-card',
     template: `
-        <div class="group-card">
+        <div class="group-card"
+        [ngClass]="{'group-card--active': active, 'group-card--selected': selected, 'group-card--highlighted': highlighted}">
             <div class="group-card__title ${css.title}">{{getGroupName(group)}}</div>
             <div class="group-card__actions">
-                <button class="group-card__action-add-communication ${css.addCommunicationButton}">{{ 'group.card.add-communication-button' | translate }} <i class="fa fa-plus"></i></button>
+                <button
+                    class="group-card__action-add-communication ${css.addCommunicationButton}"
+                    (click)="$event.stopPropagation();">
+                    {{ 'group.card.add-communication-button' | translate }} <i class="fa fa-plus"></i>
+                </button>
+                <button
+                    class="group-card__action-remove-communication ${css.removeCommunicationButton}"
+                    (click)="$event.stopPropagation();">
+                    {{ 'group.card.remove-communication-button' | translate }} <i class="fa fa-minus"></i>
+                </button>
             </div>
-            <hr class="group-card__separator"/>
+            <hr class="group-card__separator" [hidden]="!active"/>
             <span class="group-card__actions-on-self group-card__actions-on-self--can-communicate"
                       *ngIf="group.internalCommunicationRule === 'BOTH'; else cannotCommunicateTogether;">
                 <s5l class="group-card__switch-label">group.details.members.can.communicate</s5l> <i
                     class="${css.internalCommunicationSwitch} group-card__switch fa fa-toggle-on"
-                    (click)="toggleInternalCommunicationRule()"></i>
+                    (click)="toggleInternalCommunicationRule(); $event.stopPropagation();"></i>
             </span>
             <ng-template #cannotCommunicateTogether>
                 <span class="group-card__actions-on-self group-card__actions-on-self--cannot-communicate">
                     <s5l class="group-card__switch-label">group.details.members.cannot.communicate</s5l> <i
                         class="${css.internalCommunicationSwitch} group-card__switch fa fa-toggle-off"
-                        (click)="toggleInternalCommunicationRule()"></i>
+                        (click)="toggleInternalCommunicationRule(); $event.stopPropagation();"></i>
                 </span>
             </ng-template>
         </div>`,
     styles: [`
         .group-card {
-            background-color: #2a9cc8;
+            background-color: #c0c0c0;
+            color: black;
             font-size: 14px;
             padding: 10px;
-            margin: 10px 0;
+            margin: 5px 0;
             width: 340px;
-            color: white;
             box-sizing: border-box;
-            box-shadow: 1px 1px 5px #AAA;
+            cursor: pointer;
+            transition: box-shadow 125ms ease;
+        }
+
+        .group-card.group-card--active {
+            background-color: #2a9cc8;
+            color: white;
+            box-shadow: 1px 1px 5px #aaa;
+        }
+
+        .group-card.group-card--active, .group-card.group-card--selected {
+            cursor: default;
+        }
+
+        .group-card.group-card--highlighted {
+            box-shadow: 1px 1px 5px #aaa;
+        }
+
+        .group-card.group-card--active.group-card--highlighted {
+            box-shadow: 3px 3px 8px 2px #aaa;
         }
     `, `
         .group-card__title {
             font-size: 16px;
+        }
+
+        .group-card--active .group-card__title {
             margin-bottom: 15px;
         }
     `, `
         .group-card__actions {
+            display: none;
+        }
+
+        .group-card--active .group-card__actions {
+            display: initial;
         }
     `, `
-        .group-card__action-add-communication {
+        .group-card__action-remove-communication, .group-card__action-add-communication {
             background: #ff6624;
             height: 34px;
             line-height: 34px;
@@ -67,8 +106,16 @@ export const groupCardLocators = {
             border: 0;
             color: white;
         }
+
+        .group-card__action-add-communication, .group-card--selected .group-card__action-remove-communication {
+            display: none;
+        }
+
+        .group-card--selected .group-card__action-add-communication {
+            display: initial;
+        }
     `, `
-        .group-card__action-add-communication i {
+        .group-card__action-remove-communication i, .group-card__action-add-communication i {
             float: none;
         }
     `, `
@@ -85,6 +132,10 @@ export const groupCardLocators = {
         }
     `, `
         .group-card__actions-on-self {
+            display: none;
+        }
+
+        .group-card--active .group-card__actions-on-self {
             display: flex;
             align-items: center;
             padding-bottom: 10px;
@@ -103,6 +154,15 @@ export class GroupCardComponent {
 
     @Input()
     group: GroupModel;
+
+    @Input()
+    active: boolean = false;
+
+    @Input()
+    selected: boolean = false;
+
+    @Input()
+    highlighted: boolean = false;
 
     constructor(private communicationRulesService: CommunicationRulesService, private bundlesService: BundlesService) {
     }


### PR DESCRIPTION
Related to CAV2-381 : https://opendigitaleducation.atlassian.net/browse/CAV2-381

- also fixing a issue when calling the toggle internal communication rule, the service was not emitting a change if the given group was in the receiving column.