### PR TITLE
[ODE] adminv2 : masquer le bouton d'ajout ADML si le user est un élève ou parent

### DIFF
--- a/admin/src/main/ts/src/app/users/details/sections/info/user-info-section.component.html
+++ b/admin/src/main/ts/src/app/users/details/sections/info/user-info-section.component.html
@@ -66,7 +66,7 @@
         <div>
           <div *ngIf="!details.isAdmc()">
             <button type="button"
-                    *ngIf="!details.isAdml(this.structure.id)"
+                    *ngIf="showAddAdmlButton()"
                     (click)="showAddAdmlConfirmation = true">
               <s5l>adml.add</s5l>
               <i class="fa fa-cog"></i>

--- a/admin/src/main/ts/src/app/users/details/sections/info/user-info-section.component.ts
+++ b/admin/src/main/ts/src/app/users/details/sections/info/user-info-section.component.ts
@@ -12,6 +12,8 @@ import { UserModel } from 'src/app/core/store/models/user.model';
 import { NotifyService } from 'src/app/core/services/notify.service';
 import { SpinnerService } from 'ngx-ode-ui';
 import { PlatformInfoService } from 'src/app/core/services/platform-info.service';
+import { SessionModel } from 'src/app/core/store/models/session.model';
+import { Session } from 'src/app/core/store/mappings/session';
 
 @Component({
     selector: 'ode-user-info-section',
@@ -32,6 +34,8 @@ export class UserInfoSectionComponent extends AbstractSection implements OnInit 
     userInfoSubscriber: Subscription;
 
     loginAliasPattern = /^[0-9a-z\-\.]+$/;
+
+    isAdmc: boolean = false;
 
     @Input() structure: StructureModel;
     @Input() user: UserModel;
@@ -58,7 +62,7 @@ export class UserInfoSectionComponent extends AbstractSection implements OnInit 
         super();
     }
 
-    ngOnInit() {
+    async ngOnInit() {
         this.passwordResetMail = this.details.email;
         this.passwordResetMobile = this.details.mobile;
         PlatformInfoService.isSmsModule().then(res => {
@@ -68,6 +72,10 @@ export class UserInfoSectionComponent extends AbstractSection implements OnInit 
 
         this.userInfoSubscriber = this.userInfoService.getState()
             .subscribe(() => this.cdRef.markForCheck());
+
+        const session: Session = await SessionModel.getSession();
+        this.isAdmc = session.isADMC();
+        this.cdRef.markForCheck();
     }
 
     protected onUserChange() {
@@ -288,5 +296,15 @@ export class UserInfoSectionComponent extends AbstractSection implements OnInit 
 
     showLightbox() {
         this.showMassMailConfirmation = true;
+    }
+
+    showAddAdmlButton() {
+        if (this.details.isAdml(this.structure.id)) {
+            return false;
+        }
+        if (this.isAdmc) {
+            return true;
+        }
+        return this.user.type !== 'Student' && this.user.type !== 'Relative';
     }
 }


### PR DESCRIPTION
http://support.web-education.net/issues/45896

cadrage fonctionnel : 
Masquer le bouton "Attribuer les droits d'administration" pour les profils élève et parents pour les ADML.
Le bouton doit être visible pour les ADMC.