### PR TITLE
Adminv2: Import image for connector icon

### DIFF
--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -420,11 +420,17 @@
     "services.connector.create.button": "Créer un connecteur",
     "services.connector.create.title": "Nouveau connecteur",
 
+    "services.connector.icon.title": "Icône",
+    "services.connector.icon.url": "Url de l'icône",
+    "services.connector.icon.url.help": "Le champ Url de l'icône peut être saisi avec :<ul><li>l'url d'une image d'un site web, sous la forme : http(s)://[lien-vers-image]</li><li>le nom d'une icône, par exemple : actualites-large</li><li>ou bien en utilisant le bouton 'Parcourir' ou le 'glisser/déposer' ci-dessus, l'url de l'image téléversée sera mise automatiquement dans ce champ</li></ul>",
+    "services.connector.icon.upload": "Importer un fichier",
+    "services.connector.icon.upload.error.title": "Erreur lors de l'import de l'icône",
+    "services.connector.icon.upload.error.content": "L'import de l'icône n'a pas pu aboutir",
+
     "services.connector.properties.title": "Paramètres du lien",
     "services.connector.properties.inherits": "Partager le connecteur avec les sous-structures",
     "services.connector.properties.id": "Identifiant",
     "services.connector.properties.displayName": "Nom d'affichage",
-    "services.connector.properties.icon": "Icône",
     "services.connector.properties.url": "URL",
     "services.connector.properties.target": "Cible",
     "services.connector.properties.target.portal": "Page",
@@ -609,5 +615,8 @@
     "quota.terabyte": "TeraOctet(s)",
     "quota.usedSpace": "utilisés.",
     "quota.form.title": "Modifier l'espace de stockage de l'utilisateur",
-    "quota.maxQuota": "Quota maximum autorisé pour ce profil :"
+    "quota.maxQuota": "Quota maximum autorisé pour ce profil :",
+    
+    "ux.upload-files.button.label": "Parcourir",
+    "ux.upload-files.button.help": "Glisser-déposer un fichier depuis votre appareil ou cliquez sur parcourir"
 }

--- a/admin/src/main/resources/public/styles/admin.scss
+++ b/admin/src/main/resources/public/styles/admin.scss
@@ -457,7 +457,7 @@ i.group_add {
 
 .message {
   margin: 15px 0px;
-  p {margin: 0px;}
+  p {margin: 10px 0;}
   .message-header {
     padding: 10px 20px;
     background: black;
@@ -472,10 +472,11 @@ i.group_add {
     &::before {
       font-family: "FontAwesome";
       display: inline-block;
-      padding: 0 10px;
+      padding: 0 0;
       font-size: 20px;
       vertical-align: middle;
     }
+    ul {list-style: initial;}
   }
   &.is-success {
     color: $success;

--- a/admin/src/main/resources/public/styles/admin.scss
+++ b/admin/src/main/resources/public/styles/admin.scss
@@ -472,7 +472,7 @@ i.group_add {
     &::before {
       font-family: "FontAwesome";
       display: inline-block;
-      padding: 0 0;
+      padding: 0;
       font-size: 20px;
       vertical-align: middle;
     }

--- a/admin/src/main/ts/app/core/services/notify.service.ts
+++ b/admin/src/main/ts/app/core/services/notify.service.ts
@@ -88,7 +88,3 @@ export class NotifyService {
     }
 
 }
-
-export interface Error {
-    message: string;
-}

--- a/admin/src/main/ts/app/core/services/notify.service.ts
+++ b/admin/src/main/ts/app/core/services/notify.service.ts
@@ -88,3 +88,7 @@ export class NotifyService {
     }
 
 }
+
+export interface Error {
+    message: string;
+}

--- a/admin/src/main/ts/app/core/store/models/connector.model.ts
+++ b/admin/src/main/ts/app/core/store/models/connector.model.ts
@@ -24,6 +24,7 @@ export class ConnectorModel extends Model<ConnectorModel> {
     name: string;
     displayName: string;
     icon: string;
+    iconFile: File | Blob;
     url: string;
     target: string;
     inherits: boolean;

--- a/admin/src/main/ts/app/services/connectors/connector/properties/connector-properties.component.ts
+++ b/admin/src/main/ts/app/services/connectors/connector/properties/connector-properties.component.ts
@@ -1,12 +1,32 @@
-import { Component, Input, Output, EventEmitter, ViewChild } from "@angular/core";
+import { Component, Input, Output, EventEmitter, ViewChild, ElementRef } from "@angular/core";
 import { ConnectorModel } from "../../../../core/store";
 import { CasType } from "../CasType";
 import { NgForm } from "@angular/forms";
+import { Error } from "../../../../core/services";
 
 @Component({
     selector: 'connector-properties',
     template: `
         <form #propertiesForm="ngForm">
+            <panel-section section-title="services.connector.icon.title">
+                <upload-files [fileSrc]="connector.icon"
+                            [allowedExtensions]="['jpeg', 'jpg', 'bmp', 'png']" 
+                            [maxFilesNumber]="1"
+                            (upload)="onUpload($event)"
+                            (invalidUpload)="onInvalidUpload($event)">
+                </upload-files>
+
+                <fieldset>
+                    <form-field label="services.connector.icon.url" 
+                                help="services.connector.icon.url.help">
+                        <input type="text" 
+                                [(ngModel)]="connector.icon" 
+                                name="icon"
+                                (change)="connector.iconFile = null">
+                    </form-field>
+                </fieldset>
+            </panel-section>
+
             <panel-section section-title="services.connector.properties.title">
                 <fieldset [disabled]="disabled">
                     <div *ngIf="structureChildren"
@@ -34,10 +54,6 @@ import { NgForm } from "@angular/forms";
                             required 
                             #displayNameInput="ngModel">
                         <form-errors [control]="displayNameInput"></form-errors>
-                    </form-field>
-
-                    <form-field label="services.connector.properties.icon">
-                        <input type="text" [(ngModel)]="connector.icon" name="icon">
                     </form-field>
 
                     <form-field label="services.connector.properties.url">
@@ -223,6 +239,10 @@ export class ConnectorPropertiesComponent {
 
     @Output()
     create: EventEmitter<string> = new EventEmitter<string>();
+    @Output()
+    iconFileChanged: EventEmitter<File[]> = new EventEmitter();
+    @Output()
+    iconFileInvalid: EventEmitter<Error> = new EventEmitter();
 
     @ViewChild('propertiesForm')
     propertiesFormRef: NgForm;
@@ -237,7 +257,7 @@ export class ConnectorPropertiesComponent {
     OAUTH_GRANTTYPE_CLIENT_CREDENTIALS = 'client_credentials';
     OAUTH_GRANTTYPE_PASSWORD = 'password';
     OAUTH_GRANTTYPE_BASIC = 'Basic';
-    
+
     public toggleCasType(): void {
         if (this.connector.hasCas) {
             this.connector.casTypeId = this.CAS_DEFAULT_CAS_TYPE_ID;            
@@ -263,5 +283,13 @@ export class ConnectorPropertiesComponent {
             && this.connector.oauthScope && this.connector.oauthScope.indexOf('userinfo') !== -1){
                 this.connector.oauthScope = this.connector.oauthScope.replace('userinfo', '')
 		}
-	}
+    }
+
+    public onUpload($event: File[]): void {
+        this.iconFileChanged.emit($event);
+    }
+
+    public onInvalidUpload($event: Error): void {
+        this.iconFileInvalid.emit($event);
+    }
 }

--- a/admin/src/main/ts/app/services/connectors/connector/properties/connector-properties.component.ts
+++ b/admin/src/main/ts/app/services/connectors/connector/properties/connector-properties.component.ts
@@ -2,7 +2,6 @@ import { Component, Input, Output, EventEmitter, ViewChild, ElementRef } from "@
 import { ConnectorModel } from "../../../../core/store";
 import { CasType } from "../CasType";
 import { NgForm } from "@angular/forms";
-import { Error } from "../../../../core/services";
 
 @Component({
     selector: 'connector-properties',
@@ -242,7 +241,7 @@ export class ConnectorPropertiesComponent {
     @Output()
     iconFileChanged: EventEmitter<File[]> = new EventEmitter();
     @Output()
-    iconFileInvalid: EventEmitter<Error> = new EventEmitter();
+    iconFileInvalid: EventEmitter<string> = new EventEmitter();
 
     @ViewChild('propertiesForm')
     propertiesFormRef: NgForm;
@@ -289,7 +288,7 @@ export class ConnectorPropertiesComponent {
         this.iconFileChanged.emit($event);
     }
 
-    public onInvalidUpload($event: Error): void {
+    public onInvalidUpload($event: string): void {
         this.iconFileInvalid.emit($event);
     }
 }

--- a/admin/src/main/ts/app/services/connectors/connector/smart-connector.component.spec.ts
+++ b/admin/src/main/ts/app/services/connectors/connector/smart-connector.component.spec.ts
@@ -8,7 +8,7 @@ import { ServicesStore } from '../../services.store';
 import { NotifyService, SpinnerService } from '../../../core/services';
 import { StructureModel, ConnectorModel, RoleModel, GroupModel, ConnectorCollection } from '../../../core/store';
 import { Router, ActivatedRoute } from '@angular/router';
-import { ServicesService, Document } from '../../services.service';
+import { ServicesService } from '../../services.service';
 import { Observable } from 'rxjs';
 import { Component, Input, Output, EventEmitter, ViewChild } from '@angular/core';
 import { CasType } from './CasType';
@@ -254,7 +254,6 @@ describe('SmartConnector', () => {
             expect(mockServicesService.uploadPublicImage).toHaveBeenCalledWith(file);
             expect(mockServicesStore.connector.icon).toBe(`/workspace/document/${resId}`);
             expect(component.connectorPropertiesComponent.propertiesFormRef.form.markAsDirty).toHaveBeenCalled();
-            expect(mockNotifyService.success).toHaveBeenCalled();
         });
     })
 })

--- a/admin/src/main/ts/app/services/connectors/connector/smart-connector.component.spec.ts
+++ b/admin/src/main/ts/app/services/connectors/connector/smart-connector.component.spec.ts
@@ -8,13 +8,12 @@ import { ServicesStore } from '../../services.store';
 import { NotifyService, SpinnerService } from '../../../core/services';
 import { StructureModel, ConnectorModel, RoleModel, GroupModel, ConnectorCollection } from '../../../core/store';
 import { Router, ActivatedRoute } from '@angular/router';
-import { ServicesService } from '../../services.service';
+import { ServicesService, Document } from '../../services.service';
 import { Observable } from 'rxjs';
 import { Component, Input, Output, EventEmitter, ViewChild } from '@angular/core';
 import { CasType } from './CasType';
 import { Structure, Profile } from '../../shared/services-types';
 import { ExportFormat } from './export/connector-export';
-import { By } from '@angular/platform-browser';
 import { ConnectorPropertiesComponent } from './properties/connector-properties.component';
 
 describe('SmartConnector', () => {
@@ -32,7 +31,7 @@ describe('SmartConnector', () => {
     let connectorsDataSpliceSpy: jasmine.Spy;
 
     beforeEach(() => {
-        mockServicesService = jasmine.createSpyObj('ServicesService', ['createConnector', 'saveConnector', 'deleteConnector', 'toggleLockConnector', 'getCasTypes', 'massAssignConnector', 'massUnassignConnector', 'getExportConnectorUrl']);
+        mockServicesService = jasmine.createSpyObj('ServicesService', ['createConnector', 'saveConnector', 'deleteConnector', 'toggleLockConnector', 'getCasTypes', 'massAssignConnector', 'massUnassignConnector', 'getExportConnectorUrl', 'uploadPublicImage']);
         (mockServicesService.getCasTypes as jasmine.Spy).and.returnValue(Observable.of([
             {id: 'casType1', name:'casType1', description: 'casType1s'}
         ]));
@@ -238,6 +237,26 @@ describe('SmartConnector', () => {
             expect(window.open).toHaveBeenCalledWith(expectedUrl, '_blank');
         })
     });
+
+    describe('onIconFileChanged', () => {
+        it('should call ServicesService.uploadPublicImage', () => {
+            let file: File = {} as File;
+            const resId: string = 'idDoc1';
+            
+            (mockServicesService.uploadPublicImage as jasmine.Spy).and.returnValue(Observable.of({_id: resId}));
+            
+            component.connectorPropertiesComponent.propertiesFormRef = <NgForm>{};
+            component.connectorPropertiesComponent.propertiesFormRef.form = new FormBuilder().group({});
+            spyOn(component.connectorPropertiesComponent.propertiesFormRef.form, 'markAsDirty');
+
+            component.onIconFileChanged([file]);
+            expect(mockSpinnerService.perform).toHaveBeenCalled();
+            expect(mockServicesService.uploadPublicImage).toHaveBeenCalledWith(file);
+            expect(mockServicesStore.connector.icon).toBe(`/workspace/document/${resId}`);
+            expect(component.connectorPropertiesComponent.propertiesFormRef.form.markAsDirty).toHaveBeenCalled();
+            expect(mockNotifyService.success).toHaveBeenCalled();
+        });
+    })
 })
 
 @Component({

--- a/admin/src/main/ts/app/services/connectors/connector/smart-connector.component.ts
+++ b/admin/src/main/ts/app/services/connectors/connector/smart-connector.component.ts
@@ -134,7 +134,9 @@ import 'rxjs/add/operator/toPromise';
             [structureChildren]="hasStructureChildren()"
             [creationMode]="isCreationMode()"
             [disabled]="arePropertiesDisabled()"
-            (create)="onCreate($event)">
+            (create)="onCreate($event)"
+            (iconFileChanged)="onIconFileChanged($event)"
+            (iconFileInvalid)="onIconFileInvalid($event)">
         </connector-properties>
 
         <connector-assignment
@@ -509,5 +511,30 @@ export class SmartConnectorComponent implements OnInit, OnDestroy {
             this.servicesService.getExportConnectorUrl(
                 $event.exportFormat, $event.profile, this.servicesStore.structure.id)
             , '_blank');
+    }
+
+    public onIconFileChanged($event: File[]): void {
+        const file: Blob = $event[0];
+        
+        this.spinnerService.perform('portal-content', 
+            this.servicesService.uploadPublicImage(file)
+                .do(res => {
+                    this.servicesStore.connector.icon = `/workspace/document/${res._id}`;
+                    this.connectorPropertiesComponent.propertiesFormRef.form.markAsDirty();
+                })
+                .catch(error => {
+                    this.notifyService.error('services.connector.icon.upload.error.content'
+                        , 'services.connector.icon.upload.error.title'
+                        , error);
+                    throw error;
+                })
+                .toPromise()
+        );
+    }
+
+    public onIconFileInvalid($event: Error): void {
+        this.notifyService.error('services.connector.icon.upload.error.content'
+            , 'services.connector.icon.upload.error.title'
+            , $event);
     }
 }

--- a/admin/src/main/ts/app/services/connectors/connector/smart-connector.component.ts
+++ b/admin/src/main/ts/app/services/connectors/connector/smart-connector.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy, ViewChild } from "@angular/core";
 import { Subscription } from "rxjs";
 import { CasType } from "./CasType";
 import { ConnectorModel, Session, SessionModel } from "../../../core/store";
-import { ServicesService } from "../../services.service";
+import { ServicesService, WorkspaceDocument } from "../../services.service";
 import { ActivatedRoute, Params, Router } from "@angular/router";
 import { ServicesStore } from "../../services.store";
 import { SpinnerService, NotifyService } from "../../../core/services";
@@ -518,7 +518,7 @@ export class SmartConnectorComponent implements OnInit, OnDestroy {
         
         this.spinnerService.perform('portal-content', 
             this.servicesService.uploadPublicImage(file)
-                .do(res => {
+                .do((res: WorkspaceDocument) => {
                     this.servicesStore.connector.icon = `/workspace/document/${res._id}`;
                     this.connectorPropertiesComponent.propertiesFormRef.form.markAsDirty();
                 })
@@ -532,9 +532,9 @@ export class SmartConnectorComponent implements OnInit, OnDestroy {
         );
     }
 
-    public onIconFileInvalid($event: Error): void {
+    public onIconFileInvalid($event: string): void {
         this.notifyService.error('services.connector.icon.upload.error.content'
             , 'services.connector.icon.upload.error.title'
-            , $event);
+            , { message: $event });
     }
 }

--- a/admin/src/main/ts/app/services/services.service.spec.ts
+++ b/admin/src/main/ts/app/services/services.service.spec.ts
@@ -143,4 +143,47 @@ describe('ServicesService', () => {
             expect(res).toBe('/directory/export/users?format=csv&structureId=structure1&type=Gepi');
         });
     });
+
+    describe('isIconImage', () => {
+        it('should return true with connector.icon equals to /workspace/image1', () => {
+            const connector = new ConnectorModel();
+            connector.icon = '/workspace/image1';
+            const res = servicesService.isIconImage(connector);
+            expect(res).toBe(true);
+        });
+
+        it('should return true with connector.icon equals to http://image.com/image1', () => {
+            const connector = new ConnectorModel();
+            connector.icon = 'http://image.com/image1';
+            const res = servicesService.isIconImage(connector);
+            expect(res).toBe(true);
+        });
+
+        it('should return false with connector.icon equals to admin-large', () => {
+            const connector = new ConnectorModel();
+            connector.icon = 'admin-large';
+            const res = servicesService.isIconImage(connector);
+            expect(res).toBe(false);
+        });
+    });
+
+    describe('uploadPublicImage', () => {
+        it('should call POST /workspace/document with given query params and form data body', () => {
+            const file: Blob = new Blob();
+            const expectedBody = new FormData();
+            expectedBody.append('file', file);
+            const params: string[] = [];
+            params.push('public=true');
+            params.push('application=admin');
+            params.push('quality=0.7');
+            params.push('thumbnail=120x120&thumbnail=150x150&thumbnail=100x100&thumbnail=290x290&thumbnail=48x48&thumbnail=82x82&thumbnail=381x381');
+            const expectedParams = params.join('&');
+
+            servicesService.uploadPublicImage(file).subscribe();
+    
+            const request = httpTestingController.expectOne(`/workspace/document?${expectedParams}`);
+            expect(request.request.method).toBe('POST');
+            expect(request.request.body).toEqual(expectedBody);
+        });
+    });
 })

--- a/admin/src/main/ts/app/services/services.service.spec.ts
+++ b/admin/src/main/ts/app/services/services.service.spec.ts
@@ -144,29 +144,6 @@ describe('ServicesService', () => {
         });
     });
 
-    describe('isIconImage', () => {
-        it('should return true with connector.icon equals to /workspace/image1', () => {
-            const connector = new ConnectorModel();
-            connector.icon = '/workspace/image1';
-            const res = servicesService.isIconImage(connector);
-            expect(res).toBe(true);
-        });
-
-        it('should return true with connector.icon equals to http://image.com/image1', () => {
-            const connector = new ConnectorModel();
-            connector.icon = 'http://image.com/image1';
-            const res = servicesService.isIconImage(connector);
-            expect(res).toBe(true);
-        });
-
-        it('should return false with connector.icon equals to admin-large', () => {
-            const connector = new ConnectorModel();
-            connector.icon = 'admin-large';
-            const res = servicesService.isIconImage(connector);
-            expect(res).toBe(false);
-        });
-    });
-
     describe('uploadPublicImage', () => {
         it('should call POST /workspace/document with given query params and form data body', () => {
             const file: Blob = new Blob();

--- a/admin/src/main/ts/app/services/services.service.ts
+++ b/admin/src/main/ts/app/services/services.service.ts
@@ -8,26 +8,6 @@ import { ExportFormat } from "./connectors/connector/export/connector-export";
 
 import 'rxjs/add/operator/do';
 
-export interface Document {
-    _id: string;
-    ancestors: Array<any>;
-    application: string;
-    created: Date;
-    eParent: any;
-    eType: string;
-    file: string;
-    inheritedShares: Array<any>;
-    isShared: boolean;
-    metadata: any;
-    modified: Date;
-    name: string;
-    nameSearch: string;
-    owner: string;
-    ownerName: string;
-    public: boolean;
-    shared: Array<any>;
-}
-
 @Injectable()
 export class ServicesService {
 
@@ -126,13 +106,7 @@ export class ServicesService {
         return `${query}?${queryParams}`;
     }
 
-    public isIconImage(connector: ConnectorModel): boolean {
-        return connector 
-            && connector.icon 
-            && (connector.icon.startsWith('/workspace') || connector.icon.startsWith("http"));
-    }
-
-    public uploadPublicImage(image: File | Blob): Observable<Document> {
+    public uploadPublicImage(image: File | Blob): Observable<WorkspaceDocument> {
         let formData: FormData = new FormData();
         formData.append('file', image);
         
@@ -142,6 +116,26 @@ export class ServicesService {
         queryParams.push('quality=0.7');
         queryParams.push('thumbnail=120x120&thumbnail=150x150&thumbnail=100x100&thumbnail=290x290&thumbnail=48x48&thumbnail=82x82&thumbnail=381x381');
 
-        return this.httpClient.post<Document>(`/workspace/document?${queryParams.join('&')}`, formData);
+        return this.httpClient.post<WorkspaceDocument>(`/workspace/document?${queryParams.join('&')}`, formData);
     }
+}
+
+export interface WorkspaceDocument {
+    _id: string;
+    ancestors: Array<any>;
+    application: string;
+    created: Date;
+    eParent: any;
+    eType: string;
+    file: string;
+    inheritedShares: Array<any>;
+    isShared: boolean;
+    metadata: any;
+    modified: Date;
+    name: string;
+    nameSearch: string;
+    owner: string;
+    ownerName: string;
+    public: boolean;
+    shared: Array<any>;
 }

--- a/admin/src/main/ts/app/services/services.service.ts
+++ b/admin/src/main/ts/app/services/services.service.ts
@@ -8,6 +8,26 @@ import { ExportFormat } from "./connectors/connector/export/connector-export";
 
 import 'rxjs/add/operator/do';
 
+export interface Document {
+    _id: string;
+    ancestors: Array<any>;
+    application: string;
+    created: Date;
+    eParent: any;
+    eType: string;
+    file: string;
+    inheritedShares: Array<any>;
+    isShared: boolean;
+    metadata: any;
+    modified: Date;
+    name: string;
+    nameSearch: string;
+    owner: string;
+    ownerName: string;
+    public: boolean;
+    shared: Array<any>;
+}
+
 @Injectable()
 export class ServicesService {
 
@@ -104,5 +124,24 @@ export class ServicesService {
         }
 
         return `${query}?${queryParams}`;
+    }
+
+    public isIconImage(connector: ConnectorModel): boolean {
+        return connector 
+            && connector.icon 
+            && (connector.icon.startsWith('/workspace') || connector.icon.startsWith("http"));
+    }
+
+    public uploadPublicImage(image: File | Blob): Observable<Document> {
+        let formData: FormData = new FormData();
+        formData.append('file', image);
+        
+        let queryParams: string[] = [];
+        queryParams.push('public=true');
+        queryParams.push('application=admin');
+        queryParams.push('quality=0.7');
+        queryParams.push('thumbnail=120x120&thumbnail=150x150&thumbnail=100x100&thumbnail=290x290&thumbnail=48x48&thumbnail=82x82&thumbnail=381x381');
+
+        return this.httpClient.post<Document>(`/workspace/document?${queryParams.join('&')}`, formData);
     }
 }

--- a/admin/src/main/ts/app/services/shared/services-list.component.ts
+++ b/admin/src/main/ts/app/services/shared/services-list.component.ts
@@ -6,7 +6,7 @@ import { Subscription } from 'rxjs/Subscription';
 
 import { ServicesStore } from '../services.store';
 import { ApplicationModel, SessionModel, ConnectorModel } from '../../core/store';
-import { ServicesService } from '../services.service';
+import { InputFileService } from '../../shared/ux/services';
 
 interface ServiceInfo {
     collection: any[],
@@ -40,7 +40,7 @@ interface ServiceInfo {
                                 [title]="'services.connector.locked' | translate"></i>
                         </div>
                         <div class="service-icon">
-                            <img [src]="item.icon" *ngIf="servicesService.isIconImage(item) else isIconClassSelector"/>
+                            <img [src]="item.icon" *ngIf="inputFileService.isSrcUrl(item.icon) else isIconClassSelector"/>
                             <ng-template #isIconClassSelector>
                                 <i [ngClass]="item.icon"></i>
                             </ng-template>
@@ -71,7 +71,7 @@ export class ServicesListComponent {
         public router: Router,
         public route: ActivatedRoute,
         private servicesStore: ServicesStore,
-        public servicesService: ServicesService
+        public inputFileService: InputFileService
         ) {
     }
 

--- a/admin/src/main/ts/app/services/shared/services-list.component.ts
+++ b/admin/src/main/ts/app/services/shared/services-list.component.ts
@@ -6,6 +6,7 @@ import { Subscription } from 'rxjs/Subscription';
 
 import { ServicesStore } from '../services.store';
 import { ApplicationModel, SessionModel, ConnectorModel } from '../../core/store';
+import { ServicesService } from '../services.service';
 
 interface ServiceInfo {
     collection: any[],
@@ -39,7 +40,7 @@ interface ServiceInfo {
                                 [title]="'services.connector.locked' | translate"></i>
                         </div>
                         <div class="service-icon">
-                            <img [src]="item.icon" *ngIf="isIconUrlImg(item.icon) else isIconClassSelector"/>
+                            <img [src]="item.icon" *ngIf="servicesService.isIconImage(item) else isIconClassSelector"/>
                             <ng-template #isIconClassSelector>
                                 <i [ngClass]="item.icon"></i>
                             </ng-template>
@@ -69,7 +70,9 @@ export class ServicesListComponent {
     constructor(
         public router: Router,
         public route: ActivatedRoute,
-        private servicesStore: ServicesStore) {
+        private servicesStore: ServicesStore,
+        public servicesService: ServicesService
+        ) {
     }
 
     ngOnInit(): void {
@@ -143,10 +146,6 @@ export class ServicesListComponent {
             return false;
         }
     };
-
-    public isIconUrlImg(src: String) {
-        return src && (src.startsWith('/workspace') || src.startsWith("http"));
-    }
 
     public isInherited(connector: ConnectorModel) {
         return connector.inherits && connector.structureId != this.servicesStore.structure.id;

--- a/admin/src/main/ts/app/shared/ux/components/form-field.component.ts
+++ b/admin/src/main/ts/app/shared/ux/components/form-field.component.ts
@@ -4,7 +4,13 @@ import { Component, Input } from '@angular/core'
     selector: 'form-field',
     template:`
         <div class="form-field">
-            <label>{{ label | translate }}</label>
+            <label>
+                {{ label | translate }}
+                <message-sticker *ngIf="help" 
+                            [type]="'info'" 
+                            [messages]="[help]">
+                </message-sticker>
+            </label>
             <ng-content></ng-content>
         </div>
     `,
@@ -12,8 +18,10 @@ import { Component, Input } from '@angular/core'
         div.form-field { display: flex; align-items: center; }
         div.form-field >>> > * { flex: 1; margin-left: 5px; }
         div.form-field > *:first-child { flex: 0 0 200px; margin-left: 0; }
+        div.form-field message-sticker { font-size: 1.3em; }
     `]
 })
 export class FormFieldComponent {
-    @Input() label: string
+    @Input() label: string;
+    @Input() help: string;
 }

--- a/admin/src/main/ts/app/shared/ux/components/index.ts
+++ b/admin/src/main/ts/app/shared/ux/components/index.ts
@@ -10,6 +10,7 @@ export { SimpleSelectComponent } from './value-editable/simple-select.component'
 export { MessageStickerComponent } from './message/message-sticker.component';
 export { MessageBoxComponent } from './message/message-box.component';
 export { GroupPickerComponent } from './group-picker.component';
+export { UploadFilesComponent } from './upload-files.component';
 
 // (Infra components historic)
 export { ItemTreeComponent } from './item-tree.component';

--- a/admin/src/main/ts/app/shared/ux/components/message/message-box.component.ts
+++ b/admin/src/main/ts/app/shared/ux/components/message/message-box.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, ChangeDetectorRef, ElementRef, EventEmitter, OnInit, OnDestroy } from '@angular/core'
+import { Component, Input, Output, ChangeDetectorRef, ElementRef, EventEmitter, OnInit } from '@angular/core'
 
 export type MessageType = 'info' | 'success' | 'warning' | 'danger';
 

--- a/admin/src/main/ts/app/shared/ux/components/message/message-sticker.component.ts
+++ b/admin/src/main/ts/app/shared/ux/components/message/message-sticker.component.ts
@@ -1,6 +1,5 @@
-import { Component, Input,ChangeDetectorRef, ViewChild, OnInit, EventEmitter } from '@angular/core'
+import { Component, Input, ViewChild, OnInit, EventEmitter } from '@angular/core'
 import { ComponentDescriptor, DynamicComponentDirective } from '../../directives'
-import { BundlesService } from 'sijil'
 import { MessageBoxComponent, MessageType, icons } from './message-box.component'
 
 @Component({
@@ -24,9 +23,6 @@ import { MessageBoxComponent, MessageType, icons } from './message-box.component
     `]
 })
 export class MessageStickerComponent implements OnInit {
-    constructor (
-        private cdRef:ChangeDetectorRef)  {}
-
     @Input() type: MessageType;
     @Input() header:string;
     @Input() messages:(string | [string,Object])[];

--- a/admin/src/main/ts/app/shared/ux/components/upload-files.component.spec.ts
+++ b/admin/src/main/ts/app/shared/ux/components/upload-files.component.spec.ts
@@ -1,0 +1,34 @@
+import { UploadFilesComponent } from './upload-files.component'
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { Directive, Input } from '@angular/core';
+import { SijilModule } from 'sijil';
+
+describe('UploadFilesComponent', () => {
+    let component: UploadFilesComponent;
+    let fixture: ComponentFixture<UploadFilesComponent>;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [UploadFilesComponent, MockDragAndDropFilesDirective],
+            providers: [],
+            imports: [SijilModule.forRoot()]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(UploadFilesComponent);
+        component = fixture.debugElement.componentInstance;
+    }));
+
+    it('should create a UploadFilesComponent', () => {
+        expect(component).toBeDefined();
+    });
+});
+
+@Directive({
+    selector: '[dragAndDropFiles]'
+})
+export class MockDragAndDropFilesDirective {
+    @Input()
+    allowedExtensions: Array<string> = [];
+    @Input()
+    maxFilesNumber: number = 1;
+}

--- a/admin/src/main/ts/app/shared/ux/components/upload-files.component.spec.ts
+++ b/admin/src/main/ts/app/shared/ux/components/upload-files.component.spec.ts
@@ -2,6 +2,7 @@ import { UploadFilesComponent } from './upload-files.component'
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import { Directive, Input } from '@angular/core';
 import { SijilModule } from 'sijil';
+import { InputFileService } from '../services/inputFile.service';
 
 describe('UploadFilesComponent', () => {
     let component: UploadFilesComponent;
@@ -10,7 +11,7 @@ describe('UploadFilesComponent', () => {
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             declarations: [UploadFilesComponent, MockDragAndDropFilesDirective],
-            providers: [],
+            providers: [InputFileService],
             imports: [SijilModule.forRoot()]
         }).compileComponents();
 

--- a/admin/src/main/ts/app/shared/ux/components/upload-files.component.ts
+++ b/admin/src/main/ts/app/shared/ux/components/upload-files.component.ts
@@ -119,15 +119,10 @@ export class UploadFilesComponent implements OnInit {
 
     public onChange($event): void {
         if ($event.target) {
-            let files: File[];
-            try {
-                files = this.inputFileService.validateFiles($event.target.files
-                    , this.maxFilesNumber
-                    , this.allowedExtensions);
-                this.upload.emit(files);
-            } catch(e) {
-                this.invalidUpload.emit(e);
-            }
+            this.inputFileService
+                .validateFiles($event.target.files, this.maxFilesNumber, this.allowedExtensions)
+                .subscribe(files => this.upload.emit(files)
+                    , error => this.invalidUpload.emit(error));
         }
     }
 

--- a/admin/src/main/ts/app/shared/ux/components/upload-files.component.ts
+++ b/admin/src/main/ts/app/shared/ux/components/upload-files.component.ts
@@ -1,0 +1,168 @@
+import { Component, Output, EventEmitter, Input, ViewChild, ElementRef, OnInit } from "@angular/core";
+import { Error } from "../../../core/services";
+
+@Component({
+    selector: 'upload-files',
+    template: `
+        <div class="upload-files-dropzone" 
+            dragAndDropFiles 
+            [allowedExtensions]="allowedExtensions" 
+            [maxFilesNumber]="maxFilesNumber"
+            (dragAndDrop)="onDragAndDrop($event)" 
+            (invalidDragAndDrop)="onInvalidDragAndDrop($event)">
+            <div *ngIf="fileSrc" class="upload-files-dropzone-image">
+                <img *ngIf="isFileImage(fileSrc) else isFileIcon" 
+                    src="{{ fileSrc }}" 
+                    class="upload-files-dropzone-image__image">
+                <ng-template #isFileIcon>
+                    <i class="upload-files-dropzone-image__icon {{ fileSrc }}"></i>
+                </ng-template>
+            </div>
+
+            <div class="upload-files-dropzone-input">
+                <button class="confirm upload-files-dropzone-input__button" 
+                    (click)="onClickDropzoneInput($event)">
+                    <s5l>ux.upload-files.button.label</s5l>
+                </button>
+                <i class="upload-files-dropzone-input__icon fa fa-cloud-upload fa-2x">
+                </i>
+                <span class="upload-files-dropzone-input__help">
+                    <s5l>ux.upload-files.button.help</s5l>
+                </span>
+                <input *ngIf="multiple === true else singleFileInput"
+                    class="upload-files-dropzone-input__input" 
+                    type="file" 
+                    (change)="onChange($event)"
+                    multiple
+                    #inputFileRef>
+                <ng-template #singleFileInput>
+                    <input class="upload-files-dropzone-input__input" 
+                        type="file" 
+                        (change)="onChange($event)"
+                        #inputFileRef>
+                </ng-template>
+            </div>
+        </div>
+    `,
+    styles: [`
+        .upload-files-dropzone {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 150px;
+            margin: 20px 20px;
+            padding: 20px 10px;
+            background-color: #fafafa;
+            border: 2px dashed #ddd;
+            border-radius: 5px;
+        }
+        .upload-files-dropzone-image {
+            
+        }
+        .upload-files-dropzone-image__image {
+            height: 130px;
+            width: 130px;
+            margin: 20px 20px;
+        }
+        .upload-files-dropzone-image__icon {
+            font-size: 7em;
+            margin: 20px 20px;
+        }
+        .upload-files-dropzone-input {
+            display: flex;
+            align-items: center;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 1px 1px 5px rgba(0,0,0,0.3);
+            padding: 10px;
+            margin: 0px 40px 0px 20px;
+        }
+        .upload-files-dropzone-input__input {
+            display: none;
+        }
+        .upload-files-dropzone-input__button {
+            
+        }
+        .upload-files-dropzone-input__icon {
+            margin-left: 10px;
+        }
+        .upload-files-dropzone-input__help {
+            margin-left: 10px;
+            font-style: italic;
+        }
+    `]
+})
+export class UploadFilesComponent implements OnInit {
+    @Input()
+    fileSrc: string;
+    @Input()
+    allowedExtensions: Array<string>;
+    @Input()
+    maxFilesNumber: number;
+    
+    @Output()
+    upload: EventEmitter<File[]> = new EventEmitter();
+    @Output()
+    invalidUpload: EventEmitter<Error> = new EventEmitter();
+
+    @ViewChild('inputFileRef')
+    inputFileRef: ElementRef;
+
+    public multiple: boolean;
+
+    public ngOnInit(): void {
+        this.multiple = this.maxFilesNumber > 1 ? true : false;
+    }
+
+    public onChange($event): void {
+        if ($event.target && $event.target.files) {
+            if ($event.target.files.length > this.maxFilesNumber) {
+                const error: Error = new Error();
+                error.message = `Only ${this.maxFilesNumber} file(s) allowed`;
+                console.error(error);
+                this.invalidUpload.emit(error);
+            } else {
+                let valid_files = [];
+                let invalid_files = [];
+                for (let i = 0; i < $event.target.files.length; i++) {
+                    let filenameSplit = $event.target.files[i].name.split('.');
+                    let ext = filenameSplit[filenameSplit.length - 1];
+                    if (this.allowedExtensions.lastIndexOf(ext) != -1) {
+                        valid_files.push($event.target.files[i]);
+                    } else {
+                        invalid_files.push($event.target.files[i]);
+                    }
+                }
+        
+                if (valid_files.length > 0) {
+                    this.upload.emit(valid_files);
+                }
+        
+                if (invalid_files.length > 0) {
+                    const error: Error = new Error();
+                    error.message = `Extension not allowed. Allowed extensions: ${this.allowedExtensions}`
+                    console.error(error);
+                    this.invalidUpload.emit(error);
+                }
+            }
+        }
+    }
+
+    public isFileImage(fileSrc: string): boolean {
+        return fileSrc.startsWith('/workspace') || fileSrc.startsWith("http");
+    }
+
+    public onClickDropzoneInput($event: Event): void {
+        $event.stopPropagation();
+        let inputFileElement = this.inputFileRef.nativeElement;
+        inputFileElement.click();
+    }
+
+    public onDragAndDrop($event: File[]): void {
+        this.upload.emit($event);
+    }
+
+    public onInvalidDragAndDrop($event: Error): void {
+        this.invalidUpload.emit($event);
+    }
+}

--- a/admin/src/main/ts/app/shared/ux/directives/drag-and-drop-files.directive.ts
+++ b/admin/src/main/ts/app/shared/ux/directives/drag-and-drop-files.directive.ts
@@ -1,0 +1,86 @@
+import { Directive, HostListener, HostBinding, Output, EventEmitter, Input } from "@angular/core";
+import { Error } from "../../../core/services";
+
+@Directive({
+    selector: '[dragAndDropFiles]'
+})
+export class DragAndDropFilesDirective {
+    @Input()
+    allowedExtensions: Array<string> = [];
+    @Input()
+    maxFilesNumber: number = 1;
+
+    @Output()
+    dragAndDrop: EventEmitter<File[]> = new EventEmitter();
+    @Output()
+    invalidDragAndDrop: EventEmitter<Error> = new EventEmitter();
+
+    @HostBinding('style.background') 
+    private backgroundColor = '#fafafa';
+    @HostBinding('style.border-color') 
+    private borderColor = '#ddd';
+
+    @HostListener('dragover', ['$event'])
+    public onDragOver(evt) {
+        evt.preventDefault();
+        evt.stopPropagation();
+        this.highlightColors();
+    }
+
+    @HostListener('dragleave', ['$event'])
+    public onDragLeave(evt) {
+        evt.preventDefault();
+        evt.stopPropagation();
+        this.resetColors();
+    }
+
+    @HostListener('drop', ['$event'])
+    public onDrop(event) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        let files = event.dataTransfer.files;
+        let validFiles : Array<File> = [];
+        let invalidFiles : Array<File> = [];
+        
+        if (files.length > this.maxFilesNumber) {
+            const error: Error = new Error();
+            error.message = `Only ${this.maxFilesNumber} file(s) allowed`;
+            console.error(error);
+            this.invalidDragAndDrop.emit(error);
+        } else {
+            for (let i = 0; i < files.length; i++) {
+                let filenameSplit = files[i].name.split('.');
+                let ext = filenameSplit[filenameSplit.length - 1];
+                if (this.allowedExtensions.lastIndexOf(ext) != -1) {
+                    validFiles.push(files[i]);
+                } else {
+                    invalidFiles.push(files[i]);
+                }
+            }
+    
+            if (validFiles.length > 0) {
+                this.dragAndDrop.emit(validFiles);
+            }
+    
+            if (invalidFiles.length > 0) {
+                const error: Error = new Error();
+                error.message = `Extension not allowed. Allowed extensions: ${this.allowedExtensions}`
+                console.error(error);
+                this.invalidDragAndDrop.emit(error);
+            }
+        }
+
+        this.resetColors();
+    }
+
+    private resetColors() {
+        this.backgroundColor = '#fafafa';
+        this.borderColor = '#ddd';
+    }
+
+    private highlightColors() {
+        this.backgroundColor = '#ffd1b6';
+        this.borderColor = '#ff8352';
+    }
+}

--- a/admin/src/main/ts/app/shared/ux/directives/drag-and-drop-files.directive.ts
+++ b/admin/src/main/ts/app/shared/ux/directives/drag-and-drop-files.directive.ts
@@ -43,15 +43,10 @@ export class DragAndDropFilesDirective {
         event.stopPropagation();
 
         if (event.dataTransfer) {
-            let files: File[];
-            try {
-                files = this.inputFileService.validateFiles(event.dataTransfer.files
-                    , this.maxFilesNumber
-                    , this.allowedExtensions);
-                this.dragAndDrop.emit(files);
-            } catch(e) {
-                this.invalidDragAndDrop.emit(e);
-            }
+            this.inputFileService
+                .validateFiles(event.dataTransfer.files, this.maxFilesNumber, this.allowedExtensions)
+                .subscribe(files => this.dragAndDrop.emit(files)
+                    , error => this.invalidDragAndDrop.emit(error));
         }
 
         this.resetColors();

--- a/admin/src/main/ts/app/shared/ux/directives/drag-and-drop-files.directive.ts
+++ b/admin/src/main/ts/app/shared/ux/directives/drag-and-drop-files.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, HostListener, HostBinding, Output, EventEmitter, Input } from "@angular/core";
-import { Error } from "../../../core/services";
+import { InputFileService } from "../services/inputFile.service";
 
 @Directive({
     selector: '[dragAndDropFiles]'
@@ -13,12 +13,15 @@ export class DragAndDropFilesDirective {
     @Output()
     dragAndDrop: EventEmitter<File[]> = new EventEmitter();
     @Output()
-    invalidDragAndDrop: EventEmitter<Error> = new EventEmitter();
+    invalidDragAndDrop: EventEmitter<string> = new EventEmitter();
 
     @HostBinding('style.background') 
     private backgroundColor = '#fafafa';
     @HostBinding('style.border-color') 
     private borderColor = '#ddd';
+
+    constructor(private inputFileService: InputFileService) {
+    }
 
     @HostListener('dragover', ['$event'])
     public onDragOver(evt) {
@@ -39,35 +42,15 @@ export class DragAndDropFilesDirective {
         event.preventDefault();
         event.stopPropagation();
 
-        let files = event.dataTransfer.files;
-        let validFiles : Array<File> = [];
-        let invalidFiles : Array<File> = [];
-        
-        if (files.length > this.maxFilesNumber) {
-            const error: Error = new Error();
-            error.message = `Only ${this.maxFilesNumber} file(s) allowed`;
-            console.error(error);
-            this.invalidDragAndDrop.emit(error);
-        } else {
-            for (let i = 0; i < files.length; i++) {
-                let filenameSplit = files[i].name.split('.');
-                let ext = filenameSplit[filenameSplit.length - 1];
-                if (this.allowedExtensions.lastIndexOf(ext) != -1) {
-                    validFiles.push(files[i]);
-                } else {
-                    invalidFiles.push(files[i]);
-                }
-            }
-    
-            if (validFiles.length > 0) {
-                this.dragAndDrop.emit(validFiles);
-            }
-    
-            if (invalidFiles.length > 0) {
-                const error: Error = new Error();
-                error.message = `Extension not allowed. Allowed extensions: ${this.allowedExtensions}`
-                console.error(error);
-                this.invalidDragAndDrop.emit(error);
+        if (event.dataTransfer) {
+            let files: File[];
+            try {
+                files = this.inputFileService.validateFiles(event.dataTransfer.files
+                    , this.maxFilesNumber
+                    , this.allowedExtensions);
+                this.dragAndDrop.emit(files);
+            } catch(e) {
+                this.invalidDragAndDrop.emit(e);
             }
         }
 

--- a/admin/src/main/ts/app/shared/ux/directives/index.ts
+++ b/admin/src/main/ts/app/shared/ux/directives/index.ts
@@ -1,4 +1,5 @@
-export { AnchorDirective } from './anchor.directive'
-export { DynamicTemplateDirective } from './dynamictemplate.directive'
-export { DynamicComponentDirective } from './dynamic-component/dynamic-component.directive'
-export { ComponentDescriptor } from './dynamic-component/component-descriptor.model'
+export { AnchorDirective } from './anchor.directive';
+export { DynamicTemplateDirective } from './dynamictemplate.directive';
+export { DynamicComponentDirective } from './dynamic-component/dynamic-component.directive';
+export { ComponentDescriptor } from './dynamic-component/component-descriptor.model';
+export { DragAndDropFilesDirective } from './drag-and-drop-files.directive';

--- a/admin/src/main/ts/app/shared/ux/services/index.ts
+++ b/admin/src/main/ts/app/shared/ux/services/index.ts
@@ -1,2 +1,3 @@
-export { DynamicModuleImportsService } from './dynamicModuleImports.service'
-export { LabelsService } from './labels.service'
+export { DynamicModuleImportsService } from './dynamicModuleImports.service';
+export { LabelsService } from './labels.service';
+export { InputFileService } from './inputFile.service';

--- a/admin/src/main/ts/app/shared/ux/services/inputFile.service.spec.ts
+++ b/admin/src/main/ts/app/shared/ux/services/inputFile.service.spec.ts
@@ -1,0 +1,117 @@
+import { InputFileService } from './inputFile.service'
+import { TestBed } from "@angular/core/testing";
+
+describe('InputFileService', () => {
+    let inputFileService: InputFileService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [InputFileService]
+        });
+        inputFileService = TestBed.get(InputFileService);
+    });
+
+    describe('validateFiles', () => {
+        it('should return [file] when given FileList file1.jpg, maxFilesNumber 1 and allowedExtensions jpg)', () => {
+            const blob = new Blob([""], { type: "text/html" });
+            blob["name"] = "file1.jpg";
+            const file = <File>blob;
+            const fileList = {
+              0: file,
+              length: 1,
+              item: (index: number) => file
+            };
+
+            const files = inputFileService.validateFiles(fileList, 1, ['jpg']);
+            expect(files).toEqual([file]);
+        });
+
+        it('should return [file1, file2, file3] when given FileList file1.bmp, file2.jpg, file3.png, maxFilesNumber 3 and allowedExtensions jpg, png, bmp)', () => {
+            const blob1 = new Blob([""], { type: "text/html" });
+            blob1["name"] = "file1.bmp";
+            const file1 = <File>blob1;
+
+            const blob2 = new Blob([""], { type: "text/html" });
+            blob2["name"] = "file2.jpg";
+            const file2 = <File>blob2;
+
+            const blob3 = new Blob([""], { type: "text/html" });
+            blob3["name"] = "file3.png";
+            const file3 = <File>blob3;
+
+            const fileList = {
+              0: file1,
+              1: file2,
+              2: file3,
+              length: 3,
+              item: (index: number) => file1
+            };
+
+            const files = inputFileService.validateFiles(fileList, 3, ['jpg', 'png', 'bmp']);
+            expect(files).toEqual([file1, file2, file3]);
+        });
+
+        it('should throw "Only 1 file(s) allowed" error when given FileList file1.bmp, file2.jpg, maxFilesNumber 1 and allowedExtensions bmp, jpg, png)', () => {
+            const blob1 = new Blob([""], { type: "text/html" });
+            blob1["name"] = "file1.bmp";
+            const file1 = <File>blob1;
+
+            const blob2 = new Blob([""], { type: "text/html" });
+            blob2["name"] = "file2.jpg";
+            const file2 = <File>blob2;
+
+            const fileList = {
+              0: file1,
+              1: file2,
+              length: 2,
+              item: (index: number) => file1
+            };
+
+            const maxFilesNumber = 1;
+
+            try {
+                inputFileService.validateFiles(fileList, maxFilesNumber, ['jpg', 'png', 'bmp']);
+            } catch (e) {
+                expect(e).toBe(`Only ${maxFilesNumber} file(s) allowed`);
+            }
+        });
+
+        it('should throw "Extension not allowed. Allowed extensions: [jpg]" error when given FileList file1.bmp, maxFilesNumber 1 and allowedExtensions jpg)', () => {
+            const blob1 = new Blob([""], { type: "text/html" });
+            blob1["name"] = "file1.bmp";
+            const file1 = <File>blob1;
+
+            const fileList = {
+              0: file1,
+              length: 1,
+              item: (index: number) => file1
+            };
+
+            const allowedExtensions = ['jpg'];
+
+            try {
+                inputFileService.validateFiles(fileList, 1, allowedExtensions);
+            } catch (e) {
+                expect(e).toBe(`Extension not allowed. Allowed extensions: ${allowedExtensions}`);
+            }
+        });
+    });
+
+    describe('isIconImage', () => {
+        it('should return true with src equals to /workspace/image1', () => {
+            expect(inputFileService.isSrcUrl('/workspace/image1')).toBe(true);
+        });
+    
+        it('should return true with src equals to http://image.com/image1', () => {
+            expect(inputFileService.isSrcUrl('http://image.com/image1')).toBe(true);
+        });
+
+        it('should return true with src equals to https://securedimage.com/image1', () => {
+            expect(inputFileService.isSrcUrl('https://securedimage.com/image1')).toBe(true);
+        });
+    
+        it('should return false with src equals to admin-large', () => {
+            expect(inputFileService.isSrcUrl('admin-large')).toBe(false);
+        });
+    });
+});

--- a/admin/src/main/ts/app/shared/ux/services/inputFile.service.spec.ts
+++ b/admin/src/main/ts/app/shared/ux/services/inputFile.service.spec.ts
@@ -22,8 +22,9 @@ describe('InputFileService', () => {
               item: (index: number) => file
             };
 
-            const files = inputFileService.validateFiles(fileList, 1, ['jpg']);
-            expect(files).toEqual([file]);
+            inputFileService
+                .validateFiles(fileList, 1, ['jpg'])
+                .subscribe(files => expect(files).toEqual([file]))
         });
 
         it('should return [file1, file2, file3] when given FileList file1.bmp, file2.jpg, file3.png, maxFilesNumber 3 and allowedExtensions jpg, png, bmp)', () => {
@@ -47,8 +48,9 @@ describe('InputFileService', () => {
               item: (index: number) => file1
             };
 
-            const files = inputFileService.validateFiles(fileList, 3, ['jpg', 'png', 'bmp']);
-            expect(files).toEqual([file1, file2, file3]);
+            inputFileService
+                .validateFiles(fileList, 3, ['jpg', 'png', 'bmp'])
+                .subscribe(files => expect(files).toEqual([file1, file2, file3]));
         });
 
         it('should throw "Only 1 file(s) allowed" error when given FileList file1.bmp, file2.jpg, maxFilesNumber 1 and allowedExtensions bmp, jpg, png)', () => {
@@ -69,11 +71,10 @@ describe('InputFileService', () => {
 
             const maxFilesNumber = 1;
 
-            try {
-                inputFileService.validateFiles(fileList, maxFilesNumber, ['jpg', 'png', 'bmp']);
-            } catch (e) {
-                expect(e).toBe(`Only ${maxFilesNumber} file(s) allowed`);
-            }
+            inputFileService
+                .validateFiles(fileList, maxFilesNumber, ['jpg', 'png', 'bmp'])
+                .subscribe(files => {}
+                    , error => expect(error).toBe(`Only ${maxFilesNumber} file(s) allowed`));
         });
 
         it('should throw "Extension not allowed. Allowed extensions: [jpg]" error when given FileList file1.bmp, maxFilesNumber 1 and allowedExtensions jpg)', () => {
@@ -89,11 +90,10 @@ describe('InputFileService', () => {
 
             const allowedExtensions = ['jpg'];
 
-            try {
-                inputFileService.validateFiles(fileList, 1, allowedExtensions);
-            } catch (e) {
-                expect(e).toBe(`Extension not allowed. Allowed extensions: ${allowedExtensions}`);
-            }
+            inputFileService
+                .validateFiles(fileList, 1, allowedExtensions)
+                .subscribe(files => {}
+                    , error => expect(error).toBe(`Extension not allowed. Allowed extensions: ${allowedExtensions}`));
         });
     });
 

--- a/admin/src/main/ts/app/shared/ux/services/inputFile.service.ts
+++ b/admin/src/main/ts/app/shared/ux/services/inputFile.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from "@angular/core";
+
+@Injectable()
+export class InputFileService {
+    public validateFiles(files: FileList, maxFilesNumber: number, allowedExtensions: string[]): File[] {
+        if (!files) {
+            throw 'files is empty';
+        } 
+        
+        if (files.length > maxFilesNumber) {
+            throw `Only ${maxFilesNumber} file(s) allowed`;
+        } else {
+            let validFiles: File[] = [];
+            let invalidFiles: File[] = [];
+            for (let i = 0; i < files.length; i++) {
+                let filenameSplit = files[i].name.split('.');
+                let ext = filenameSplit[filenameSplit.length - 1];
+                if (allowedExtensions.lastIndexOf(ext) != -1) {
+                    validFiles.push(files[i]);
+                } else {
+                    invalidFiles.push(files[i]);
+                }
+            }
+    
+            if (validFiles.length > 0) {
+                return validFiles;
+            }
+    
+            if (invalidFiles.length > 0) {
+                throw `Extension not allowed. Allowed extensions: ${allowedExtensions}`;
+            }
+        }
+    }
+
+    public isSrcUrl(src: string): boolean {
+        return src.startsWith('/workspace') 
+            || src.startsWith("http://") 
+            || src.startsWith("https://");
+    }
+}

--- a/admin/src/main/ts/app/shared/ux/services/inputFile.service.ts
+++ b/admin/src/main/ts/app/shared/ux/services/inputFile.service.ts
@@ -1,35 +1,37 @@
 import { Injectable } from "@angular/core";
+import { Observable } from "rxjs";
 
 @Injectable()
 export class InputFileService {
-    public validateFiles(files: FileList, maxFilesNumber: number, allowedExtensions: string[]): File[] {
+    public validateFiles(files: FileList, maxFilesNumber: number, allowedExtensions: string[]): Observable<File[]> {
         if (!files) {
-            throw 'files is empty';
-        } 
-        
+            return Observable.throw('files is empty');
+        }
         if (files.length > maxFilesNumber) {
-            throw `Only ${maxFilesNumber} file(s) allowed`;
-        } else {
-            let validFiles: File[] = [];
-            let invalidFiles: File[] = [];
-            for (let i = 0; i < files.length; i++) {
-                let filenameSplit = files[i].name.split('.');
-                let ext = filenameSplit[filenameSplit.length - 1];
-                if (allowedExtensions.lastIndexOf(ext) != -1) {
-                    validFiles.push(files[i]);
-                } else {
-                    invalidFiles.push(files[i]);
-                }
-            }
-    
-            if (validFiles.length > 0) {
-                return validFiles;
-            }
-    
-            if (invalidFiles.length > 0) {
-                throw `Extension not allowed. Allowed extensions: ${allowedExtensions}`;
+            return Observable.throw(`Only ${maxFilesNumber} file(s) allowed`);
+        }
+
+        let validFiles: File[] = [];
+        let invalidFiles: File[] = [];
+        for (let i = 0; i < files.length; i++) {
+            let filenameSplit = files[i].name.split('.');
+            let ext = filenameSplit[filenameSplit.length - 1];
+            if (allowedExtensions.lastIndexOf(ext) != -1) {
+                validFiles.push(files[i]);
+            } else {
+                invalidFiles.push(files[i]);
             }
         }
+
+        return Observable.create(observer => {
+            if (validFiles.length > 0) {
+                observer.next(validFiles);
+            }
+            if (invalidFiles.length > 0) {
+                observer.error(`Extension not allowed. Allowed extensions: ${allowedExtensions}`);
+            }
+            observer.complete();
+        });
     }
 
     public isSrcUrl(src: string): boolean {

--- a/admin/src/main/ts/app/shared/ux/ux.module.ts
+++ b/admin/src/main/ts/app/shared/ux/ux.module.ts
@@ -26,10 +26,9 @@ import { DatepickerComponent,
     SimpleSelectComponent,
     MessageStickerComponent,
     MessageBoxComponent,
-    GroupPickerComponent } from './components'
-import { AnchorDirective, 
-    DynamicTemplateDirective,
-    DynamicComponentDirective } from './directives'
+    GroupPickerComponent,
+    UploadFilesComponent } from './components'
+import { AnchorDirective, DynamicTemplateDirective, DynamicComponentDirective, DragAndDropFilesDirective } from './directives'
 import { FilterPipe, OrderPipe, StorePipe, LimitPipe, FlattenObjectArrayPipe, LocalizedDatePipe, BytesPipe } from './pipes'
 import { DynamicModuleImportsService, LabelsService } from './services';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
@@ -66,10 +65,12 @@ import { InfiniteScrollModule } from 'ngx-infinite-scroll';
         MessageStickerComponent,
         MessageBoxComponent,
         GroupPickerComponent,
+        UploadFilesComponent,
         // directives
         AnchorDirective,
         DynamicTemplateDirective,
         DynamicComponentDirective,
+        DragAndDropFilesDirective,
         // pipes
         FilterPipe,
         FlattenObjectArrayPipe,
@@ -103,10 +104,12 @@ import { InfiniteScrollModule } from 'ngx-infinite-scroll';
         MessageStickerComponent,
         MessageBoxComponent,
         GroupPickerComponent,
+        UploadFilesComponent,
         // directives
         AnchorDirective,
         DynamicTemplateDirective,
         DynamicComponentDirective,
+        DragAndDropFilesDirective,
         // pipes
         FilterPipe,
         FlattenObjectArrayPipe,

--- a/admin/src/main/ts/app/shared/ux/ux.module.ts
+++ b/admin/src/main/ts/app/shared/ux/ux.module.ts
@@ -30,7 +30,7 @@ import { DatepickerComponent,
     UploadFilesComponent } from './components'
 import { AnchorDirective, DynamicTemplateDirective, DynamicComponentDirective, DragAndDropFilesDirective } from './directives'
 import { FilterPipe, OrderPipe, StorePipe, LimitPipe, FlattenObjectArrayPipe, LocalizedDatePipe, BytesPipe } from './pipes'
-import { DynamicModuleImportsService, LabelsService } from './services';
+import { DynamicModuleImportsService, LabelsService, InputFileService } from './services';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 
 @NgModule({
@@ -128,7 +128,8 @@ export class UxModule {
             ngModule: UxModule,
             providers: [
                 DynamicModuleImportsService,
-                labelsProvider || LabelsService
+                labelsProvider || LabelsService,
+                InputFileService
             ]
         };
     }


### PR DESCRIPTION
feat(adminv2): #CAV2-431, import image for connector icon

Creation of an upload-files component and a drag'n'drop directive to allow user to pick or drag'n'drop files in the connector icon section.
Connector icon can also be a css selector.