### PR TITLE
[ODE] sort groups by structure in communication rules view

### DIFF
--- a/admin/src/main/ts/app/core/services/routing.service.ts
+++ b/admin/src/main/ts/app/core/services/routing.service.ts
@@ -1,24 +1,24 @@
-import { ActivatedRoute, ActivatedRouteSnapshot, Data, Params } from '@angular/router'
-import { Observable } from 'rxjs/Observable'
-import 'rxjs/add/observable/merge'
+import { ActivatedRoute, ActivatedRouteSnapshot, Data, Params } from '@angular/router';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/merge';
 
 export let routing = {
-    get: function(item: String, field: "params" | "data" , route: ActivatedRouteSnapshot) : any {
-        if(route[field][<any> item]) {
-            return route[field][<any> item]
+    get: function (item: String, field: "params" | "data", route: ActivatedRouteSnapshot): any {
+        if (route[field][<any>item]) {
+            return route[field][<any>item]
         }
 
         return route.parent ? this.get(item, field, route.parent) : undefined
     },
-    getData: function(route: ActivatedRouteSnapshot, item: String) : any {
+    getData: function (route: ActivatedRouteSnapshot, item: string): any {
         return this.get(item, "data", route)
     },
-    getParam: function(route: ActivatedRouteSnapshot, item: String) : String {
+    getParam: function (route: ActivatedRouteSnapshot, item: string): string {
         return this.get(item, "params", route)
     },
-    observe: function(route: ActivatedRoute, to: "params" | "data") : Observable<Params> | Observable<Data> {
-        let observables:  (Observable<Params> | Observable<Data>)[] = route.pathFromRoot.map(route => route[to])
+    observe: function (route: ActivatedRoute, to: "params" | "data"): Observable<Params> | Observable<Data> {
+        let observables: (Observable<Params> | Observable<Data>)[] = route.pathFromRoot.map(route => route[to])
 
         return Observable.merge(...observables)
     }
-}
+};

--- a/admin/src/main/ts/app/groups/groups.resolver.ts
+++ b/admin/src/main/ts/app/groups/groups.resolver.ts
@@ -1,28 +1,29 @@
-import { Injectable } from '@angular/core'
-import { Resolve, ActivatedRouteSnapshot } from '@angular/router'
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 
-import { globalStore, GroupCollection } from '../core/store'
-import { GroupModel } from '../core/store/models'
-import { SpinnerService, routing } from '../core/services'
+import { globalStore } from '../core/store';
+import { GroupModel } from '../core/store/models';
+import { routing, SpinnerService } from '../core/services';
 
 @Injectable()
 export class GroupsResolver implements Resolve<GroupModel[]> {
 
-    constructor(private spinner: SpinnerService) { }
+    constructor(private spinner: SpinnerService) {
+    }
 
     resolve(route: ActivatedRouteSnapshot): Promise<GroupModel[]> {
         let currentStructure = globalStore.structures.data.find(
-            s => s.id === routing.getParam(route, 'structureId'))
+            s => s.id === routing.getParam(route, 'structureId')
+        );
         if (currentStructure.groups.data.length > 0) {
             return Promise.resolve(currentStructure.groups.data)
         } else {
             return this.spinner.perform('portal-content', currentStructure.groups.sync()
                 .then(() => {
-                    return currentStructure.groups.data
+                    return currentStructure.groups.data;
                 }).catch(e => {
-                    console.error(e)
-                }))
+                    console.error(e);
+                }));
         }
     }
-
 }

--- a/admin/src/main/ts/app/shared/utils/testing.ts
+++ b/admin/src/main/ts/app/shared/utils/testing.ts
@@ -12,7 +12,7 @@ export function generateGroup(name: string,
                               internalCommunicationRule: InternalCommunicationRule = 'BOTH',
                               type: string = null, subType: string = null,
                               classes: { id: string, name: string }[] = null,
-                              structures: { id: string, name: string }[] = null,
+                              structures: { id: string, name: string }[] = [{id: 'structureId', name: 'structureName'}],
                               filter: string = null): GroupModel {
     return {name, id: name, internalCommunicationRule, type, subType, classes, structures, filter} as GroupModel;
 }

--- a/admin/src/main/ts/app/users/communication/communication-rules.component.ts
+++ b/admin/src/main/ts/app/users/communication/communication-rules.component.ts
@@ -1,16 +1,16 @@
 import { ChangeDetectorRef, Component, Input } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { BundlesService } from 'sijil';
 import { GroupModel } from '../../core/store/models';
 import { CommunicationRulesService } from './communication-rules.service';
 import { GroupNameService, NotifyService } from '../../core/services';
 import { Subject } from 'rxjs/Subject';
-import { BundlesService } from 'sijil';
+import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/first';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/mergeMap';
-import { HttpErrorResponse } from '@angular/common/http';
-import { Observable } from 'rxjs/Observable';
 
 const css = {
     group: 'lct-user-communication-group',
@@ -44,6 +44,8 @@ const WARNING_BOTH_GROUPS_USERS_CAN_COMMUNICATE = "both-groups-users-can-communi
                     (mouseenter)="highlight('sending', group, selected)"
                     (mouseleave)="resetHighlight()"
                     [group]="group"
+                    [manageable]="isGroupInAManageableStructure(group, manageableStructuresId)"
+                    [communicationRuleManageable]="isCommunicationRuleManageable(group, selected, manageableStructuresId)"
                     [selectable]="activeColumn === 'sending'"
                     [selected]="isSelected('sending', group, selected)"
                     [highlighted]="isRelatedWithCell('sending', group, highlighted, communicationRules)"
@@ -59,6 +61,8 @@ const WARNING_BOTH_GROUPS_USERS_CAN_COMMUNICATE = "both-groups-users-can-communi
                     (mouseenter)="highlight('receiving', group, selected)"
                     (mouseleave)="resetHighlight()"
                     [group]="group"
+                    [manageable]="isGroupInAManageableStructure(group, manageableStructuresId)"
+                    [communicationRuleManageable]="isCommunicationRuleManageable(group, selected, manageableStructuresId)"
                     [selectable]="activeColumn === 'receiving'"
                     [selected]="isSelected('receiving', group, selected)"
                     [highlighted]="isRelatedWithCell('receiving', group, highlighted, communicationRules)"
@@ -151,6 +155,12 @@ export class CommunicationRulesComponent {
     @Input()
     public activeColumn: Column;
 
+    @Input()
+    public activeStructureId: string;
+
+    @Input()
+    public manageableStructuresId: string[];
+
     public selected: Cell;
     public highlighted: Cell;
 
@@ -190,13 +200,13 @@ export class CommunicationRulesComponent {
         const senders = this.communicationRules
             .map(rule => rule.sender)
             .filter(group => !!group);
-        return uniqueGroups(senders);
+        return sortGroups(uniqueGroups(senders), (g) => this.groupNameService.getGroupName(g), this.activeStructureId);
     }
 
     public getReceivers(): GroupModel[] {
         const receivers: GroupModel[] = [];
         this.communicationRules.forEach(rule => receivers.push(...rule.receivers));
-        return uniqueGroups(receivers);
+        return sortGroups(uniqueGroups(receivers), (g) => this.groupNameService.getGroupName(g), this.activeStructureId);
     }
 
     public trackByGroupId(index: number, group: GroupModel): string {
@@ -264,6 +274,19 @@ export class CommunicationRulesComponent {
         return true;
     };
 
+    public isGroupInAManageableStructure(g: GroupModel, structuresId: string[]): boolean {
+        return structuresId.indexOf(getStructureIdOfGroup(g)) > -1;
+    }
+
+    public isCommunicationRuleManageable(group: GroupModel, cell: Cell, structuresId: string[]): boolean {
+        if (!group || !cell) {
+            return false;
+        }
+
+        return this.isGroupInAManageableStructure(group, structuresId)
+            && this.isGroupInAManageableStructure(cell.group, structuresId);
+    }
+
     public onGroupPick(pickedGroup: GroupModel) {
         const sender: GroupModel = this.activeColumn === 'sending' ? this.selected.group : pickedGroup;
         const receiver: GroupModel = this.activeColumn === 'sending' ? pickedGroup : this.selected.group;
@@ -323,6 +346,47 @@ export function uniqueGroups(groups: GroupModel[]): GroupModel[] {
         }
     });
     return uniqGroups;
+}
+
+export function sortGroups(groups: GroupModel[], getGroupNameFn: (GroupModel) => string, activeStructureId: string): GroupModel[] {
+    const alphabeticallySortedGroups = groups.sort((a, b) => getGroupNameFn(a).localeCompare(getGroupNameFn(b)));
+
+    const countByStructure = alphabeticallySortedGroups
+        .map(g => g.structures[0].id)
+        .reduce((previousCounter, structureId) => {
+            const counter = Object.assign({}, previousCounter);
+            counter[structureId] = counter[structureId] ? counter[structureId] + 1 : 1;
+            return counter;
+        }, {});
+
+    alphabeticallySortedGroups.sort((a, b) => {
+        const structureOfA = getStructureIdOfGroup(a);
+        const structureOfB = getStructureIdOfGroup(b);
+        if (structureOfA === structureOfB) {
+            return 0;
+        }
+
+        if (structureOfA === activeStructureId) {
+            return -1;
+        }
+
+        if (structureOfB === activeStructureId) {
+            return 1;
+        }
+
+        return countByStructure[structureOfB] - countByStructure[structureOfA];
+    });
+
+
+    return alphabeticallySortedGroups;
+}
+
+export function getStructureOfGroup(group: GroupModel): { id: string, name: string } {
+    return group.structures[0];
+}
+
+export function getStructureIdOfGroup(group: GroupModel): string {
+    return getStructureOfGroup(group).id;
 }
 
 export type Column = 'sending' | 'receiving';

--- a/admin/src/main/ts/app/users/communication/group-card.component.spec.ts
+++ b/admin/src/main/ts/app/users/communication/group-card.component.spec.ts
@@ -45,6 +45,8 @@ describe('GroupCardComponent', () => {
         component.group = generateGroup('Elèves du Lycée Paul Martin');
         (groupNameService.getGroupName as jasmine.Spy).and.returnValue('Elèves du Lycée Paul Martin');
         component.active = true;
+        component.manageable = true;
+        component.communicationRuleManageable = true;
         fixture.detectChanges();
     }));
 
@@ -95,7 +97,7 @@ describe('GroupCardComponent', () => {
 });
 
 function getTitle(fixture: ComponentFixture<GroupCardComponent>): DebugElement {
-    return fixture.debugElement.query(By.css(locators.title));
+    return fixture.debugElement.query(By.css(locators.label));
 }
 
 function getInternalCommunicationSwitch(fixture: ComponentFixture<GroupCardComponent>): DebugElement {

--- a/admin/src/main/ts/app/users/communication/group-card.component.ts
+++ b/admin/src/main/ts/app/users/communication/group-card.component.ts
@@ -1,9 +1,10 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { ActivatedRoute } from '@angular/router';
 import { GroupModel } from '../../core/store/models';
 import { CommunicationRulesService } from './communication-rules.service';
-import { ActivatedRoute } from '@angular/router';
-import { NotifyService, SpinnerService, GroupNameService } from '../../core/services';
-import { HttpErrorResponse } from '@angular/common/http';
+import { GroupNameService, NotifyService, SpinnerService } from '../../core/services';
+import { getStructureOfGroup } from './communication-rules.component';
 import { Subject } from 'rxjs/Subject';
 import 'rxjs/add/operator/first';
 import 'rxjs/add/operator/do';
@@ -11,14 +12,20 @@ import 'rxjs/add/operator/mergeMap';
 
 const css = {
     title: 'lct-group-card-title',
+    subtitle: 'lct-group-card-subtitle',
+    label: 'lct-group-card-label',
+    structure: 'lct-group-card-structure',
     viewMembersButton: 'lct-group-card-view-members-button',
-    addCommunicationButton: 'lct-group-card-add-communicaiton-button',
-    removeCommunicationButton: 'lct-group-card-remove-communicaiton-button',
+    addCommunicationButton: 'lct-group-card-add-communication-button',
+    removeCommunicationButton: 'lct-group-card-remove-communication-button',
     internalCommunicationSwitch: 'lct-group-card-internal-communication-switch'
 };
 
 export const groupCardLocators = {
     title: `.${css.title}`,
+    subtitle: `.${css.subtitle}`,
+    label: `.${css.label}`,
+    structure: `.${css.structure}`,
     viewMembersButton: `.${css.viewMembersButton}`,
     addCommunicationButton: `.${css.addCommunicationButton}`,
     removeCommunicationButton: `.${css.removeCommunicationButton}`,
@@ -29,10 +36,15 @@ export const groupCardLocators = {
     selector: 'group-card',
     template: `
         <div class="group-card"
-        [ngClass]="{'group-card--active': active, 'group-card--selected': selected, 'group-card--highlighted': highlighted, 'group-card--selectable': selectable}">
+        [ngClass]="{'group-card--active': active,'group-card--selected': selected,
+                    'group-card--highlighted': highlighted, 'group-card--selectable': selectable,
+                    'group-card--manageable': manageable, 'group-card--communication-rule-manageable': communicationRuleManageable}">
             <div class="group-card__title ${css.title}">
-                <span class="group-card__title-label">{{groupNameService.getGroupName(group)}}</span>
+                <span class="group-card__title-label ${css.label}">{{groupNameService.getGroupName(group)}}</span>
                 <i *ngIf="groupTypeRouteMapping.has(group.type)" (click)="viewMembers(group)" class="group-card__title-icon ${css.viewMembersButton} fa fa-users" [title]="'group.card.view-members-button' | translate"></i>
+            </div>
+            <div class="group-card__subtitle ${css.subtitle}">
+                <span class="group-card__title-structure ${css.structure}">{{getStructureNameOfGroup(group)}}</span>
             </div>
             <div class="group-card__actions">
                 <button
@@ -51,19 +63,23 @@ export const groupCardLocators = {
                       *ngIf="group.internalCommunicationRule === 'BOTH'; else cannotCommunicateTogether;">
                 <s5l class="group-card__switch-label">group.details.members.can.communicate</s5l>
                 <i class="${css.internalCommunicationSwitch} group-card__switch group-card__switch--clickable fa fa-toggle-on"
-                   *ngIf="active"
+                   *ngIf="active && manageable"
                    (click)="toggleInternalCommunicationRule(); $event.stopPropagation();"></i>
                 <i class="${css.internalCommunicationSwitch} group-card__switch fa fa-toggle-on"
-                   *ngIf="!active"></i>
+                   *ngIf="!active && manageable"></i>
+                <i class="${css.internalCommunicationSwitch} group-card__switch fa fa-lock"
+                   *ngIf="!manageable"></i>
             </span>
             <ng-template #cannotCommunicateTogether>
                 <span class="group-card__actions-on-self group-card__actions-on-self--cannot-communicate">
                     <s5l class="group-card__switch-label">group.details.members.cannot.communicate</s5l>
                     <i class="${css.internalCommunicationSwitch} group-card__switch group-card__switch--clickable fa fa-toggle-off"
-                       *ngIf="active"
+                       *ngIf="active && manageable"
                        (click)="toggleInternalCommunicationRule(); $event.stopPropagation();"></i>
                     <i class="${css.internalCommunicationSwitch} group-card__switch fa fa-toggle-off"
-                       *ngIf="!active"></i>
+                       *ngIf="!active && manageable"></i>
+                <i class="${css.internalCommunicationSwitch} group-card__switch fa fa-lock"
+                   *ngIf="!manageable"></i>
                 </span>
             </ng-template>
         </div>
@@ -123,13 +139,18 @@ export const groupCardLocators = {
             display: flex;
             align-items: center;
         }
-
-        .group-card--active .group-card__title {
+    `, `
+        .group-card--active .group-card__subtitle {
             margin-bottom: 15px;
         }
     `, `
         .group-card__title-label {
             flex-grow: 1;
+        }
+    `, `
+        .group-card__title-structure {
+            font-size: 12px;
+            font-style: italic;
         }
     `, `
         .group-card__title-icon {
@@ -138,7 +159,7 @@ export const groupCardLocators = {
             transition: color 125ms ease;
         }
 
-        .group-card--active .group-card__title-icon {
+        .group-card--active.group-card--manageable .group-card__title-icon {
             display: initial;
         }
 
@@ -150,7 +171,8 @@ export const groupCardLocators = {
             display: none;
         }
 
-        .group-card--active .group-card__actions {
+        .group-card--active.group-card--communication-rule-manageable .group-card__actions,
+        .group-card--selected.group-card--manageable .group-card__actions {
             display: initial;
         }
     `, `
@@ -228,18 +250,25 @@ export class GroupCardComponent {
     @Input()
     highlighted: boolean = false;
 
-    confirmationDisplayed = false;
-    confirmationClicked: Subject<'confirm' | 'cancel'> = new Subject<'confirm' | 'cancel'>();
+    @Input()
+    manageable: boolean = false;
+
+    @Input()
+    communicationRuleManageable: boolean = false;
+
     @Output()
     clickAddCommunication: EventEmitter<GroupModel> = new EventEmitter<GroupModel>();
+
+    @Output()
+    clickOnRemoveCommunication: EventEmitter<void> = new EventEmitter<void>();
+
+    confirmationDisplayed = false;
+    confirmationClicked: Subject<'confirm' | 'cancel'> = new Subject<'confirm' | 'cancel'>();
 
     groupTypeRouteMapping: Map<string, string> = new Map<string, string>()
         .set('ManualGroup', 'manual')
         .set('ProfileGroup', 'profile')
         .set('FunctionalGroup', 'functional');
-
-    @Output()
-    clickOnRemoveCommunication: EventEmitter<void> = new EventEmitter<void>();
 
 
     constructor(
@@ -275,5 +304,9 @@ export class GroupCardComponent {
 
     public viewMembers(group: GroupModel) {
         window.open(`/admin/${group.structures[0].id}/groups/${this.groupTypeRouteMapping.get(group.type)}/${group.id}`, '_blank');
+    }
+
+    getStructureNameOfGroup(group: GroupModel): string {
+        return getStructureOfGroup(group).name;
     }
 }

--- a/admin/src/main/ts/app/users/communication/smart-user-communication.component.ts
+++ b/admin/src/main/ts/app/users/communication/smart-user-communication.component.ts
@@ -1,18 +1,21 @@
 import { ActivatedRoute, Data, Router } from '@angular/router';
 import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
-import { UserModel, GroupModel } from '../../core/store/models';
-import { Subscription } from 'rxjs/Subscription';
-import { SpinnerService } from '../../core/services';
+import { GroupModel, UserModel } from '../../core/store/models';
+import { routing, SpinnerService } from '../../core/services';
 import { CommunicationRulesService } from './communication-rules.service';
 import { CommunicationRule } from './communication-rules.component';
-import { UsersStore } from '../users.store'
+import { UsersStore } from '../users.store';
+import { GlobalStore } from '../../core/store';
+import { Subscription } from 'rxjs/Subscription';
 
 @Component({
     selector: 'smart-user-communication',
     providers: [CommunicationRulesService],
     template: `
-        <user-communication *ngIf="user && userSendingCommunicationRules" 
+        <user-communication *ngIf="user && userSendingCommunicationRules"
                             [user]="user"
+                            [activeStructureId]="activeStructureId"
+                            [manageableStructuresId]="manageableStructuresId"
                             [userSendingCommunicationRules]="userSendingCommunicationRules"
                             [userReceivingCommunicationRules]="userReceivingCommunicationRules"
                             [addCommunicationPickableGroups]="addCommunicationPickableGroups"
@@ -22,6 +25,8 @@ import { UsersStore } from '../users.store'
 export class SmartUserCommunicationComponent implements OnInit, OnDestroy {
 
     public user: UserModel;
+    public activeStructureId: string;
+    public manageableStructuresId: string[];
     public userSendingCommunicationRules: CommunicationRule[];
     public userReceivingCommunicationRules: CommunicationRule[];
     public addCommunicationPickableGroups: GroupModel[];
@@ -35,7 +40,8 @@ export class SmartUserCommunicationComponent implements OnInit, OnDestroy {
         private route: ActivatedRoute,
         private router: Router,
         private changeDetector: ChangeDetectorRef,
-        private usersStore: UsersStore
+        private usersStore: UsersStore,
+        private globalStore: GlobalStore
     ) {
     }
 
@@ -47,9 +53,11 @@ export class SmartUserCommunicationComponent implements OnInit, OnDestroy {
         });
         this.routeSubscription = this.route.data.subscribe((data: Data) => {
             this.user = data['user'];
+            this.manageableStructuresId = this.globalStore.structures.data.map(s => s.id);
             this.communicationRulesService.setGroups(data['groups']);
         });
         this.addCommunicationPickableGroups = this.usersStore.structure.groups.data;
+        this.activeStructureId = routing.getParam(this.route.snapshot, 'structureId');
     }
 
     public openUserDetails() {

--- a/admin/src/main/ts/app/users/communication/user-communication.component.spec.ts
+++ b/admin/src/main/ts/app/users/communication/user-communication.component.spec.ts
@@ -51,6 +51,8 @@ describe('UserCommunicationComponent', () => {
         component.user = axellePotier.user;
         component.userSendingCommunicationRules = axellePotier.communicationRules;
         component.addCommunicationPickableGroups = [generateGroup('group1')];
+        component.activeStructureId = 'activeStructure';
+        component.manageableStructuresId = ['activeStructure'];
         fixture.detectChanges();
     }));
 
@@ -110,6 +112,12 @@ function getBackButton(fixture: ComponentFixture<UserCommunicationComponent>): D
     template: ''
 })
 class MockCommunicationRulesComponent {
+    @Input()
+    public activeStructureId: string;
+
+    @Input()
+    public manageableStructuresId: string[];
+
     @Input()
     sendingHeaderLabel: string;
 

--- a/admin/src/main/ts/app/users/communication/user-communication.component.ts
+++ b/admin/src/main/ts/app/users/communication/user-communication.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { UserModel, GroupModel } from '../../core/store/models';
+import { GroupModel, UserModel } from '../../core/store/models';
 import { CommunicationRule } from './communication-rules.component';
 
 const css = {
@@ -34,10 +34,12 @@ export const userCommunicationLocators = {
 
             <div class="user-communication__content">
                 <communication-rules
+                [activeStructureId]="activeStructureId"
                 [sendingHeaderLabel]="'user.communication.groups-of-user' | translate"
                 [receivingHeaderLabel]="'user.communication.groups-that-user-can-communicate-with' | translate"
                 [communicationRules]="userSendingCommunicationRules"
                 [activeColumn]="'sending'"
+                [manageableStructuresId]="manageableStructuresId"
                 [addCommunicationPickableGroups]="addCommunicationPickableGroups"></communication-rules>
             </div>
         </panel-section>
@@ -49,10 +51,12 @@ export const userCommunicationLocators = {
             
             <div class="user-communication__content">
                 <communication-rules
+                [activeStructureId]="activeStructureId"
                 [sendingHeaderLabel]="'user.communication.groups-that-can-communicate-with-user' | translate"
                 [receivingHeaderLabel]="'user.communication.groups-of-user' | translate"
                 [communicationRules]="userReceivingCommunicationRules"
                 [activeColumn]="'receiving'"
+                [manageableStructuresId]="manageableStructuresId"
                 [addCommunicationPickableGroups]="addCommunicationPickableGroups"></communication-rules>
             </div>
         </panel-section>`,
@@ -79,6 +83,11 @@ export const userCommunicationLocators = {
     `]
 })
 export class UserCommunicationComponent {
+    @Input()
+    public activeStructureId: string;
+
+    @Input()
+    public manageableStructuresId: string[];
 
     @Input()
     public user: UserModel;


### PR DESCRIPTION
Related to CAV2-402: https://opendigitaleducation.atlassian.net/browse/CAV2-402

Sort groups by structure in communication rules view, display structure name in group card and also show buttons in group card based on ADML rights.