### PR TITLE
fix(feeder): #23677, Fix ONDE relative import when class is overriden

### DIFF
--- a/feeder/src/main/java/org/entcore/feeder/csv/CsvFeeder.java
+++ b/feeder/src/main/java/org/entcore/feeder/csv/CsvFeeder.java
@@ -458,6 +458,7 @@ public class CsvFeeder implements Feed {
 									} else {
 										childClasses = user.getValue("childClasses");
 									}
+									//TODO refactor duplicated code between csvfeeder and csvvalidator?
 									if (childUsername instanceof JsonArray && childLastName instanceof JsonArray &&
 											childFirstName instanceof JsonArray && childClasses instanceof JsonArray &&
 											((JsonArray) childClasses).size() == ((JsonArray) childLastName).size() &&
@@ -479,6 +480,23 @@ public class CsvFeeder implements Feed {
 												childClasses.toString().trim() +
 												defaultStudentSeed;
 										relativeStudentMapping(linkStudents, mapping);
+									} else if (childUsername instanceof JsonArray && childLastName instanceof JsonArray &&
+											childFirstName instanceof JsonArray && childClasses instanceof String &&
+											!((String)childClasses).trim().isEmpty() &&
+											((JsonArray) childFirstName).size() == ((JsonArray) childUsername).size() &&
+											((JsonArray) childFirstName).size() == ((JsonArray) childLastName).size()) {
+										//ONDE files have children array foreach parent row but
+										//in case of paramclass => childClasses is aalways String => structure.getOverrideClass() is defined as string
+										// see ImportInfos.setOverrideClass and CSVUtil.getStructure
+										for (int j = 0; j < ((JsonArray) childUsername).size(); j++) {
+											String mapping = structure.getExternalId() +
+													((JsonArray) childUsername).getString(j).trim() +
+													((JsonArray) childLastName).getString(j).trim() +
+													((JsonArray) childFirstName).getString(j).trim() +
+													((String)childClasses).trim() +
+													defaultStudentSeed;
+											relativeStudentMapping(linkStudents, mapping);
+										}
 									} else {
 										handler.handle(new ResultMessage().error("invalid.child.mapping"));
 										return;
@@ -510,6 +528,20 @@ public class CsvFeeder implements Feed {
 													childFirstName.toString().trim() +
 													childClasses.toString().trim() + defaultStudentSeed;
 											relativeStudentMapping(linkStudents, mapping);
+									} else if (childLastName instanceof JsonArray && childFirstName instanceof JsonArray
+											&& childClasses instanceof String && !((String)childClasses).trim().isEmpty() &&
+											((JsonArray) childFirstName).size() == ((JsonArray) childLastName).size()) {
+										//ONDE files have children array foreach parent row but
+										//in case of paramclass => childClasses is aalways String => structure.getOverrideClass() is defined as string
+										// see ImportInfos.setOverrideClass and CSVUtil.getStructure
+										for (int j = 0; j < ((JsonArray) childLastName).size(); j++) {
+											String mapping = structure.getExternalId() +
+													((JsonArray) childLastName).getString(j).trim() +
+													((JsonArray) childFirstName).getString(j).trim() +
+													((String)childClasses).trim() +
+													defaultStudentSeed;
+											relativeStudentMapping(linkStudents, mapping);
+										}
 									} else {
 										handler.handle(new ResultMessage().error("invalid.child.mapping"));
 										return;

--- a/feeder/src/main/java/org/entcore/feeder/csv/CsvValidator.java
+++ b/feeder/src/main/java/org/entcore/feeder/csv/CsvValidator.java
@@ -443,6 +443,23 @@ public class CsvValidator extends Report implements ImportValidator {
 													childClasses.toString().trim() +
 													defaultStudentSeed;
 											relativeStudentMapping(linkStudents, mapping);
+										} else if (childUsername instanceof JsonArray && childLastName instanceof JsonArray &&
+												childFirstName instanceof JsonArray && childClasses instanceof String &&
+												!((String)childClasses).trim().isEmpty() &&
+												((JsonArray) childFirstName).size() == ((JsonArray) childUsername).size() &&
+												((JsonArray) childFirstName).size() == ((JsonArray) childLastName).size()) {
+											//ONDE files have children array foreach parent row but
+											//in case of paramclass => childClasses is aalways String => structure.getOverrideClass() is defined as string
+											// see ImportInfos.setOverrideClass and CSVUtil.getStructure
+											for (int j = 0; j < ((JsonArray) childUsername).size(); j++) {
+												String mapping = structure.getExternalId() +
+														((JsonArray) childUsername).getString(j).trim() +
+														((JsonArray) childLastName).getString(j).trim() +
+														((JsonArray) childFirstName).getString(j).trim() +
+														((String)childClasses).trim() +
+														defaultStudentSeed;
+												relativeStudentMapping(linkStudents, mapping);
+											}
 										} else {
 											addErrorByFile(profile, "invalid.child.mapping", "" + (i+1) , "childLUsername");
 											handler.handle(result);
@@ -477,6 +494,20 @@ public class CsvValidator extends Report implements ImportValidator {
 													childClasses.toString().trim() +
 													defaultStudentSeed;
 											relativeStudentMapping(linkStudents, mapping);
+										} else if (childLastName instanceof JsonArray && childFirstName instanceof JsonArray
+												&& childClasses instanceof String && !((String)childClasses).trim().isEmpty() &&
+												((JsonArray) childFirstName).size() == ((JsonArray) childLastName).size()) {
+											//ONDE files have children array foreach parent row but
+											//in case of paramclass => childClasses is aalways String => structure.getOverrideClass() is defined as string
+											// see ImportInfos.setOverrideClass and CSVUtil.getStructure
+											for (int j = 0; j < ((JsonArray) childLastName).size(); j++) {
+												String mapping = structure.getExternalId() +
+														((JsonArray) childLastName).getString(j).trim() +
+														((JsonArray) childFirstName).getString(j).trim() +
+														((String)childClasses).trim() +
+														defaultStudentSeed;
+												relativeStudentMapping(linkStudents, mapping);
+											}
 										} else {
 											addErrorByFile(profile, "invalid.child.mapping", "" + (i+1) , "childLastName & childFirstName");
 											handler.handle(result);


### PR DESCRIPTION
L'import du fichier ONDE parent crée systématiquement un JSONArray alors que le overrideClass est toujours une String
Le problème ne se pose qu'avec paramétrage de la classe (la console d'admin semble faire une pré-validation qui ne provoque pas l'erreur)
Testé en local, semble marcher