### PR TITLE
fix(myinfos): return the user functions properly

### DIFF
--- a/directory/src/main/java/org/entcore/directory/controllers/DirectoryController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/DirectoryController.java
@@ -525,7 +525,7 @@ public class DirectoryController extends BaseController {
 				userService.list(userId, itSelf2, excludeUserId, responseHandler(message));
 				break;
 			case "getUser" :
-				userService.get(userId, false, BusResponseHandler.busResponseHandler(message));
+				userService.get(userId, false, false, BusResponseHandler.busResponseHandler(message));
 				break;
 			case "getUserInfos" :
 				userService.getInfos(userId, BusResponseHandler.busResponseHandler(message));

--- a/directory/src/main/java/org/entcore/directory/controllers/UserController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/UserController.java
@@ -210,9 +210,9 @@ public class UserController extends BaseController {
 					.add("lastLogin").add("created").add("modified").add("ine").add("email").add("emailAcademy")
 					.add("workPhone").add("homePhone").add("country").add("zipCode").add("address").add("postbox")
 					.add("city").add("otherNames").add("title");
-			userService.get(userId, getManualGroups, filter, notEmptyResponseHandler(request));
+			userService.get(userId, getManualGroups, filter, false, notEmptyResponseHandler(request));
 		} else {
-			userService.get(userId, getManualGroups, notEmptyResponseHandler(request));
+			userService.get(userId, getManualGroups, false, notEmptyResponseHandler(request));
 		}
 	}
 
@@ -228,7 +228,7 @@ public class UserController extends BaseController {
 	@SecuredAction(value = "auth.user.info", type = ActionType.AUTHENTICATED)
 	public void myinfos(final HttpServerRequest request) {
 		UserUtils.getUserInfos(eb, request, user ->
-				userService.get(user.getUserId(), true, defaultResponseHandler(request))
+				userService.get(user.getUserId(), true, true, defaultResponseHandler(request))
 		);
 	}
 

--- a/directory/src/main/java/org/entcore/directory/services/UserService.java
+++ b/directory/src/main/java/org/entcore/directory/services/UserService.java
@@ -41,9 +41,9 @@ public interface UserService {
 
 	void getForExternalService(String id, Handler<Either<String, JsonObject>> result);
 
-	void get(String id, boolean getManualGroups, Handler<Either<String, JsonObject>> result);
+	void get(String id, boolean getManualGroups, boolean filterNullReturn, Handler<Either<String, JsonObject>> result);
 
-	void get(String id, boolean getManualGroups, JsonArray filterAttributes, Handler<Either<String, JsonObject>> result);
+	void get(String id, boolean getManualGroups, JsonArray filterAttributes, boolean filterNullReturn, Handler<Either<String, JsonObject>> result);
 
 	void getClasses(String id, Handler<Either<String, JsonObject>> result);
 


### PR DESCRIPTION
Bonjour, 

Nous avons une requête de la région IDF qui sont embêtés sur le scope myinfos s’appuyant sur la route « directory/myinfos » car nous avons toujours la valeur de functions à null alors que l’utilisateur possède des fonctions.
 
En analysant le code, il s’agit de la fonction _fullNodeMergeHandler_ qui écrase les fonctions de l’utilisateur. 
 
Afin de remédier à cela, je modifie le return de la fonction et j'en ai profité pour filtrer les valeurs nulles dans les listes des autres champs afin de ne pas polluer la réponse du scope.

Dans un premier temps, le nouveau RETURN est pris en compte avec un booléen. Ainsi on conserve le comportement actuel et si on constate le problème ailleurs on pourra généraliser le comportement à toutes les autres fonctions. vu avec @nabil-mansouri

Merci d'avance,
