### PR TITLE
MZI-29 - create function ReadStreamFile to have a ReadStream<Buffer> when getting document from workspace

### DIFF
--- a/common/src/main/java/org/entcore/common/storage/Storage.java
+++ b/common/src/main/java/org/entcore/common/storage/Storage.java
@@ -19,6 +19,7 @@
 
 package org.entcore.common.storage;
 
+import io.vertx.core.streams.ReadStream;
 import org.entcore.common.validation.FileValidator;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -46,6 +47,8 @@ public interface Storage {
 	void writeFsFile(String id, String filename, Handler<JsonObject> handler);
 
 	void readFile(String id, Handler<Buffer> handler);
+
+	void readStreamFile(String id, Handler<ReadStream<Buffer>> handler);
 
 	void sendFile(String id, String downloadName, HttpServerRequest request, boolean inline, JsonObject metadata);
 

--- a/common/src/main/java/org/entcore/common/storage/impl/FileStorage.java
+++ b/common/src/main/java/org/entcore/common/storage/impl/FileStorage.java
@@ -23,6 +23,8 @@ import fr.wseduc.swift.utils.FileUtils;
 import fr.wseduc.webutils.DefaultAsyncResult;
 import fr.wseduc.webutils.http.ETag;
 import fr.wseduc.webutils.http.Renders;
+import io.vertx.core.file.OpenOptions;
+import io.vertx.core.streams.ReadStream;
 import org.entcore.common.storage.AntivirusClient;
 import org.entcore.common.storage.BucketStats;
 import org.entcore.common.storage.FileStats;
@@ -82,6 +84,7 @@ public class FileStorage implements Storage {
 			this.basePaths.add(((!basePath.endsWith("/")) ? basePath + "/" : basePath));
 		}
 		this.lastBucketIdx = this.basePaths.size() - 1;
+
 	}
 
 	@Override
@@ -353,6 +356,34 @@ public class FileStorage implements Storage {
 		});
 	}
 
+	/**
+	 * Allows the user to get a document from their workspace
+	 * Same as readFile but returns a ReadStream<Buffer> rather than a buffer
+	 * @param id : id of the attachment
+	 * @param handler
+	 */
+	@Override
+	public void readStreamFile(String id, final Handler<ReadStream<Buffer>> handler) {
+		getReadPath(id, ar -> {
+			if (ar.succeeded()) {
+				fs.open(ar.result(), new OpenOptions(), fileRes -> {
+					if (fileRes.succeeded()) {
+						ReadStream<Buffer> fileStream = fileRes.result();
+						handler.handle(fileStream);
+					} else {
+						handler.handle(null);
+						log.error(fileRes.cause().getMessage(), fileRes.cause());
+					}
+				});
+			} else {
+				handler.handle(null);
+				log.warn(ar.cause().getMessage(), ar.cause());
+			}
+		});
+	}
+
+
+
 	@Override
 	public void sendFile(String id, String downloadName, HttpServerRequest request, boolean inline, JsonObject metadata) {
 		sendFile(id, downloadName, request, inline, metadata, null);
@@ -413,6 +444,7 @@ public class FileStorage implements Storage {
 			}
 		});
 	}
+
 
 	@Override
 	public void removeFile(String id, final Handler<JsonObject> handler) {

--- a/common/src/main/java/org/entcore/common/storage/impl/GridfsStorage.java
+++ b/common/src/main/java/org/entcore/common/storage/impl/GridfsStorage.java
@@ -26,6 +26,8 @@ import fr.wseduc.webutils.DefaultAsyncResult;
 import fr.wseduc.webutils.http.ETag;
 import io.vertx.core.file.OpenOptions;
 import io.vertx.core.http.HttpServerFileUpload;
+import io.vertx.core.streams.ReadStream;
+import org.apache.commons.lang3.NotImplementedException;
 import org.entcore.common.storage.BucketStats;
 import org.entcore.common.storage.FileStats;
 import org.entcore.common.storage.Storage;
@@ -333,6 +335,11 @@ public class GridfsStorage implements Storage {
 			}
 		});
 		}
+	}
+
+	@Override
+	public void readStreamFile(String id, Handler<ReadStream<Buffer>> handler) {
+		throw new NotImplementedException("Error. Not Implemented exception");
 	}
 
 	@Override

--- a/common/src/main/java/org/entcore/common/storage/impl/SwiftStorage.java
+++ b/common/src/main/java/org/entcore/common/storage/impl/SwiftStorage.java
@@ -22,6 +22,8 @@ package org.entcore.common.storage.impl;
 import fr.wseduc.swift.SwiftClient;
 import fr.wseduc.swift.storage.StorageObject;
 import fr.wseduc.webutils.DefaultAsyncResult;
+import io.vertx.core.streams.ReadStream;
+import org.apache.commons.lang3.NotImplementedException;
 import org.entcore.common.storage.BucketStats;
 import org.entcore.common.storage.FileStats;
 import org.entcore.common.storage.Storage;
@@ -138,6 +140,11 @@ public class SwiftStorage implements Storage {
 				}
 			}
 		});
+	}
+
+	@Override
+	public void readStreamFile(String id, Handler<ReadStream<Buffer>> handler) {
+		throw new NotImplementedException("Error. Not Implemented exception");
 	}
 
 	@Override


### PR DESCRIPTION
Nouvelle fonction ReadStreamFile à partir de la fonction ReadFile pour récupérer un `ReadStream<Buffer>` et non un Buffer
On utilise un webClient et non un HttpRequest dans le module zimbra, en utilisant un sendStream

- cf la PR dans zimbra : https://github.com/OPEN-ENT-NG/zimbra-connector/pull/25
- cf la documentation de WebClient :  https://vertx.io/docs/vertx-web-client/java/
