### PR TITLE
 feat(common): #MA-298, Add legal traces

### DIFF
--- a/common/src/main/java/org/entcore/common/http/BaseServer.java
+++ b/common/src/main/java/org/entcore/common/http/BaseServer.java
@@ -46,6 +46,7 @@ import org.entcore.common.search.SearchingEvents;
 import org.entcore.common.search.SearchingHandler;
 import org.entcore.common.sql.DB;
 import org.entcore.common.sql.Sql;
+import org.entcore.common.trace.TraceFilter;
 import org.entcore.common.user.RepositoryEvents;
 import org.entcore.common.user.RepositoryHandler;
 import org.entcore.common.user.UserUtils;
@@ -120,6 +121,7 @@ public abstract class BaseServer extends Server {
 		addFilter(new AccessLoggerFilter(accessLogger));
 		addFilter(new UserAuthFilter(new AppOAuthResourceProvider(
 				getEventBus(vertx), getPathPrefix(config)), new BasicFilter()));
+		addFilter(new TraceFilter(getEventBus(vertx), securedUriBinding));
 	}
 
 	@Override

--- a/common/src/main/java/org/entcore/common/http/filter/Trace.java
+++ b/common/src/main/java/org/entcore/common/http/filter/Trace.java
@@ -1,0 +1,11 @@
+package org.entcore.common.http.filter;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.SOURCE)
+@Documented
+@Target(ElementType.METHOD)
+public @interface Trace {
+    String value();
+    boolean body() default true;
+}

--- a/common/src/main/java/org/entcore/common/trace/TraceFilter.java
+++ b/common/src/main/java/org/entcore/common/trace/TraceFilter.java
@@ -1,0 +1,197 @@
+package org.entcore.common.trace;
+
+import fr.wseduc.mongodb.MongoDb;
+import fr.wseduc.webutils.http.Binding;
+import fr.wseduc.webutils.request.filter.Filter;
+import fr.wseduc.webutils.security.SecureHttpServerRequest;
+import fr.wseduc.webutils.security.XSSUtils;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.entcore.common.http.filter.Trace;
+import org.entcore.common.user.UserInfos;
+import org.entcore.common.user.UserUtils;
+import org.entcore.common.utils.Config;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.*;
+import java.util.regex.Matcher;
+
+public class TraceFilter implements Filter {
+
+    private static final Logger log = LoggerFactory.getLogger(TraceFilter.class);
+    private final EventBus eb;
+    private final Set<Binding> bindings;
+    private Set<Binding> tracedBinding;
+    HashMap<String, JsonObject> actions = new HashMap<>();
+    private static final List<String> bodyMethods = Arrays.asList("POST", "PUT");
+
+    private static final String COLLECTION = "traces";
+
+    public TraceFilter(EventBus eb, Set<Binding> bindings) {
+        this.eb = eb;
+        this.bindings = bindings;
+    }
+
+    private void loadTracedMethods() {
+        tracedBinding = new HashSet<>();
+        InputStream is = TraceFilter.class.getClassLoader().getResourceAsStream(Trace.class.getSimpleName() + ".json");
+        if (is != null) {
+            BufferedReader r = null;
+            try {
+                r = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+                String line;
+                while ((line = r.readLine()) != null) {
+                    final JsonObject trace = new JsonObject(line);
+                    for (Binding binding : bindings) {
+                        if (binding != null && trace.getString("method", "").equals(binding.getServiceMethod())) {
+                            tracedBinding.add(binding);
+                            JsonObject action = new JsonObject()
+                                    .put("value", trace.getString("value"))
+                                    .put("body", trace.getBoolean("body"));
+                            actions.put(binding.getServiceMethod(), action);
+                            break;
+                        }
+                    }
+                }
+            } catch (IOException | DecodeException e) {
+                log.error("Unable to load traced methods", e);
+            } finally {
+                if (r != null) {
+                    try {
+                        r.close();
+                    } catch (IOException e) {
+                        log.error("Close input stream error", e);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void canAccess(HttpServerRequest request, Handler<Boolean> handler) {
+        handler.handle(true);
+        JsonObject entry = MongoDb.now();
+        if (tracedBinding == null) {
+            loadTracedMethods();
+        }
+
+        if (request instanceof SecureHttpServerRequest && trace(request)) {
+            request.response().endHandler(event -> {
+                List<Future> futures = new ArrayList<>();
+                Future<UserInfos> userFuture = Future.future();
+                Future<Object> bodyFuture = Future.future();
+                futures.add(userFuture);
+                if (bodyMethods.contains(request.method().name()) && actions.get(getRequestServiceMethod(request)).getBoolean("body")) {
+                    futures.add(bodyFuture);
+                    getBody(request, bodyFuture);
+                }
+                CompositeFuture.all(futures).setHandler(futureEvent -> {
+                    if (futureEvent.failed()) {
+                        log.error("[TraceFilter] Failed to create trace : " + request.uri(), futureEvent.cause());
+                        return;
+                    }
+                    UserInfos user = userFuture.result();
+
+                    JsonObject trace = new JsonObject()
+                            .put("application", Config.getInstance().getConfig().getString("app-name"))
+                            .put("user", getUserObject(user))
+                            .put("request", getActionObject(request))
+                            .put("entry", entry)
+                            .put("response", MongoDb.now())
+                            .put("action", actions.get(getRequestServiceMethod(request)).getString("value"))
+                            .put("status", request.response().getStatusCode());
+
+                    if (bodyMethods.contains(request.method().name()) && actions.get(getRequestServiceMethod(request)).getBoolean("body")) {
+                        trace.put("resource", bodyFuture.result());
+                    }
+
+                    MongoDb.getInstance().insert(COLLECTION, trace);
+                });
+
+                getUser(request, userFuture);
+            });
+        }
+    }
+
+    private JsonObject getUserObject(UserInfos user) {
+        return new JsonObject()
+                .put("login", user.getLogin())
+                .put("id", user.getUserId());
+    }
+
+    private JsonObject getActionObject (HttpServerRequest request) {
+        JsonObject parameters = new JsonObject();
+        Iterator<Map.Entry<String, String>> iterator = request.params().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, String> param = iterator.next();
+            parameters.put(param.getKey(), param.getValue());
+        }
+        return new JsonObject()
+                .put("method", request.method().name())
+                .put("uri", request.uri())
+                .put("params", parameters);
+    }
+
+    private void getUser(HttpServerRequest request, Future<UserInfos> future) {
+        UserUtils.getUserInfos(this.eb, request, user -> {
+            if (user == null) {
+                future.fail("Null user");
+            } else {
+                future.complete(user);
+            }
+        });
+    }
+
+    private void getBody(HttpServerRequest request, Future<Object> future) {
+        request.bodyHandler(bodyEvt -> {
+            String body = XSSUtils.stripXSS(bodyEvt.toString("UTF-8"));
+            if (body == null || "".equals(body.trim())){
+                future.complete(null);
+            } else {
+                Object parsedBody  = body.startsWith("{") ? new JsonObject(body) : new JsonArray(body);
+                future.complete(parsedBody);
+            }
+        });
+    }
+
+    private String getRequestServiceMethod(HttpServerRequest request) {
+        for (Binding binding : tracedBinding) {
+            if (!request.method().name().equals(binding.getMethod().name())) {
+                continue;
+            }
+            Matcher m = binding.getUriPattern().matcher(request.path());
+            if (m.matches()) {
+                return binding.getServiceMethod();
+            }
+        }
+
+        return "";
+    }
+
+    private boolean trace(HttpServerRequest request) {
+        if (!tracedBinding.isEmpty()) {
+            for (Binding binding : tracedBinding) {
+                if (!request.method().name().equals(binding.getMethod().name())) {
+                    continue;
+                }
+                Matcher m = binding.getUriPattern().matcher(request.path());
+                return m.matches();
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void deny(HttpServerRequest httpServerRequest) {}
+}

--- a/migration/3.6.0/traces_ttl_index.js
+++ b/migration/3.6.0/traces_ttl_index.js
@@ -1,0 +1,2 @@
+// Add ttl index on traces. Expire after 1 year
+db.traces.createIndex({"entry": 1},{expireAfterSeconds: 31536000});


### PR DESCRIPTION
> Pull request liée à celle de [web-utils#5](https://github.com/opendigitaleducation/web-utils/pull/5)

# Description
Ajout de l'annotation `@Trace`. Cette annotation permet de tracer les interactions HTTP dans un but "juridique", notamment dans les outils de vie scolaires.
L'utilisation de l'annotation sur une route sauvegarde un objet dans une collection. Par exemple : 
```json
{
    "_id" : "a4b2648f-2a89-4ce8-bfc6-05d894cfb66a",
    "application" : "Presences",
    "user" : {
        "login" : "jane.doe",
        "id" : "a25cd679-b30b-4701-8c60-231cdc30cdf2"
    },
    "request" : {
        "method" : "POST",
        "uri" : "/presences/events",
        "params" : {}
    },
    "entry" : ISODate("2019-05-03T16:15:56.329Z"),
    "response" : ISODate("2019-05-03T16:15:56.373Z"),
    "action" : "POST_EVENT",
    "status" : 201,
    "resource" : {
        "register_id" : 1019869,
        "type_id" : 1,
        "student_id" : "d2c7bbf9-baa9-4385-b5e7-cfbf66bdd9db",
        "start_date" : "2019-05-03T08:00:00.000",
        "end_date" : "2019-05-03T08:55:00.000"
    }
}
```

# Utilisation
L'annotation prend en paramètres :
- `value` décrivant la valeur de l'action
- `body` indiquant si il faut enregistrer le body de la requête (par défaut oui)

Il est possible de l'utiliser de la manière suivante :
```java
  @Post("/events")
  @ApiDoc("Create event")
  @SecuredAction(Presences.CREATE_EVENT)
  @Trace("POST_EVENT")
  public void postEvent(HttpServerRequest request) {}
```
ou 
```java
 @Put("/events/:id")
 @ApiDoc("Update given event")
 @ResourceFilter(CreateEventRight.class)
 @SecuredAction(value = "", type = ActionType.RESOURCE)
 @Trace(value = "PUT_EVENT", body = false)
 public void putEvent(HttpServerRequest request) {}
```