### PR TITLE
feat(buffer-stream): #MZI-90 add write buffer methods in stream asynchronous

### DIFF
--- a/common/src/main/java/org/entcore/common/storage/Storage.java
+++ b/common/src/main/java/org/entcore/common/storage/Storage.java
@@ -19,6 +19,7 @@
 
 package org.entcore.common.storage;
 
+import io.vertx.core.Future;
 import io.vertx.core.streams.ReadStream;
 import org.entcore.common.validation.FileValidator;
 import io.vertx.core.AsyncResult;
@@ -41,6 +42,27 @@ public interface Storage {
 	void writeBuffer(String id, Buffer buff, String contentType, String filename, Handler<JsonObject> handler);
 
 	void writeBuffer(String basePath, String id, Buffer buff, String contentType, String filename, Handler<JsonObject> handler);
+
+	/**
+	 * write file in file system with buffer stream
+	 *
+	 * @param bufferReadStream	Buffer in read stream
+	 * @param contentType		content type data of the read buffer
+	 * @param filename			filename
+	 * @return Future {@link Future <JsonObject>} containing "_id" which corresponds to the written file identifier and its "metadata" content
+	 */
+	Future<JsonObject> writeBufferStream(ReadStream<Buffer> bufferReadStream, String contentType, String filename);
+
+	/**
+	 * write file in file system with buffer stream
+	 *
+	 * @param id				identifier chosen for the file
+	 * @param bufferReadStream	Buffer in read stream
+	 * @param contentType		content type data of the read buffer
+	 * @param filename			filename
+	 * @return Future {@link Future <JsonObject>} containing "_id" which corresponds to the written file identifier and its "metadata" content
+	 */
+	Future<JsonObject> writeBufferStream(String id, ReadStream<Buffer> bufferReadStream, String contentType, String filename);
 
 	void writeFsFile(String filename, Handler<JsonObject> handler);
 
@@ -76,6 +98,8 @@ public interface Storage {
 	String getProtocol();
 
 	String getBucket();
+
+	void scanFile(String path);
 
 	void stats(Handler<AsyncResult<BucketStats>> handler);
 

--- a/common/src/main/java/org/entcore/common/storage/impl/GridfsStorage.java
+++ b/common/src/main/java/org/entcore/common/storage/impl/GridfsStorage.java
@@ -24,6 +24,7 @@ import fr.wseduc.mongodb.MongoDb;
 import fr.wseduc.mongodb.MongoQueryBuilder;
 import fr.wseduc.webutils.DefaultAsyncResult;
 import fr.wseduc.webutils.http.ETag;
+import io.vertx.core.Future;
 import io.vertx.core.file.OpenOptions;
 import io.vertx.core.http.HttpServerFileUpload;
 import io.vertx.core.streams.ReadStream;
@@ -146,6 +147,16 @@ public class GridfsStorage implements Storage {
 	@Override
 	public void writeBuffer(String basePath, String id, Buffer buff, String contentType, String filename, Handler<JsonObject> handler) {
 		writeBuffer(id, buff, null, contentType, filename, null, handler);
+	}
+
+	@Override
+	public Future<JsonObject> writeBufferStream(ReadStream<Buffer> bufferReadStream, String contentType, String filename) {
+		return writeBufferStream(null, bufferReadStream, contentType, filename);
+	}
+
+	@Override
+	public Future<JsonObject> writeBufferStream(String id, ReadStream<Buffer> bufferReadStream, String contentType, String filename) {
+		throw new NotImplementedException("writeBufferStream not implemented");
 	}
 
 	private void writeBuffer(String id, Buffer buff, Long maxSize, String contentType, String filename, final JsonObject m, Handler<JsonObject> handler) {
@@ -333,7 +344,7 @@ public class GridfsStorage implements Storage {
 					handler.handle(null);
 				}
 			}
-		});
+			});
 		}
 	}
 
@@ -603,6 +614,11 @@ public class GridfsStorage implements Storage {
 	@Override
 	public String getBucket() {
 		return bucket;
+	}
+
+	@Override
+	public void scanFile(String path) {
+		throw new NotImplementedException("ScanFile not implemented");
 	}
 
 	@Override

--- a/common/src/main/java/org/entcore/common/storage/impl/SwiftStorage.java
+++ b/common/src/main/java/org/entcore/common/storage/impl/SwiftStorage.java
@@ -22,6 +22,7 @@ package org.entcore.common.storage.impl;
 import fr.wseduc.swift.SwiftClient;
 import fr.wseduc.swift.storage.StorageObject;
 import fr.wseduc.webutils.DefaultAsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.streams.ReadStream;
 import org.apache.commons.lang3.NotImplementedException;
 import org.entcore.common.storage.BucketStats;
@@ -97,6 +98,16 @@ public class SwiftStorage implements Storage {
 	public void writeBuffer(String basePath, String id, Buffer buff, String contentType, String filename, Handler<JsonObject> handler) {
 		StorageObject o = new StorageObject(id, buff, filename, contentType);
 		writeStorageObject(handler, o);
+	}
+
+	@Override
+	public Future<JsonObject> writeBufferStream(ReadStream<Buffer> bufferReadStream, String contentType, String filename) {
+		return writeBufferStream(null, bufferReadStream, contentType, filename);
+	}
+
+	@Override
+	public Future<JsonObject> writeBufferStream(String id, ReadStream<Buffer> bufferReadStream, String contentType, String filename) {
+		throw new NotImplementedException("writeBufferStream not implemented");
 	}
 
 	@Override
@@ -255,6 +266,11 @@ public class SwiftStorage implements Storage {
 	@Override
 	public String getBucket() {
 		return container;
+	}
+
+	@Override
+	public void scanFile(String path) {
+		throw new NotImplementedException("ScanFile not implemented");
 	}
 
 	@Override


### PR DESCRIPTION
## Contexte

Cette Pull Request permet de répondre au besoin du ticket Zimbra MZI-88/90 qui consiste à stocker un fichier directement dans l'espace documentaire en plus de pouvoir le télécharger sur son ordinateur.

On implémente une méthode qui reprend l'instruction de `writeBuffer` (création folder/fichier avec un id retourné …) pour faire du [write ](https://vertx.io/docs/apidocs/io/vertx/core/streams/WriteStream.html)[stream](https://vertx.io/docs/apidocs/io/vertx/core/streams/Pipe.html).

Exemple d'implémentation :  https://github.com/OPEN-ENT-NG/zimbra-connector/pull/32



