### PR TITLE
fix(scratch): fix url when editing scratch project

### DIFF
--- a/workspace/src/main/java/org/entcore/workspace/controllers/WorkspaceController.java
+++ b/workspace/src/main/java/org/entcore/workspace/controllers/WorkspaceController.java
@@ -1687,9 +1687,7 @@ public class WorkspaceController extends BaseController {
 	public void view(final HttpServerRequest request) {
 		final JsonObject context = new JsonObject();
 		context.put("enableLool", config.getBoolean("enable-lool", false));
-		if(config.containsKey("scratch-url") && config.getValue("scratch-url") instanceof String && isNotEmpty(config.getString("scratch-url"))){
-			context.put("scratchUrl", config.getString("scratch-url")+"#"+config.getString("host"));
-		}
+		context.put("enableScratch", config.getBoolean("enable-scratch", false));
 		context.put("lazyMode", config.getJsonObject("publicConf", new JsonObject()).getBoolean("lazy-mode", false));
 		context.put("cacheDocTTl", config.getJsonObject("publicConf", new JsonObject()).getInteger("ttl-documents", -1));
 		context.put("cacheFolderTtl", config.getJsonObject("publicConf", new JsonObject()).getInteger("ttl-folders", -1));

--- a/workspace/src/main/resources/public/template/toaster.html
+++ b/workspace/src/main/resources/public/template/toaster.html
@@ -8,12 +8,12 @@
 				<i18n>workspace.open</i18n>
 			</button>
             <button ng-disabled="!canBeOpenOnLool(selectedDocuments()[0])"
-					ng-if="selectedDocuments().length === 1 && ENABLE_LOOL && !(SCRATCH_URL && canBeOpenOnScratch(selectedDocuments()[0]))"
+					ng-if="selectedDocuments().length === 1 && ENABLE_LOOL && !(ENABLE_SCRATCH && canBeOpenOnScratch(selectedDocuments()[0]))"
                     workflow="lool.openFile" ng-click="openOnLool(selectedDocuments()[0])">
                 <i18n>workspace.external.open</i18n>
             </button>
-			<button ng-if="selectedDocuments().length === 1 && SCRATCH_URL && canBeOpenOnScratch(selectedDocuments()[0])"
-					ng-click="openOnScratch(selectedDocuments()[0],SCRATCH_URL)">
+			<button ng-if="selectedDocuments().length === 1 && ENABLE_SCRATCH && canBeOpenOnScratch(selectedDocuments()[0])"
+					ng-click="openOnScratch(selectedDocuments()[0])">
 				<i18n>workspace.external.open</i18n>
 			</button>
 			<button ng-if="showOpenLocation()" ng-click="openLocation()" class="cell">

--- a/workspace/src/main/resources/public/ts/controller.ts
+++ b/workspace/src/main/resources/public/ts/controller.ts
@@ -31,10 +31,10 @@ import {ScratchDelegate, ScratchDelegateScope} from "./delegates/scratch";
 
 
 declare var ENABLE_LOOL: boolean;
-declare var SCRATCH_URL: string;
+declare var ENABLE_SCRATCH: boolean;
 export interface WorkspaceScope extends RevisionDelegateScope, NavigationDelegateScope, TreeDelegateScope, ActionDelegateScope, CommentDelegateScope, DragDelegateScope, SearchDelegateScope, KeyboardDelegateScope, LoolDelegateScope, ScratchDelegateScope {
 	ENABLE_LOOL: boolean;
-	SCRATCH_URL: string;
+	ENABLE_SCRATCH: boolean;
 	documentList:models.DocumentsListModel;
 	documentListSorted:models.DocumentsListModel;
 	//new
@@ -156,9 +156,9 @@ export let workspaceController = ng.controller('Workspace', ['$scope', '$rootSco
 	RevisionDelegate($scope);
 	KeyboardDelegate($scope);
 	ENABLE_LOOL && LoolDelegate($scope, $route);
-	SCRATCH_URL && ScratchDelegate($scope, $route);
+	ENABLE_SCRATCH && ScratchDelegate($scope, $route);
 	$scope.ENABLE_LOOL = ENABLE_LOOL;
-	$scope.SCRATCH_URL = SCRATCH_URL;
+	$scope.ENABLE_SCRATCH = ENABLE_SCRATCH;
 
 	/**
 	 * INIT

--- a/workspace/src/main/resources/public/ts/delegates/scratch.ts
+++ b/workspace/src/main/resources/public/ts/delegates/scratch.ts
@@ -1,7 +1,7 @@
 export interface ScratchDelegateScope {
     onInit(cab: () => void);
     canBeOpenOnScratch({metadata}): boolean;
-    openOnScratch(file,scratch_url): void;
+    openOnScratch(file): void;
 }
 
 export function ScratchDelegate($scope: ScratchDelegateScope, $route) {
@@ -9,8 +9,8 @@ export function ScratchDelegate($scope: ScratchDelegateScope, $route) {
         $scope.canBeOpenOnScratch = ({metadata}) => {
             return ["sb","sb2","sb3"].includes(metadata.extension) && metadata["content-type"] === "application/octet-stream";
         };
-        $scope.openOnScratch = (file,scratch_url) => {
-            window.open(`${scratch_url}/workspace/document/base64/${file._id}`);
+        $scope.openOnScratch = (file) => {
+            window.open(`/scratch/open?ent_id=${file._id}`);
         }
     });
 }

--- a/workspace/src/main/resources/public/ts/directives/fileViewer.ts
+++ b/workspace/src/main/resources/public/ts/directives/fileViewer.ts
@@ -4,7 +4,7 @@ import { workspaceService, models } from "../services";
 import { CsvDelegate, CsvFile, CsvController } from './csvViewer';
 import { TxtDelegate, TxtController, TxtFile } from './txtViewer';
 declare var ENABLE_LOOL: boolean;
-declare var SCRATCH_URL: string;
+declare var ENABLE_SCRATCH: boolean;
 
 
 interface FileViewerScope {
@@ -181,7 +181,7 @@ export const fileViewer = ng.directive('fileViewer', ['$sce', ($sce) => {
 			}
 
 			scope.openOnScratch = () => {
-				SCRATCH_URL && window.open(`${SCRATCH_URL}/workspace/document/base64/${scope.ngModel._id}`);
+				ENABLE_SCRATCH && window.open(`/scratch/open?ent_id=${scope.ngModel._id}`);
 			}
 
 			scope.canEditInLool = () => {
@@ -191,7 +191,7 @@ export const fileViewer = ng.directive('fileViewer', ['$sce', ($sce) => {
 			}
 
 			scope.canEditInScratch = () => {
-				return SCRATCH_URL &&
+				return ENABLE_SCRATCH &&
 					["sb","sb2","sb3"].includes(scope.ngModel.metadata.extension) &&
 					scope.ngModel.metadata["content-type"] === "application/octet-stream";
 			}

--- a/workspace/src/main/resources/view-src/workspace.html
+++ b/workspace/src/main/resources/view-src/workspace.html
@@ -13,7 +13,7 @@
 	<script type="text/javascript" src="/workspace/public/dist/application.js"></script>
 	<script type="text/javascript">
 		var ENABLE_LOOL= {{enableLool}};
-		var SCRATCH_URL= "{{scratchUrl}}";
+		var ENABLE_SCRATCH= {{enableScratch}};
 		var LAZY_MODE = {{lazyMode}}
 		var CACHE_DOC_TTL_SEC = {{cacheDocTTl}}
 		var CACHE_FOLDER_TTL_SEC = {{cacheFolderTtl}}


### PR DESCRIPTION
Bonjour,

Nous avons besoin de livrer un correctif pour le connecteur scratch dans l'espace documentaire. 
Cela permettrait de d'abord passer par le nouveau module scratch-connector et de gérer le lien entre l'espace documentaire et l'application Scratch. Ce nouveau module scratch-connecteur apporte une grande couche de sécurité pour les échanges entre la plateforme ENT et l'application Scratch.
Cette version ne présente pas de risque.
Le seul impact sera de modifier la conf du module workspace et mettre :
"enable-scratch" à la place de "scratch-url"

Elle a été testé et validé.