### PR TITLE
fix(saml): add extra callback redirect when logged in

### DIFF
--- a/auth/src/main/java/org/entcore/auth/controllers/AuthController.java
+++ b/auth/src/main/java/org/entcore/auth/controllers/AuthController.java
@@ -559,7 +559,7 @@ public class AuthController extends BaseController {
 						callBack.append(config.getJsonObject("authenticationServer").getString("loginCallback"));
 					}
 				} else {
-					callBack.append(config.getJsonObject("authenticationServer").getString("loginCallback"));
+					checkAndAppendCookieCallback(callBack, request);
 				}
 				DataHandler data = oauthDataFactory.create(new HttpServerRequestAdapter(request));
 				final String login = request.formAttributes().get("email");
@@ -641,6 +641,23 @@ public class AuthController extends BaseController {
 
 			}
 		});
+	}
+
+	/**
+	 * This method occurs when there is no "callBack" param in request {@link io.vertx.core.MultiMap}
+	 * We check if we have a "callback" in a getSignedCookie {@link CookieHelper} to assign to our callBack {@link StringBuilder}
+	 *
+	 * @param callBack  String builder containing callback for redirect option... {@link StringBuilder}
+	 * @param request 	Request where we attempt to fetch our "callback" {@link CookieHelper} {@link HttpServerRequest}
+	 */
+	private void checkAndAppendCookieCallback(StringBuilder callBack, HttpServerRequest request) {
+		final String callbackCookie = CookieHelper.getInstance().getSigned("callback", request);
+		if (isNotEmpty(callbackCookie)) {
+			CookieHelper.getInstance().setSigned("callback", "", 0, request);
+			callBack.append(callbackCookie);
+			return;
+		}
+		callBack.append(config.getJsonObject("authenticationServer").getString("loginCallback"));
 	}
 
 	private void handleGetUserId(String login, String userId, HttpServerRequest request, String callback) {


### PR DESCRIPTION
Sur les environnement redirigeant vers un site vitrine pour réaliser l'authentification (Nouvelle Aquitaine, ou  Normandie par exemple).
## Description

La cinématique SSO "SP provided" de nextcloud (et les autres services dans ce mode) permet de le contexte initial au niveau du site vitrine, ce qui empêche de ramener l'utilisateur sur le service initialement souhaité après l'authentification dans un des  IDP accessibles depuis le site vitrine.

Cette cinématique est notamment utilisée depuis l'application mobile.

La cinématique SAML SSO SP provided permet de résoudre cette problématique par l'usage d'un paramètre plus au moins opaque transmis entre les différents acteurs : RelayState. Ce paramètre transmis sans modification, doit permettre au SP de rediriger l'utilisateur sur la ressource initialement demandée une fois le circuit SSO terminé.

Dans notre cas le site vitrine vient interrompre le mécanisme SSO, ne  permettant pas de profiter de ce mécanisme prévu au protocole.

Dans openENTNG, un autre mécanisme existe. Un cookie de session, signé est créé : CallbackCookie.

Ce cookie est utilisé pour rediriger l'utilisateur  vers l'url qui ait stocké à l'instar de la redirection par défaut ("timeline").

Nous proposons d'utiliser ce mécanisme appuyé sur le cookie CallbackCookie, sur la route auth/login.

## Test

Il faut simuler la redirection : 

* Dans le module "Auth", il faut modifier le loginUri et mettre une url pour déclencher une redirection autre que l'host.
* Depuis un service externe, on fait déclencher l'endpoint `auth/saml/redirect/sso/` qui, avec votre loginUri, vous redirigera dans une URL que vous avez configuré
* Dans un nouvel onglet, aller sur $host/login/auth et puis se connecter, vous devriez normalement pouvoir accéder à votre service externe

