### PR TITLE
Zimbra permission management for admin console V2

### DIFF
--- a/admin/src/main/java/org/entcore/admin/Admin.java
+++ b/admin/src/main/java/org/entcore/admin/Admin.java
@@ -21,6 +21,7 @@ package org.entcore.admin;
 import org.entcore.admin.controllers.AdminController;
 import org.entcore.admin.controllers.BlockProfileTraceController;
 import org.entcore.admin.controllers.PlatformInfoController;
+import org.entcore.admin.controllers.ZimbraController;
 import org.entcore.admin.services.BlockProfileTraceService;
 import org.entcore.admin.services.impl.DefaultBlockProfileTraceService;
 import org.entcore.common.http.BaseServer;
@@ -43,6 +44,7 @@ public class Admin extends BaseServer {
 		 BlockProfileTraceService blockProfileTraceService = new DefaultBlockProfileTraceService("adminv2");
 		 blockProfileTraceController.setBlockProfileTraceService(blockProfileTraceService);
 		 addController(blockProfileTraceController);
+		 addController(new ZimbraController());
 		 
 		 final PlatformInfoController platformInfoController = new PlatformInfoController();
 

--- a/admin/src/main/java/org/entcore/admin/controllers/ZimbraController.java
+++ b/admin/src/main/java/org/entcore/admin/controllers/ZimbraController.java
@@ -1,0 +1,24 @@
+package org.entcore.admin.controllers;
+
+import fr.wseduc.rs.Get;
+import fr.wseduc.security.ActionType;
+import fr.wseduc.security.SecuredAction;
+import fr.wseduc.webutils.http.BaseController;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
+import org.entcore.common.http.filter.AdminFilter;
+import org.entcore.common.http.filter.ResourceFilter;
+
+public class ZimbraController extends BaseController {
+
+    @Get("api/zimbra/config")
+    @SecuredAction(type = ActionType.RESOURCE, value = "")
+    @ResourceFilter(AdminFilter.class)
+    public void readConfig(HttpServerRequest request) {
+        final JsonObject services = config.getJsonObject("services", new JsonObject());
+        final JsonObject displayZimbra = new JsonObject()
+                .put("displayZimbra", services.getBoolean("zimbra", false));
+        renderJson(request, displayZimbra);
+    }
+
+}

--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -95,6 +95,19 @@
     "management.block.profile.traces.table.header.action": "Type d'action",
     "management.block.profile.traces.table.header.profile": "Profil",
     "management.block.profile.traces.table.header.displayName": "Nom d'affichage",
+
+    "management.zimbra.warning.content": "Attention, lorsque vous ouvrez des droits vers l'extérieur, les règles de communication définies par l'établissement ne sont plus appliquées dans la messagerie pour les utilisateurs contenus dans les groupes sélectionnés.",
+    "management.zimbra.panel.content": "Ouverture de la messagerie vers l'exterieur",
+    "management.zimbra.tab": "Messagerie",
+    "management.zimbra.permission.give.success.title" : "Droit accordé avec succès",
+    "management.zimbra.permission.give.success.content" : "Le droit d'accès a été accordé au groupe {{group}}",
+    "management.zimbra.permission.delete.success.title" : "Droit retiré avec succès",
+    "management.zimbra.permission.delete.success.content" : "Le droit d'accès a été retiré au groupe {{group}}",
+    "management.zimbra.permission.give.error.title" : "Une erreur est survenue",
+    "management.zimbra.permission.give.error.content" : "Le droit d'accès n'a pas pu être accordé",
+    "management.zimbra.permission.delete.error.title" : "Une erreur est survenue",
+    "management.zimbra.permission.delete.error.content" : "Le droit d'accès n'a pas pu être retiré au groupe",
+
     "BLOCK": "Blocage",
     "UNBLOCK": "Déblocage",
 

--- a/admin/src/main/ts/src/app/core/store/models/group.model.ts
+++ b/admin/src/main/ts/src/app/core/store/models/group.model.ts
@@ -19,6 +19,7 @@ export class GroupModel extends Model<GroupModel> {
     lockDelete?:boolean;
     users: UserModel[];
     internalCommunicationRule?: InternalCommunicationRule;
+    roles?: string[];
 
     constructor() {
         super({

--- a/admin/src/main/ts/src/app/management/management-root/management-root.component.ts
+++ b/admin/src/main/ts/src/app/management/management-root/management-root.component.ts
@@ -3,6 +3,7 @@ import { Data, NavigationEnd } from '@angular/router';
 import { OdeComponent } from 'ngx-ode-core';
 import { routing } from '../../core/services/routing.service';
 import { StructureModel } from '../../core/store/models/structure.model';
+import {ZimbraService} from '../zimbra/zimbra.service';
 import { Session } from 'src/app/core/store/mappings/session';
 import { SessionModel } from 'src/app/core/store/models/session.model';
 
@@ -18,13 +19,17 @@ export class ManagementRootComponent extends OdeComponent implements OnInit, OnD
         { label: 'management.message.flash', view: 'message-flash/list', active: 'message-flash'},
         { label: 'management.block.profile.tab', view: 'block-profiles', active: 'block-profiles'},
         { label: 'management.calendar', view: 'calendar', active: 'calendar'}
+        { label: 'management.zimbra.tab', view: 'zimbra', active: 'zimbra'},
+        { label: 'management.edt.tab', view: 'import-edt', active: 'import-edt'}
     ];
 
     edt_tab = { label: 'management.edt.tab', view: 'import-edt', active: 'import-edt'};
 
     private structure: StructureModel;
 
-    constructor(injector: Injector) {
+    private displayZimbra : boolean;
+
+    constructor(injector: Injector, private zimbraService: ZimbraService) {
         super(injector);
     }
 
@@ -50,6 +55,15 @@ export class ManagementRootComponent extends OdeComponent implements OnInit, OnD
         // Watch selected structure
         this.subscriptions.add(routing.observe(this.route, 'data').subscribe((data: Data) => {
             if (data.structure) {
+                /* Remove zimbra tab if the config key is set to false */
+                this.zimbraService.getZimbraConfKey().subscribe((conf) => {
+                    this.displayZimbra = conf.displayZimbra;
+                    for (let i = 0; i < this.tabs.length; i++) {
+                        if (this.tabs[i].view === 'zimbra' && !this.displayZimbra) {
+                            this.tabs.splice(i, 1);
+                        }
+                    }
+                });
                 this.structure = data.structure;
                 this.admcSpecific();
                 this.changeDetector.markForCheck();

--- a/admin/src/main/ts/src/app/management/management-routing.module.ts
+++ b/admin/src/main/ts/src/app/management/management-routing.module.ts
@@ -7,7 +7,9 @@ import {DuplicateMessageFlashComponent} from './message-flash/form/duplicate-mes
 import {CreateMessageFlashComponent} from './message-flash/form/create-message-flash.component';
 import {MessageFlashResolver} from './message-flash/message-flash.resolver';
 import { BlockProfilesComponent } from './block-profile/block-profiles.component';
+import { ZimbraComponent } from './zimbra/zimbra.component';
 import { ImportEDTComponent } from './import-edt/import-edt.component';
+import {ZimbraGuardService} from './zimbra/zimbra-guard.service';
 import {CalendarComponent} from "./calendar/calendar.component";
 
 export let routes: Routes = [
@@ -53,6 +55,11 @@ export let routes: Routes = [
             {
                 path: 'block-profiles',
                 component: BlockProfilesComponent
+            },
+            {
+                path: 'zimbra',
+                canActivate : [ZimbraGuardService],
+                component: ZimbraComponent
             },
             {
                 path: 'import-edt',

--- a/admin/src/main/ts/src/app/management/management.module.ts
+++ b/admin/src/main/ts/src/app/management/management.module.ts
@@ -20,6 +20,7 @@ import {MessageFlashStore} from './message-flash/message-flash.store';
 import {MessageFlashResolver} from './message-flash/message-flash.resolver';
 import {BlockProfilesComponent} from './block-profile/block-profiles.component';
 import {BlockProfilesService} from './block-profile/block-profiles.service';
+import {ZimbraComponent} from './zimbra/zimbra.component';
 import {ImportEDTComponent} from './import-edt/import-edt.component';
 import { MatPaginatorIntlService } from './block-profile/MatPaginatorIntl.service';
 import { NgxTrumbowygModule } from 'ngx-trumbowyg';
@@ -27,6 +28,7 @@ import {CalendarComponent} from "./calendar/calendar.component";
 import {MatRadioModule} from "@angular/material/radio";
 import {MatDividerModule} from "@angular/material/divider";
 import {FlexLayoutModule} from "@angular/flex-layout";
+import {ZimbraService} from "./zimbra/zimbra.service";
 
 @NgModule({
     imports: [
@@ -56,6 +58,7 @@ import {FlexLayoutModule} from "@angular/flex-layout";
         FlexLayoutModule
     ],
     declarations: [
+        ZimbraComponent,
         ManagementRootComponent,
         MessageFlashComponent,
         MessageFlashListComponent,
@@ -75,6 +78,7 @@ import {FlexLayoutModule} from "@angular/flex-layout";
         MessageFlashStore,
         MessageFlashResolver,
         BlockProfilesService,
+        ZimbraService,
         {
             provide: MatPaginatorIntl,
             useFactory: (bundlesService) => new MatPaginatorIntlService(bundlesService),

--- a/admin/src/main/ts/src/app/management/zimbra/zimbra-guard.service.ts
+++ b/admin/src/main/ts/src/app/management/zimbra/zimbra-guard.service.ts
@@ -1,0 +1,19 @@
+import {Injectable} from '@angular/core';
+import {ActivatedRouteSnapshot, CanActivate} from '@angular/router';
+import {ZimbraService} from './zimbra.service';
+import {pluck} from 'rxjs/operators';
+import {Observable} from 'rxjs';
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ZimbraGuardService implements CanActivate {
+
+  constructor(private zimbraService: ZimbraService) {}
+
+  public canActivate(route: ActivatedRouteSnapshot): Observable<boolean> {
+    return this.zimbraService.getZimbraConfKey().pipe(
+        pluck('displayZimbra'));
+  }
+}

--- a/admin/src/main/ts/src/app/management/zimbra/zimbra.component.html
+++ b/admin/src/main/ts/src/app/management/zimbra/zimbra.component.html
@@ -1,0 +1,19 @@
+<div class="panel-section-header">
+      <span><s5l>management.zimbra.panel.content</s5l></span>
+    </div>
+    <div class="container">
+        <div class="flashmsg red">
+            <i class=" fa fa-exclamation-triangle" tabindex="0" style="color: white;"></i>
+            <span style="color: white;"><s5l>management.zimbra.warning.content</s5l></span>
+        </div>
+
+        <ul class="zimbra-group-list">
+            <li *ngFor="let group of groups; let i= index">
+                <div class="checkbox__item">
+                    <input id="group-checkbox-{{i}}" type="checkbox" [(ngModel)]="checkboxes[i]" (change)="updatePermission(i)">
+                    <label for="group-checkbox-{{i}}" [ngClass]="{'is-bold' : this.checkboxes[i]}">{{ group.name }} </label>
+                </div>
+            </li>
+        </ul>
+
+    </div>

--- a/admin/src/main/ts/src/app/management/zimbra/zimbra.component.scss
+++ b/admin/src/main/ts/src/app/management/zimbra/zimbra.component.scss
@@ -1,0 +1,5 @@
+.panel-section-header{padding:10px;font-size: 1.1em;}
+.container{font-size: 1.1em;}
+.zimbra-group-list{ columns: 3;}
+
+

--- a/admin/src/main/ts/src/app/management/zimbra/zimbra.component.ts
+++ b/admin/src/main/ts/src/app/management/zimbra/zimbra.component.ts
@@ -1,0 +1,118 @@
+import {ChangeDetectionStrategy, Component, Injector, OnInit} from '@angular/core';
+import {ZimbraService} from './zimbra.service';
+import {routing} from '../../core/services/routing.service';
+import {StructureModel} from '../../core/store/models/structure.model';
+import {Data} from '@angular/router';
+import {OdeComponent} from 'ngx-ode-core';
+import {GroupModel} from '../../core/store/models/group.model';
+import {NotifyService} from '../../core/services/notify.service';
+import {switchMap} from 'rxjs/operators';
+
+
+@Component({
+    selector: 'ode-zimbra',
+    templateUrl: './zimbra.component.html',
+    styleUrls: ['./zimbra.component.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+
+export class ZimbraComponent extends OdeComponent implements OnInit {
+    private structure: StructureModel;
+    public groups: GroupModel[] = [];
+    public roleId: string;
+    public checkboxes: boolean[] = [];
+
+    constructor(injector: Injector,
+                private zimbraService: ZimbraService,
+                private notifyService: NotifyService) {
+        super(injector);
+    }
+
+    ngOnInit(): void {
+        super.ngOnInit();
+
+        /* Get the current structure and init arrays. */
+        this.subscriptions.add(routing.observe(this.route, 'data').subscribe((data: Data) => {
+            if (data.structure) {
+                this.structure = data.structure;
+                this.groups = [];
+                this.checkboxes = [];
+                this._getGroups();
+            }
+        }));
+    }
+    /**
+     * Get all groups for the current structure.
+     * Get the role id corresponding to Zimbra.
+     * Sort by boolean (if a checkbox is checked or not) and alphabetically.
+     */
+    private _getGroups(): void {
+        this.subscriptions.add(this.zimbraService.getRoleId().pipe(
+            switchMap(data => {
+                this.roleId = data.role.id;
+                return this.zimbraService.getGroups(this.structure.id);
+            })
+        ).subscribe(groupData => {
+            this.groups = groupData;
+            this.groups.sort((a, b) => (+b.roles.includes(this.roleId)) - (+a.roles.includes(this.roleId)) || a.name.localeCompare(b.name));
+            this.groups.forEach(
+                (group: GroupModel) => {
+                    this.checkboxes.push(group.roles.includes(this.roleId));
+                }
+            );
+            this.changeDetector.detectChanges();
+        })
+        );
+    }
+    /**
+     * Remove the permission for the selected group.
+     * @param groupModel The selected group.
+     */
+    private _deletePermission(group: GroupModel): void {
+        this.subscriptions.add(this.zimbraService.deletePermission(group.id, this.roleId).subscribe(
+            () => {
+                this.notifyService.success(
+                    {key: 'management.zimbra.permission.delete.success.content',
+                        parameters: {group: group.name }},
+                    'management.zimbra.permission.delete.success.title');
+            },
+            (err) => {
+                this.notifyService.notify(
+                    'management.zimbra.permission.delete.error.content',
+                    'management.zimbra.permission.delete.error.title', err.error.error, 'error');
+            }
+        ));
+
+    }
+    /**
+     * Grant the permission for the selected group.
+     * @param groupModel The selected group.
+     */
+    private _givePermission(group: GroupModel): void {
+        this.subscriptions.add(this.zimbraService.givePermission(group.id, this.roleId).subscribe(
+            () => {
+                this.notifyService.success(
+                    {key: 'management.zimbra.permission.give.success.content',
+                        parameters: {group: group.name }},
+                    'management.zimbra.permission.give.success.title');
+            },
+            (err) => {
+                this.notifyService.notify(
+                    'management.zimbra.permission.give.error.content',
+                    'management.zimbra.permission.give.error.title', err.error.error, 'error');
+            }
+        ));
+    }
+    /**
+     * Update the permission of the selected group when you click on the checkbox.
+     * @param index Index of the selected group.
+     */
+    public updatePermission(index: number): void {
+        const group: GroupModel = this.groups[index];
+        if (this.checkboxes[index]) {
+            this._givePermission(group);
+        } else {
+            this._deletePermission(group);
+        }
+    }
+}

--- a/admin/src/main/ts/src/app/management/zimbra/zimbra.service.ts
+++ b/admin/src/main/ts/src/app/management/zimbra/zimbra.service.ts
@@ -1,0 +1,55 @@
+import {Injectable} from '@angular/core';
+import {Observable} from 'rxjs';
+import {HttpClient} from '@angular/common/http';
+import {GroupModel} from '../../core/store/models/group.model';
+import {RoleModel} from '../../core/store/models/role.model';
+import {TraceResponse} from "../../types/trace";
+
+@Injectable({
+  providedIn: 'root'
+})
+
+export class ZimbraService {
+
+  constructor(private httpClient: HttpClient) {}
+
+    /**
+     * Get the list of all groups by structure.
+     * @param structureId Id for the current structure.
+     */
+  public getGroups(structureId: string): Observable<GroupModel[]> {
+    return this.httpClient.get<GroupModel[]>(`/appregistry/groups/roles?structureId=${structureId}`);
+  }
+    /**
+     * Get the role id of the zimbra component.
+     */
+  public getRoleId(): Observable<{role: RoleModel}> {
+      return this.httpClient.get<{role: RoleModel}>('/zimbra/role');
+  }
+
+    /**
+     * Give the permission to use zimbra outside communication.
+     * @param id Group id.
+     * @param roleId Zimbra role id.
+     */
+  public givePermission(id: string, roleId: string): Observable<void> {
+        return this.httpClient.put<void>(`/appregistry/authorize/group/${id}/role/${roleId}`, {});
+  }
+
+    /**
+     *
+     * @param id Group id.
+     * @param roleId Zimbra role id.
+     */
+  public deletePermission(id: string, roleId: string): Observable<void> {
+        return this.httpClient.delete<void>(`/appregistry/authorize/group/${id}/role/${roleId}`);
+  }
+
+    /**
+     * Get the value of the configuration key "displayZimbraAdmin"
+     */
+  public getZimbraConfKey(): Observable<{ displayZimbra: boolean }> {
+        return this.httpClient.get<{ displayZimbra: boolean }>(`/admin/api/zimbra/config`);
+  }
+}
+


### PR DESCRIPTION
La gestion des droits est bien gérée, concernant la désactivation des routes et de l'onglet "Messagerie", tout fonctionne correctement. Cependant, il ne faudra pas oublier de rajouter la clé de configuration dans ent-core.json. Si cette clé est initialisée à true, l'accès aux routes et à l'onglet "Messagerie" sera possible, mais dans le cas contraire tout sera bloqué.

Clé de configuration à placer dans le composant admin : 
"services" : { 
  "zimbra" : true 
}

