### PR TITLE
feat(saml): #DRIV-33 add extra security authNRequest to avoid NPE

### DIFF
--- a/auth/src/main/java/org/entcore/auth/security/SamlValidator.java
+++ b/auth/src/main/java/org/entcore/auth/security/SamlValidator.java
@@ -509,7 +509,7 @@ public class SamlValidator extends BusModBase implements Handler<Message<JsonObj
 		response.setStatus(status);
 		response.setDestination(destination);
 		response.getAssertions().add(assertion);
-		if (!authNRequestId.isEmpty()) {
+		if (authNRequestId != null && !authNRequestId.isEmpty()) {
 			response.setInResponseTo(authNRequestId);
 		}
 		return response;


### PR DESCRIPTION
Suite à la PR https://github.com/opendigitaleducation/entcore/pull/274 et quelques échanges avec @dbreyton :

Cette PR a pour but de sécuriser le String afin d'éviter une NPE dans le cas où null serait mis à la place d'une chaîne vide