### PR TITLE
 feat(nextcloud): #DRIV-34 add nextcloud view and config to workspace

### DIFF
--- a/workspace/deployment/workspace/conf.j2
+++ b/workspace/deployment/workspace/conf.j2
@@ -22,6 +22,7 @@
 		{% if scratchUrl is defined %} "enable-scratch": true, {% endif %}
         {% if loolVersion is defined %}"enable-lool": true,{% endif %}
         {% if geogebraVersion is defined %}"enable-geogebra": true,{% endif %}
+        {% if nextcloudVersion is defined %}"enable-nextcloud": true,{% endif %}
         "publicConf": {
             "lazy-mode": {{ workspaceLazyMode|default('true') }},
             "ttl-documents":{{ workspaceTtlDoc|default('180') }},

--- a/workspace/src/main/java/org/entcore/workspace/controllers/WorkspaceController.java
+++ b/workspace/src/main/java/org/entcore/workspace/controllers/WorkspaceController.java
@@ -1707,6 +1707,7 @@ public class WorkspaceController extends BaseController {
 		context.put("enableLool", config.getBoolean("enable-lool", false));
 		context.put("enableScratch", config.getBoolean("enable-scratch", false));
 		context.put("enableGeogebra", config.getBoolean("enable-geogebra", false));
+		context.put("enableNextcloud", config.getBoolean("enable-nextcloud", false));
 		context.put("lazyMode", config.getJsonObject("publicConf", new JsonObject()).getBoolean("lazy-mode", false));
 		context.put("cacheDocTTl", config.getJsonObject("publicConf", new JsonObject()).getInteger("ttl-documents", -1));
 		context.put("cacheFolderTtl", config.getJsonObject("publicConf", new JsonObject()).getInteger("ttl-folders", -1));

--- a/workspace/src/main/resources/public/ts/controller.ts
+++ b/workspace/src/main/resources/public/ts/controller.ts
@@ -33,11 +33,13 @@ import {GeogebraDelegate, GeogebraDelegateScope} from "./delegates/geogebra";
 
 declare var ENABLE_LOOL: boolean;
 declare var ENABLE_SCRATCH: boolean;
+declare var ENABLE_NEXTCLOUD: boolean;
 declare var ENABLE_GGB: boolean;
 export interface WorkspaceScope extends RevisionDelegateScope, NavigationDelegateScope, TreeDelegateScope, ActionDelegateScope, CommentDelegateScope, DragDelegateScope, SearchDelegateScope, KeyboardDelegateScope, LoolDelegateScope, ScratchDelegateScope, GeogebraDelegateScope {
 	ENABLE_LOOL: boolean;
 	ENABLE_SCRATCH: boolean;
 	ENABLE_GGB: boolean;
+	ENABLE_NEXTCLOUD: boolean;
 	documentList:models.DocumentsListModel;
 	documentListSorted:models.DocumentsListModel;
 	//new
@@ -164,6 +166,7 @@ export let workspaceController = ng.controller('Workspace', ['$scope', '$rootSco
 	$scope.ENABLE_LOOL = ENABLE_LOOL;
 	$scope.ENABLE_SCRATCH = ENABLE_SCRATCH;
 	$scope.ENABLE_GGB = ENABLE_GGB;
+	$scope.ENABLE_NEXTCLOUD = ENABLE_NEXTCLOUD;
 
 	/**
 	 * INIT

--- a/workspace/src/main/resources/view-src/workspace.html
+++ b/workspace/src/main/resources/view-src/workspace.html
@@ -15,6 +15,7 @@
 		var ENABLE_LOOL= {{enableLool}};
 		var ENABLE_SCRATCH= {{enableScratch}};
 		var ENABLE_GGB= {{enableGeogebra}};
+		var ENABLE_NEXTCLOUD= {{enableNextcloud}};
 		var LAZY_MODE = {{lazyMode}}
 		var CACHE_DOC_TTL_SEC = {{cacheDocTTl}}
 		var CACHE_FOLDER_TTL_SEC = {{cacheFolderTtl}}
@@ -97,6 +98,11 @@
 				</div>
 				<nav class="vertical nav-droppable mobile-navigation top-spacing-twice-1d" side-nav>
 					<div data-ng-repeat="folder in wrapperTrees" data-ng-include="'folder-content'" class="folder-tree maxheight-minus350 maxheight-minus370-1d overflowx-hd maxheight-minus200-mobile minheight-100"></div>
+					<!-- nextcloud sniplet folder tree -->
+					<div ng-if="ENABLE_NEXTCLOUD">
+						<sniplet template="nextcloud-folder/workspace-nextcloud-folder" application="nextcloud"></sniplet>
+					</div>
+
 					<a ng-click="openNewFolderView()" ng-if="canCreateNewFolder()" class="classic-link centered-bloc-text vertical-spacing-twice-1d"><i18n>folder.new</i18n></a>
 					<a ng-click="openNewFolderView()" ng-if="canCreateNewFolderShared()" class="classic-link centered-bloc-text vertical-spacing-twice-1d"><i18n>folder.new.shared</i18n></a>
 					<a ng-click="confirmDelete()" ng-if="canEmptyTrash()" ng-hide="isTrashEmpty()" class="classic-link centered-bloc-text vertical-spacing-twice-1d"><i18n>workspace.empty.trash</i18n></a>


### PR DESCRIPTION
## Description

Cette feature a pour but de rajouter le sniplet de nextcloud afin de rendre l'arborescence de nextcloud accessible dans l'espace documentaire : 

![workspaceNextcloud](https://user-images.githubusercontent.com/10532050/172638450-e30a4557-c021-4568-8d38-ccca90a025eb.PNG)

On injecte le sniplet :
```
<div ng-if="ENABLE_NEXTCLOUD">
	<sniplet template="nextcloud-folder/workspace-nextcloud-folder" application="nextcloud"></sniplet>
</div>
```

Celui-ci fera l'affichage (en utilisant le composant `folder-tree`) et adaptera le contenu à droite sur l'affichages des icons/documents

## Configuration

A ajouter dans la configuration de workspace : 

<pre>
{
    ...
    "name": "org.entcore~workspace~...",
    "config": {
        ...
        "enable-nextcloud": true,
        ...
    }
    ...
}
</pre>
