### PR TITLE
fix(directory): #WB-1501, leave edition mode while browing users in class settings app

### DIFF
--- a/directory/src/main/resources/public/ts/admin/delegates/userInfos.ts
+++ b/directory/src/main/resources/public/ts/admin/delegates/userInfos.ts
@@ -76,13 +76,28 @@ export async function UserInfosDelegate($scope: UserInfosDelegateScope) {
         }
         return school;
     }
+    /**
+    * Reset all modifications and flags that were started by the users.
+    *
+    **/
+    const resetModifications = () => {
+        $scope.temp.displayName = "";
+        $scope.showDisplayNameInput = false;
+        $scope.selectedUser.tempLoginAlias = "";
+        $scope.showLoginInput = false;
+        $scope.temp.email = "";
+        $scope.showEmailInput = false;
+        $scope.temp.homePhone = "";
+        $scope.showPhoneInput = false;
+        $scope.temp.mobile = "";
+        $scope.showMobileInput = false;
+    }
     const setSelectedUser = async (user: User) => {
         $scope.mottoShouldPublish = false;
-        $scope.showLoginInput = false;
-        $scope.showEmailInput = false;
         await user.open({ withChildren: true });
         $scope.selectedUser = user;
         $scope.selectedUser.picture = user.picture || user.avatarUri;
+        resetModifications();
         $scope.safeApply();
     }
     const selectFirstUser = async (user: User) => {


### PR DESCRIPTION
### Problème rencontré

Il est possible de modifier les informations sur le compte ADML car le champs est toujours modifiable en passant d’une fiche à l’autre

### Solution implémentée

À chaque changement d'utilisateur (dans la méthode `selectUser` donc), on :
- réinitialise toutes les données contenant les modifications potentielles effectuées par l'utilisateur sur l'utilisateur précédent
- on repasse à `false` tous les booléens indiquant que l'on est en cours d'édition

Le back n'a pas été modifié car certaines fonctionnalités de la console d'admin sont présentées en cohérence avec le comportement actuel du back.

### Tests effectués

Avec un utilisateur ayant accès au paramétrage de la classe j'ai :
- ouvert la fiche dudit utilisateur
- cliquer sur "modifier" au niveau du nom d'affichage
- cliquer sur "suivant" (affichage d'un ADML)
- constater que le champ "nom d'affichage" était bien repassé en mode affichage et que sa valeur était le nom d'affichage du nouvel utilisateur et qu'aucun bouton ne me permettait de modifier ce champ