### PR TITLE
feat(i18n): Add "formulaire" line in Portal i18n

### DIFF
--- a/portal/src/main/resources/i18n/fr.json
+++ b/portal/src/main/resources/i18n/fr.json
@@ -345,6 +345,7 @@
   "finish": "Terminer",
   "folderpicker.folder.edit": "Créer un nouveau dossier",
   "form": "Formulaire",
+  "formulaire": "Formulaire",
   "forum": "Forum",
   "fr_FR": "Français",
   "friday": "vendredi",


### PR DESCRIPTION
Bonjour,

Comme vu avec @ODE-vpeiro pour plusieurs usage tels que l'import/export via le module Archive nous avons besoin que Formulaire soit dans le i18n du Portal (la clé "form" existe mais pour les usages qui se basent automatiquement sur le nom du module cette clé n'est pas la bonne et aucune correspondance correcte n'est actuellement existante)
Impacts/Risques : 0

Merci d'avance,