### PR TITLE
feat(Feeder) : add internal email on users and groups

### DIFF
--- a/feeder/src/main/java/org/entcore/feeder/Feeder.java
+++ b/feeder/src/main/java/org/entcore/feeder/Feeder.java
@@ -272,6 +272,8 @@ public class Feeder extends BusModBase implements Handler<Message<JsonObject>> {
 				break;
 			case "manual-remove-user-group" : manual.removeUserGroup(message);
 				break;
+			case "manual-update-email-group" : manual.updateEmailGroup(message);
+				break;
 			case "manual-create-tenant" : manual.createOrUpdateTenant(message);
 				break;
 			case "manual-structure-attachment" : manual.structureAttachment(message);

--- a/feeder/src/main/java/org/entcore/feeder/ManualFeeder.java
+++ b/feeder/src/main/java/org/entcore/feeder/ManualFeeder.java
@@ -33,7 +33,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.LoggerFactory;
 import org.vertx.java.busmods.BusModBase;
 
 import java.util.*;
@@ -813,6 +812,17 @@ public class ManualFeeder extends BusModBase {
 			public void apply(TransactionHelper tx) {
 				Group.removeUsers(groupId, userIds, tx);
 			}
+		});
+	}
+
+	public void updateEmailGroup(Message<JsonObject> message) {
+		final String groupId = getMandatoryString("groupId", message);
+		final String email = getMandatoryString("email", message);
+
+		if (email == null || groupId == null) return;
+
+		executeTransaction(message, tx -> {
+				Group.updateEmail(groupId, email, tx);
 		});
 	}
 

--- a/feeder/src/main/java/org/entcore/feeder/dictionary/structures/Group.java
+++ b/feeder/src/main/java/org/entcore/feeder/dictionary/structures/Group.java
@@ -22,6 +22,7 @@ package org.entcore.feeder.dictionary.structures;
 import java.util.UUID;
 
 import org.entcore.common.neo4j.Neo4jUtils;
+import org.entcore.common.validation.StringValidation;
 import org.entcore.feeder.exceptions.ValidationException;
 import org.entcore.feeder.utils.TransactionHelper;
 import org.entcore.feeder.utils.Validator;
@@ -111,5 +112,22 @@ public class Group {
 				.put("userIds", userIds);
 		
 		transactionHelper.add(query, params);
+	}
+
+	public static void updateEmail(String groupId, String emailInternal, TransactionHelper transactionHelper)
+			throws ValidationException{
+
+		if(!StringValidation.isEmail(emailInternal)) {
+			throw new ValidationException("invalid.email");
+		} else {
+			String query =  "MERGE (g:Group { id : {id}}) " +
+					"SET g.emailInternal = {email}";
+
+			JsonObject params = new JsonObject()
+					.put("id", groupId)
+					.put("email", emailInternal);
+
+			transactionHelper.add(query, params);
+		}
 	}
 }

--- a/feeder/src/main/resources/dictionary/schema/Personnel.json
+++ b/feeder/src/main/resources/dictionary/schema/Personnel.json
@@ -81,8 +81,12 @@
 			"validator" : "email"
 		},
 		"emailAcademy" : {
-		  "type" : "string",
-		  "validator" : "email"
+			"type" : "string",
+			"validator" : "email"
+		},
+		"emailInternal" : {
+			"type" : "string",
+			"validator" : "email"
 		},
 		"birthDate" : {
 			"type" : "string",
@@ -153,5 +157,5 @@
 	"required" : ["id", "externalId", "firstName", "lastName", "login", "displayName"],
 	"modifiable" : ["firstName", "lastName", "password", "displayName", "surname",
 		"otherNames", "address", "postbox", "zipCode", "city", "country", "homePhone",
-		"workPhone", "mobile", "email", "birthDate", "loginAlias"]
+		"workPhone", "mobile", "email", "birthDate", "loginAlias","emailInternal"]
 }

--- a/feeder/src/main/resources/dictionary/schema/Student.json
+++ b/feeder/src/main/resources/dictionary/schema/Student.json
@@ -80,6 +80,10 @@
 			"type" : "string",
 			"validator" : "email"
 		},
+		"emailInternal" : {
+			"type" : "string",
+			"validator" : "email"
+		},
 		"birthDate" : {
 			"type" : "string",
 			"validator" : "birthDate"
@@ -181,5 +185,5 @@
 	"required" : ["id", "externalId", "firstName", "lastName", "login", "displayName", "birthDate"],
 	"modifiable" : ["firstName", "lastName", "password", "displayName", "surname",
 		"otherNames", "address", "postbox", "zipCode", "city", "country", "homePhone",
-		"workPhone", "mobile", "email", "birthDate", "loginAlias"]
+		"workPhone", "mobile", "email", "birthDate", "loginAlias","emailInternal"]
 }

--- a/feeder/src/main/resources/dictionary/schema/User.json
+++ b/feeder/src/main/resources/dictionary/schema/User.json
@@ -88,6 +88,10 @@
 			"type" : "string",
 			"validator" : "email"
 		},
+		"emailInternal" : {
+			"type" : "string",
+			"validator" : "email"
+		},
 		"addressDiffusion" : {
 		  "type" : "boolean"
 		},
@@ -118,5 +122,5 @@
 	"required" : ["id", "externalId", "firstName", "lastName", "login", "displayName"],
 	"modifiable" : ["firstName", "lastName", "password", "displayName", "surname",
 		"otherNames", "address", "postbox", "zipCode", "city", "country", "homePhone",
-		"workPhone", "mobile", "email", "birthDate", "loginAlias"]
+		"workPhone", "mobile", "email", "birthDate", "loginAlias","emailInternal"]
 }


### PR DESCRIPTION
Ajout d'une API pour pouvoir rajouter une adresse mail interne pour les utilisateurs et pour les groupes.
A merger pour la prochaine version de Zimbra en 3.5 (livraison prévue mi-juin)