### PR TITLE
chore(doc): pull requests templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/external_contribution.md
+++ b/.github/PULL_REQUEST_TEMPLATE/external_contribution.md
@@ -1,0 +1,57 @@
+# Description
+
+_Please include a summary of the changes and the related issue._
+
+## Fixes
+
+_(Enter here Jira or Redmine ticket(s) links)_
+
+## Type of change
+
+Please check options that are relevant.
+
+- [ ] Chore (PATCH)
+- [ ] Doc (PATCH)
+- [ ] Bug fix (PATCH)
+- [ ] New feature (MINOR)
+
+## Which packages changed?
+
+Please check the name of the package you changed
+
+- [ ] admin
+- [ ] app-registry
+- [ ] archive
+- [ ] auth
+- [ ] cas
+- [ ] common
+- [ ] communication
+- [ ] conversation
+- [ ] directory
+- [ ] feeder
+- [ ] infra
+- [ ] portal
+- [ ] session
+- [ ] test
+- [ ] tests
+- [ ] timeline
+- [ ] workspace
+
+## Tests
+
+1. Describe here the tests you performed
+2. Step by step
+3. With expected results
+
+# Checklist
+
+- [ ] I have rebased my commits on **dev** branch
+- [ ] My commits follow [Conventionnal Commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines
+- [ ] I have followed the [web contribution guide](https://opendigitaleducation.atlassian.net/wiki/spaces/PUBLIC/pages/3024126017/Ajout+d+une+fonctionnalit+ou+d+un+module+Web) and the [mobile contribution guide](https://opendigitaleducation.atlassian.net/wiki/spaces/PUBLIC/pages/3025961081/Ajout+d+une+fonctionnalit+Mobile)
+- [ ] I have create a code review ticket and assigned it to the inbox Integration
+- [ ] I have created or modified at least one automatic test covering the impacted functionality
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] I have checked the impacts on the library
+- [ ] I have checked the impacts on the change of year process
+- [ ] I have checked the compatibility with the mobile version
+- [ ] I have updated the reminder for the version including my modifications

--- a/.github/PULL_REQUEST_TEMPLATE/internal_contribution.md
+++ b/.github/PULL_REQUEST_TEMPLATE/internal_contribution.md
@@ -1,0 +1,54 @@
+# Description
+
+Please include a summary of the changes and the related issue.
+
+## Fixes
+
+(Enter here Jira or Redmine ticket(s) links)
+
+## Type of change
+
+Please check options that are relevant.
+
+- [ ] Chore (PATCH)
+- [ ] Doc (PATCH)
+- [ ] Bug fix (PATCH)
+- [ ] New feature (MINOR)
+
+## Which packages changed?
+
+Please check the name of the package you changed
+
+- [ ] admin
+- [ ] app-registry
+- [ ] archive
+- [ ] auth
+- [ ] cas
+- [ ] common
+- [ ] communication
+- [ ] conversation
+- [ ] directory
+- [ ] feeder
+- [ ] infra
+- [ ] portal
+- [ ] session
+- [ ] test
+- [ ] tests
+- [ ] timeline
+- [ ] workspace
+
+## Tests
+
+1. Describe here the tests you performed
+2. Step by step
+3. With expected results
+
+# Reminder
+
+- Security flaws (bros before security holes)
+- Performance impacts (think bulk !)
+- Unit tests were replayed
+- Unit tests were added and/or changed
+- I have updated the reminder for the version including my modifications
+
+- [ ] All done ! :smiley:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+PULL_REQUEST_TEMPLATE/internal_contribution.md


### PR DESCRIPTION
# Description

Voici une proposition de 2 templates de pull requests pour le projet entcore (aisément transposable aux autres modules).
Elle reprend pour partie le template déjà établie par Clément pour le front avec des spécifités liées au back.

Je fais la PR sur master car il faut que les templates soient sur la branche par défaut (master) pour être pris en compte.

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [x] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)
