### PR TITLE
#WB-1652, rollback vertx upgrade (3.9.14 -> 3.9.5)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -44,5 +44,5 @@ mongoVersion=3.12.8
 modPostgresVersion=1.3.1
 modMongoVersion=3.2.0
 testContainerVersion=1.17.1
-micrometerMetricsVersion=3.9.14
+micrometerMetricsVersion=3.9.5
 micrometerPrometheusVersion=1.1.0


### PR DESCRIPTION
# Description 

The upgrade to 3.9.14 seems to come with some regressions in form handling and other features not fully identified that prevent the ENT from operating correctly so the upgrade has been postponed
