### PR TITLE
feat(feeder): DCN-111 Save structure/function of user when importing CSV on another structure

### DIFF
--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -300,6 +300,7 @@
     "email": "Courriel",
     "homePhone": "Téléphone",
     "mobilePhone": "Téléphone portable",
+    "multiEtab": "Multi établissements",
     "structures": "Établissement(s)",
     "city": "Ville",
     "classCategories":"Catégorie de classe",

--- a/feeder/src/main/java/org/entcore/feeder/csv/CsvReport.java
+++ b/feeder/src/main/java/org/entcore/feeder/csv/CsvReport.java
@@ -181,6 +181,8 @@ public class CsvReport extends Report {
 	//												l[i] = ((JsonArray) v).<String>get(count);
 	//											}
 											}
+										} else if (v instanceof  Boolean) {
+											l[i] = String.valueOf(v);
 										} else {
 											l[i] = "";
 										}

--- a/feeder/src/main/java/org/entcore/feeder/csv/ProfileColumnsMapper.java
+++ b/feeder/src/main/java/org/entcore/feeder/csv/ProfileColumnsMapper.java
@@ -125,6 +125,7 @@ public class ProfileColumnsMapper {
 				.put("sexe", "gender")
 				.put("alias", "loginAlias")
 				.put("login", "loginAlias")
+				.put("multietab", "multiEtab")
 				//.put("importid", "importId")
 				.put("identifiantclasse", "ignore")
 				.put("dateinscription", "ignore")

--- a/feeder/src/main/resources/dictionary/schema/Personnel.json
+++ b/feeder/src/main/resources/dictionary/schema/Personnel.json
@@ -145,6 +145,9 @@
 		"loginAlias" : {
 			"type": "login-alias",
 			"validator": "loginAlias"
+		},
+		"multiEtab": {
+			"type": "boolean"
 		}
 	},
 	"generate" : {

--- a/feeder/src/main/resources/dictionary/schema/Student.json
+++ b/feeder/src/main/resources/dictionary/schema/Student.json
@@ -181,6 +181,9 @@
 		"endDateClasses" : {
 			"type" : "array-string",
 			"validator" : "notEmpty"
+		},
+		"multiEtab": {
+			"type": "boolean"
 		}
 	},
 	"generate" : {

--- a/feeder/src/main/resources/dictionary/schema/User.json
+++ b/feeder/src/main/resources/dictionary/schema/User.json
@@ -110,6 +110,9 @@
 		"classes" : {
 			"type" : "array-string",
 			"validator" : "notEmpty"
+		},
+		"multiEtab": {
+			"type": "boolean"
 		}
 	},
 	"generate" : {


### PR DESCRIPTION
Ajout d'un paramètre CSV  `multiEtab` pour chaque utilisateur. Si la valeur est `true` alors : 

- N'écrase plus les données d'établissement après l'import CSV de l'utilisateur sur un autre établissement (un utilisateur importé sur 3 établissements sera lié aux 3 et non pas juste au dernier)

- N'écrase plus les données des fonctions de l'utilisateur liés aux autres établissements