### PR TITLE
feat(personalData/config): #DCN-95 add new configuration

### DIFF
--- a/admin/src/main/java/org/entcore/admin/controllers/PlatformInfoController.java
+++ b/admin/src/main/java/org/entcore/admin/controllers/PlatformInfoController.java
@@ -18,6 +18,7 @@
 
 package org.entcore.admin.controllers;
 
+import io.vertx.core.shareddata.LocalMap;
 import org.entcore.common.http.filter.AdminFilter;
 import org.entcore.common.http.filter.ResourceFilter;
 import io.vertx.core.http.HttpServerRequest;
@@ -59,12 +60,15 @@ public class PlatformInfoController extends BaseController {
 	@SecuredAction(type = ActionType.RESOURCE, value = "")
 	@ResourceFilter(AdminFilter.class)
 	public void readConfig(HttpServerRequest request) {
+		LocalMap<Object, Object> serverMap = vertx.sharedData().getLocalMap("server");
+
 		final JsonObject preDelete = config.getJsonObject("pre-delete");
 		final JsonObject configuration =  new JsonObject()
 				.put("delete-user-delay", config.getLong("delete-user-delay", defaultDeleteUserDelay))
 				.put("reset-code-delay", config.getLong("resetCodeDelay", 0L))
 				.put("distributions", config.getJsonArray("distributions", new JsonArray()))
-				.put("hide-adminv1-link", config.getBoolean("hide-adminv1-link", false));
+				.put("hide-adminv1-link", config.getBoolean("hide-adminv1-link", false))
+				.put("hide-personal-data", serverMap.get("hidePersonalData"));
 
 		if (preDelete != null && preDelete.size() == PROFILES.size() &&
 				PROFILES.containsAll(preDelete.fieldNames())) {

--- a/admin/src/main/ts/src/app/core/resolvers/Config.ts
+++ b/admin/src/main/ts/src/app/core/resolvers/Config.ts
@@ -7,4 +7,5 @@ export interface Config {
     'relative-pre-delete-delay': number;
     'guest-pre-delete-delay': number;
     'hide-adminv1-link': boolean;
+    'hide-personal-data': boolean;
 }

--- a/admin/src/main/ts/src/app/users/details/sections/administrative/user-administrative-section.component.html
+++ b/admin/src/main/ts/src/app/users/details/sections/administrative/user-administrative-section.component.html
@@ -24,13 +24,13 @@
         </ode-date-picker>
         <ode-form-errors [control]="birthDateInput"></ode-form-errors>
       </ode-form-field>
-      <ode-form-field label="address">
+      <ode-form-field label="address" *ngIf="!config['hide-personal-data']">
         <input type="text" [(ngModel)]="details.address" name="address" >
       </ode-form-field>
-      <ode-form-field label="zipCode">
+      <ode-form-field label="zipCode" *ngIf="!config['hide-personal-data']">
         <input type="text" [(ngModel)]="details.zipCode" name="zipCode" >
       </ode-form-field>
-      <ode-form-field label="city">
+      <ode-form-field label="city" *ngIf="!config['hide-personal-data']">
         <input type="text" [(ngModel)]="details.city" name="city">
       </ode-form-field>
       <ode-form-field label="email">
@@ -38,10 +38,10 @@
                #emailInput="ngModel" [pattern]="emailPattern" >
         <ode-form-errors [control]="emailInput"></ode-form-errors>
       </ode-form-field>
-      <ode-form-field label="homePhone">
+      <ode-form-field label="homePhone" *ngIf="!config['hide-personal-data']">
         <input type="tel" [(ngModel)]="details.homePhone" name="homePhone" >
       </ode-form-field>
-      <ode-form-field label="mobilePhone">
+      <ode-form-field label="mobilePhone" *ngIf="!config['hide-personal-data']">
         <input type="tel" [(ngModel)]="details.mobile" name="mobile" >
       </ode-form-field>
     </fieldset>

--- a/admin/src/main/ts/src/app/users/details/sections/administrative/user-administrative-section.component.ts
+++ b/admin/src/main/ts/src/app/users/details/sections/administrative/user-administrative-section.component.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, Input} from '@angular/core';
 import {AbstractControl, NgForm} from '@angular/forms';
 
 import {AbstractSection} from '../abstract.section';
@@ -10,6 +10,7 @@ import {UsersStore} from '../../../users.store';
 import { NotifyService } from 'src/app/core/services/notify.service';
 import { SpinnerService } from 'ngx-ode-ui';
 import { UserListService } from 'src/app/core/services/userlist.service';
+import {Config} from "../../../../core/resolvers/Config";
 
 @Component({
     selector: 'ode-user-administrative-section',
@@ -26,6 +27,8 @@ export class UserAdministrativeSectionComponent extends AbstractSection {
 
     @ViewChild('lastNameInput', { static: false })
     lastNameInput: AbstractControl;
+
+    @Input() config: Config;
 
     constructor(
         private usersStore: UsersStore,

--- a/admin/src/main/ts/src/app/users/details/user-details.component.html
+++ b/admin/src/main/ts/src/app/users/details/user-details.component.html
@@ -153,7 +153,7 @@
   <ode-user-info-section [user]="user" [structure]="structure" [config]="config">
   </ode-user-info-section>
 
-  <ode-user-administrative-section [user]="user" [structure]="structure">
+  <ode-user-administrative-section [user]="user" [structure]="structure" [config]="config">
   </ode-user-administrative-section>
 
   <ode-user-quota-section [user]="user"

--- a/directory/src/main/java/org/entcore/directory/controllers/UserBookController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/UserBookController.java
@@ -34,6 +34,7 @@ import java.util.*;
 
 import fr.wseduc.webutils.http.Renders;
 import fr.wseduc.webutils.request.CookieHelper;
+import io.vertx.core.shareddata.LocalMap;
 import org.entcore.common.events.EventStore;
 import org.entcore.common.events.EventStoreFactory;
 import org.entcore.common.http.request.JsonHttpServerRequest;
@@ -143,7 +144,9 @@ public class UserBookController extends BaseController {
 	@Get("/mon-compte")
 	@SecuredAction(value = "userbook.authent", type = ActionType.AUTHENTICATED)
 	public void monCompte(HttpServerRequest request) {
-		renderView(request);
+		LocalMap<Object, Object> serverMap = vertx.sharedData().getLocalMap("server");
+		JsonObject configuration = new JsonObject().put("hidePersonalData", serverMap.get("hidePersonalData"));
+		renderView(request, configuration, "mon-compte.html", null);
 		eventStore.createAndStoreEvent(DirectoryEvent.ACCESS.name(), request, new JsonObject().put("override-module", "MyAccount"));
 	}
 

--- a/directory/src/main/resources/public/js/admin/controller.js
+++ b/directory/src/main/resources/public/js/admin/controller.js
@@ -79,6 +79,7 @@ function AdminDirectoryController($scope, $rootScope, $http, $route, template, m
 			});
 			$http.get('/admin/api/platform/config').success(function (data) {
 				$scope.distributions = data.distributions;
+				$scope.hidePersonalData = data["hide-personal-data"];
 			});
 		},
         viewStructureUser: function(params){

--- a/directory/src/main/resources/public/template/admin-user-details.html
+++ b/directory/src/main/resources/public/template/admin-user-details.html
@@ -79,15 +79,15 @@
             <button type="button" class="small cell" style="padding: 0px 5px; margin-left: 5%;" ng-click="targetUser.birthDate = undefined">[[lang.translate("directory.deleteDate")]]</button>
         </div>
     </div>
-    <div class="twelve cell">
+    <div ng-if="!hidePersonalData" class="twelve cell">
         <strong class="four cell padding-top-5">[[lang.translate("directory.userAddress")]]</strong>
         <input class="six cell" type="text" ng-model="targetUser.address"/>
     </div>
-    <div class="twelve cell">
+    <div ng-if="!hidePersonalData" class="twelve cell">
         <strong class="four cell padding-top-5">[[lang.translate("directory.userCity")]]</strong>
         <input class="six cell" type="text" ng-model="targetUser.city"/>
     </div>
-    <div class="twelve cell">
+    <div ng-if="!hidePersonalData" class="twelve cell">
         <strong class="four cell padding-top-5">[[lang.translate("directory.userZipCode")]]</strong>
         <input class="six cell" type="text" ng-model="targetUser.zipCode"/>
     </div>
@@ -95,12 +95,12 @@
         <strong class="four cell padding-top-5">[[lang.translate("directory.admin.email")]] :</strong>
         <input class="six cell" type="email" name="email" ng-model="targetUser.email"/>
     </div>
-    <div class="twelve cell">
+    <div ng-if="!hidePersonalData" class="twelve cell">
         <strong class="four cell padding-top-5">[[lang.translate("userBook.profile.telephone")]] :</strong>
         <input class="six cell" type="tel"
                name="homePhone" ng-model="targetUser.homePhone"/>
     </div>
-    <div class="twelve cell">
+    <div ng-if="!hidePersonalData" class="twelve cell">
         <strong class="four cell padding-top-5">[[lang.translate("directory.admin.mobilePhone")]] :</strong>
         <input class="six cell" type="tel"
                name="mobilePhone" ng-model="targetUser.mobile"/>

--- a/directory/src/main/resources/public/template/user-edit.html
+++ b/directory/src/main/resources/public/template/user-edit.html
@@ -124,7 +124,7 @@
 				<div class="clear"></div>
 			</div>
 
-			<div class="row">
+			<div class="row" ng-if="!hidePersonalData">
 				<label translate content="userBook.profile.telephone" class="four cell"></label>
 				<div class="seven cell">
 					<input type="tel" ng-pattern="/^(00|\+)?(?:[0-9] ?-?\.?){6,15}$/" name="phone" class="twelve inline-editing" complete-change="userForm.$valid ? saveChanges() : ''" ng-model="account.homePhone" />
@@ -138,7 +138,7 @@
 				<div class="clear"></div>
       		</div>
 
-			<div class="row">
+			<div class="row" ng-if="!hidePersonalData">
 				<label translate content="userBook.profile.mobilePhone" class="four cell"></label>
 				<div class="seven cell">
 					<input type="tel" ng-pattern="/^(00|\+)?(?:[0-9] ?-?\.?){6,15}$/" name="mobilePhone" class="twelve inline-editing" complete-change="userForm.$valid ? saveChanges() : ''" ng-model="account.mobile" />

--- a/directory/src/main/resources/public/template/user-view.html
+++ b/directory/src/main/resources/public/template/user-view.html
@@ -106,7 +106,7 @@
 				<i class="[[account.visible.email]] right-magnet" title="[[translate(account.visible.email)]]" data-ng-click="changeInfosVisibility('email', account.visible.email)"></i>
 			</div>
 
-			<div class="row">
+			<div class="row" ng-if="!hidePersonalData">
 				<label translate content="userBook.profile.telephone" class="four cell"></label>
 				<div class="seven cell">
 					<input type="tel" ng-pattern="/^(00|\+)?(?:[0-9] ?-?\.?){6,15}$/" name="phone" class="twelve inline-editing" complete-change="userForm.$valid ? saveInfos() : ''" ng-model="account.homePhone" />
@@ -120,7 +120,7 @@
 				<div class="clear"></div>
 			</div>
 
-			<div class="row">
+			<div class="row" ng-if="!hidePersonalData">
 				<label translate content="userBook.profile.mobilePhone" class="four cell"></label>
 				<div class="seven cell">
 					<input type="tel" ng-pattern="/^(00|\+)?(?:[0-9] ?-?\.?){6,15}$/" name="mobilePhone" class="twelve inline-editing" complete-change="userForm.$valid ? saveInfos() : ''" ng-model="account.mobile" />

--- a/directory/src/main/resources/public/ts/controllers/account.ts
+++ b/directory/src/main/resources/public/ts/controllers/account.ts
@@ -18,6 +18,8 @@
 import { ng, idiom as lang, notify, model, Behaviours, http, template, Me, skin, moment, _ } from 'entcore';
 import { directory } from '../model';
 
+declare let window: any;
+
 export const accountController = ng.controller('MyAccount', ['$scope', 'route', 'tracker', '$location', '$anchorScroll', ($scope, route, tracker, $location, $anchorScroll) => {
 	route({
 		editUserInfos: async function(params){
@@ -154,6 +156,9 @@ export const accountController = ng.controller('MyAccount', ['$scope', 'route', 
 			published: true,
 			activated: false
 		}
+
+		$scope.hidePersonalData = window.hidePersonalData;
+
 		loadThemeConf();
 	}
 

--- a/directory/src/main/resources/view-src/mon-compte.html
+++ b/directory/src/main/resources/view-src/mon-compte.html
@@ -10,6 +10,9 @@
 		<meta name="viewport" content="initial-scale=1, maximum-scale=1">
 		<script type="text/javascript" src="/directory/public/dist/entcore/ng-app.js" id="context"></script>
 		<script type="text/javascript" src="/directory/public/dist/application.js"></script>
+		<script type="text/javascript">
+			var hidePersonalData = {{hidePersonalData}};
+		</script>
 	</head>
 	<body class="account">
 		<portal>

--- a/infra/src/main/java/org/entcore/infra/Starter.java
+++ b/infra/src/main/java/org/entcore/infra/Starter.java
@@ -63,6 +63,7 @@ public class Starter extends BaseServer {
 			serverMap.put("signKey", config.getString("key", "zbxgKWuzfxaYzbXcHnK3WnWK" + Math.random()));
 
 			serverMap.put("sameSiteValue", config.getString("sameSiteValue", "Strict"));
+			serverMap.put("hidePersonalData", config.getBoolean("hidePersonalData", false));
 
 			//JWT need signKey
 			SecurityHandler.setVertx(vertx);


### PR DESCRIPTION
Ajout d'une configuration pour désactiver les informations personnelles et ne laisser que les informations nécessaires, à savoir : 
- Adresse
- Code postal
- Ville
- Numéro de téléphone fixe
- Numéro de téléphone portable

Pour activer cette fonctionnalité, il faut ajouter dans le module infra la configuration suivante :
```json
"hidePersonalData": true
```
