### PR TITLE
[ODE] communication : les membres d'une liste de diffusion doivent rester non-visibles

### DIFF
--- a/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
+++ b/communication/src/main/java/org/entcore/communication/services/impl/DefaultCommunicationService.java
@@ -160,6 +160,9 @@ public class DefaultCommunicationService implements CommunicationService {
 		String relationship;
 		String set;
 		switch (direction) {
+			case NONE:
+				handler.handle(new Either.Right<>(new JsonObject().put("number", 0)));
+				return;	// Nothing more to do.
 			case INCOMING:
 				relationship = "g<-[r:COMMUNIQUE]-(u:User) ";
 				set = "SET g.users = CASE WHEN g.users = 'INCOMING' THEN null ELSE 'OUTGOING' END ";


### PR DESCRIPTION
Ticket d'origine [redmine 54128](https://support.web-education.net/issues/54128)
Suivi team web [JIRA WB-644](https://opendigitaleducation.atlassian.net/browse/WB-644)

Une liste de diffusion est un groupe de type 'ManualGroup' et de sous-type 'BroadcastGroup', ses membres (nombreux) ne sont pas sensés être visibles même si on peut communiquer vers elle.

Problème : le ticket redmine montre que les membres sont visibles. Confirmé par reproduction locale, voir ticket JIRA.

Le problème de visibilité provient de l'utilisation non-prévue de `DefaultCommunicationService.addLinkWithUsers()` avec la direction NONE, ayant un effet de bord : par défaut, c'est la direction "BOTH" qui se retrouvait appliquée.

Le correctif a consisté à : 
- ne pas appeler cette méthode si le besoin n'est pas là,
- gérer le cas non-prévu pour éviter que le problème se reproduise,
- appliquer de la programmation défensive face à une NPE potentielle (non-lié au problème mais vu lors du développement)