### PR TITLE
refactor(neo4j-rest): add cause message on error

### DIFF
--- a/common/src/main/java/org/entcore/common/neo4j/Neo4jRest.java
+++ b/common/src/main/java/org/entcore/common/neo4j/Neo4jRest.java
@@ -463,7 +463,7 @@ public class Neo4jRest implements GraphDatabase {
 		final String b = Json.encode(body);
 
 		req.exceptionHandler(event -> {
-			logger.error("Neo4j error in request : " + path + " - " + b, event);
+			logger.error("Neo4j error in request : " + path + " - " + b + ": " + event.getMessage(), event);
 			if (ignoreEmptyStateError && EMPTY_STATEMENTS_STRING.equals(b) && retry > 0) {
 				logger.warn("Retry sendRequest with empty statements.");
 				try {


### PR DESCRIPTION
# Description

Actuellement quand nous avons une erreur, voici les infos qu'on a : 
`[vert.x-worker-thread-114] 2022-08-01T17:07:17.696+02:00 SEVERE [org.entcore.common.neo4j.Neo4jRest]  Neo4j error in request : /cypher - {"query":"MATCH (s:Structure {id:{structureId}})<-[:BELONGS]-(c:Class)<-[:DEPENDS]-(:ProfileGroup)<-[:IN]-(u:User {id: {studentId}}) RETURN (u.lastName + ' ' + u.firstName) as name, collect(c.name) as className, collect(c.id) as classIds","params":{"structureId":"323f3ebc-0a12-42e1-8ae2-7aabee32a9de","studentId":"c2a01c71-1892-4d05-916e-fa0b70bfe722"}}
`
Nous n'avons pas d'information sur `event` qui est mis en 2eme paramètre dans `logger.error`.

On ajoute `event.getMessage()` dans les messages de logs d'erreur pour avoir plus d'information sur les erreurs du neo4j rest.

