### PR TITLE
refactor(node-pdf): add log status message on error

### DIFF
--- a/common/src/main/java/org/entcore/common/pdf/NodePdfClient.java
+++ b/common/src/main/java/org/entcore/common/pdf/NodePdfClient.java
@@ -174,7 +174,8 @@ public class NodePdfClient implements PdfGenerator {
 					handler.handle(new DefaultAsyncResult<>(pdf));
 				});
 			} else {
-				log.error("[responseHandler] Invalid status code when receive pdf response with status: "+ res.statusCode());
+				log.error("[responseHandler] Invalid status code when receive pdf response with status: " +
+						res.statusCode() + " , message: " + res.statusMessage());
 				handler.handle(new DefaultAsyncResult<>(new PdfException("invalid.pdf.response")));
 			}
 		};


### PR DESCRIPTION
# Description

Ajout de `statusMessage()` dans les messages de logs d'erreur pour avoir plus d'information sur les erreurs catché : 
https://github.com/opendigitaleducation/node-pdf-generator/blob/master/controllers/index.js#L25