### PR TITLE
feat(directory): Add special oAuth e-tude scope

### DIFF
--- a/common/src/main/java/org/entcore/common/http/filter/AppOAuthResourceProvider.java
+++ b/common/src/main/java/org/entcore/common/http/filter/AppOAuthResourceProvider.java
@@ -186,7 +186,8 @@ public class AppOAuthResourceProvider extends DefaultOAuthResourceProvider {
 						(scope.contains("userinfo") && request.path().contains("/auth/oauth2/userinfo")) ||
 						("OAuthSystemUser".equals(request.getAttribute("remote_user")) && isNotEmpty(request.getAttribute("client_id"))) ||
 						(scope.contains("myinfos") && request.path().contains("/directory/myinfos")) ||
-						(scope.contains("myinfos-ext") && request.path().contains("/directory/myinfos-ext"))
+						(scope.contains("myinfos-ext") && request.path().contains("/directory/myinfos-ext")) ||
+						(scope.contains("e-tude") && request.path().contains("/directory/e-tude"))
 				);
 						//(scope.contains("openid") && request.path().contains())
 	}

--- a/directory/src/main/java/org/entcore/directory/controllers/UserController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/UserController.java
@@ -249,6 +249,14 @@ public class UserController extends BaseController {
 		);
 	}
 
+	@Get("/e-tude")
+	@SecuredAction(value = "auth.user.info", type = ActionType.AUTHENTICATED)
+	public void myinfosETude(final HttpServerRequest request) {
+		UserUtils.getUserInfos(eb, request, user ->
+				userService.getForETude(user.getUserId(), defaultResponseHandler(request))
+		);
+	}
+
 	@Get("/myclasses")
 	@SecuredAction(value = "", type = ActionType.AUTHENTICATED)
 	public void myclasses(final HttpServerRequest request) {

--- a/directory/src/main/java/org/entcore/directory/services/UserService.java
+++ b/directory/src/main/java/org/entcore/directory/services/UserService.java
@@ -41,6 +41,8 @@ public interface UserService {
 
 	void getForExternalService(String id, Handler<Either<String, JsonObject>> result);
 
+	void getForETude(String id, Handler<Either<String, JsonObject>> result);
+
 	void get(String id, boolean getManualGroups, boolean filterNullReturn, Handler<Either<String, JsonObject>> result);
 
 	void get(String id, boolean getManualGroups, JsonArray filterAttributes, boolean filterNullReturn, Handler<Either<String, JsonObject>> result);


### PR DESCRIPTION
Bonjour,

Nous avons besoin de créer une oAuth passant certaines informations spécifiques à des services externes afin de se conformer au RGPD.

Voici les informations que ce connecteur oAuth transmettrais :

- userId
- firstName
- lastName
- classId
- level
- uai
- type (élève, parent etc)
- childrenIds (pour les comptes parents)

Cela se ferait à travers le passage du scope "e-tude".

Elle a été testé et validé.