### PR TITLE
feat(access right):Check if the user has the right to go in riot

### DIFF
--- a/auth/src/main/java/org/entcore/auth/security/SamlValidator.java
+++ b/auth/src/main/java/org/entcore/auth/security/SamlValidator.java
@@ -658,7 +658,7 @@ public class SamlValidator extends BusModBase implements Handler<Message<JsonObj
 				handler.handle(new Either.Left<String, JsonArray>("Service Providor ID is null or empty"));
 			} else {
 				SamlServiceProvider sp = spFactory.serviceProvider(SPid);
-				sp.generate(eb, userId, host, handler);
+				sp.generate(eb, userId, host, SPid, handler);
 			}
 		}
 	}

--- a/auth/src/main/java/org/entcore/auth/services/SamlServiceProvider.java
+++ b/auth/src/main/java/org/entcore/auth/services/SamlServiceProvider.java
@@ -29,6 +29,7 @@ public interface SamlServiceProvider {
 
 	void execute(Assertion assertion, Handler<Either<String, Object>> handler);
 
-	void generate(EventBus eb, String userId, String host, Handler<Either<String, io.vertx.core.json.JsonArray>> handler);
+	void generate(EventBus eb, String userId, String host, String serviceProviderEntityId,
+				  Handler<Either<String, io.vertx.core.json.JsonArray>> handler);
 
 }

--- a/auth/src/main/java/org/entcore/auth/services/impl/AbstractSSOProvider.java
+++ b/auth/src/main/java/org/entcore/auth/services/impl/AbstractSSOProvider.java
@@ -59,7 +59,7 @@ public abstract class AbstractSSOProvider implements SamlServiceProvider {
 		return true;
 	}
 
-	public void generate(EventBus eb, String userId, String host, Handler<Either<String, io.vertx.core.json.JsonArray>> handler) {
+	public void generate(EventBus eb, String userId, String host, String serviceProviderEntityId, Handler<Either<String, io.vertx.core.json.JsonArray>> handler) {
 		handler.handle(new Either.Left<String, io.vertx.core.json.JsonArray>("Override is required on generate function in AbstractSSOProvider"));
 	}
 

--- a/auth/src/main/java/org/entcore/auth/services/impl/SSOCarl.java
+++ b/auth/src/main/java/org/entcore/auth/services/impl/SSOCarl.java
@@ -11,7 +11,7 @@ import org.opensaml.saml2.core.Assertion;
 
 public class SSOCarl extends AbstractSSOProvider {
     @Override
-    public void generate(EventBus eb, String userId, String host, Handler<Either<String, JsonArray>> handler) {
+    public void generate(EventBus eb, String userId, String host, String serviceProviderEntityId, Handler<Either<String, JsonArray>> handler) {
         String query = "MATCH (u:User {id:{userId}}) RETURN u.login as login";
         Neo4j.getInstance().execute(query, new JsonObject().put("userId", userId), Neo4jResult.validUniqueResultHandler(evt -> {
             if (evt.isLeft()) {

--- a/auth/src/main/java/org/entcore/auth/services/impl/SSOGar.java
+++ b/auth/src/main/java/org/entcore/auth/services/impl/SSOGar.java
@@ -18,7 +18,7 @@ import static fr.wseduc.webutils.http.response.DefaultResponseHandler.defaultRes
 public class SSOGar extends AbstractSSOProvider {
 
     @Override
-    public void generate(EventBus eb, String userId, String host, Handler<Either<String, JsonArray>> handler) {
+    public void generate(EventBus eb, String userId, String host, String serviceProviderEntityId, Handler<Either<String, JsonArray>> handler) {
 
         JsonObject sendTOMediacentre = new JsonObject().put("action", "getConfig");
 

--- a/auth/src/main/java/org/entcore/auth/services/impl/SSOPeertube.java
+++ b/auth/src/main/java/org/entcore/auth/services/impl/SSOPeertube.java
@@ -11,7 +11,7 @@ import org.opensaml.saml2.core.Assertion;
 
 public class SSOPeertube extends AbstractSSOProvider {
     @Override
-    public void generate(EventBus eb, String userId, String host, Handler<Either<String, JsonArray>> handler) {
+    public void generate(EventBus eb, String userId, String host, String serviceProviderEntityId, Handler<Either<String, JsonArray>> handler) {
         String query = "MATCH (u:User {id:{userId}}) RETURN u.id as id, u.login as login, u.displayName as displayName, u.email as email, u.externalId as externalId";
         Neo4j.getInstance().execute(query, new JsonObject().put("userId", userId), Neo4jResult.validUniqueResultHandler(evt -> {
             if (evt.isLeft()) {


### PR DESCRIPTION
Bonjour,

Nous avons besoin de vérifier que l'utilisateur possède bien le connecteur Riot. Nous avons donc rajouter une condition dans la requête Neo4j du samlMatrix afin de vérifier si c'est le cas sinon il est renvoyé vers la plateforme car il n'a pas les droits.

Cette évolution a un impact sur l'accès au service Riot par SAML (l'utilisateur doit avoir le connecteur qui lui est attribué), mais n'a aucun impact/risque pour les autres connexions SAML.