### PR TITLE
[ODE] fix(session): #WB-1670, do not set oneSessionId cookie for oauth authenticated users

### DIFF
--- a/common/src/main/java/org/entcore/common/http/filter/AppOAuthResourceProvider.java
+++ b/common/src/main/java/org/entcore/common/http/filter/AppOAuthResourceProvider.java
@@ -20,14 +20,17 @@
 package org.entcore.common.http.filter;
 
 import fr.wseduc.webutils.DefaultAsyncResult;
+import static fr.wseduc.webutils.Utils.isNotEmpty;
 import fr.wseduc.webutils.security.SecureHttpServerRequest;
 import fr.wseduc.webutils.security.oauth.DefaultOAuthResourceProvider;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import static org.entcore.common.aggregation.MongoConstants.TRACE_TYPE_OAUTH;
 import org.entcore.common.cache.CacheService;
 import org.entcore.common.events.EventStore;
 import org.entcore.common.events.EventStoreFactory;
@@ -39,9 +42,6 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static fr.wseduc.webutils.Utils.isNotEmpty;
-import static org.entcore.common.aggregation.MongoConstants.TRACE_TYPE_OAUTH;
 
 public class AppOAuthResourceProvider extends DefaultOAuthResourceProvider {
 	private static Logger log = LoggerFactory.getLogger(AppOAuthResourceProvider.class);
@@ -211,7 +211,7 @@ public class AppOAuthResourceProvider extends DefaultOAuthResourceProvider {
 		return token;
 	}
 
-	private static Optional<String> getTokenHeader(SecureHttpServerRequest request) {
+	public static Optional<String> getTokenHeader(final HttpServerRequest request) {
 		//get from header
 		final String header = request.getHeader("Authorization");
 		if (header != null && Pattern.matches("^\\s*(OAuth|Bearer)(.*)$", header)) {


### PR DESCRIPTION
# Description

Il était impossible de valider le 2FA par Postman.

Ce problème était dû au fait que la recréation de la session positionnait un cookie oneSessionId, indépendamment du mode d'authentification de l'utilisateur, ce qui entraînait une confusion au niveau des filtres et l'attribut de requête client_id n'était plus positionné, forçant ainsi la vérification du token xsrf qui plante systématiquement dans le cas d'une requête OAuth.

La correction consiste en 2 points :
1. Dans AuthManager.recreateSession on ne renvoie plus le sessionId si la session n'a pas changé d'identifiant
2. Dans DefaultResponseHandler.recreateSessionHandler on ne positionne pas le cookie si on est en OAuth

## Fixes

WB-1670

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [x] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Les tests du ticket

# Reminder

- Security flaws (bros before security holes)
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: