### PR TITLE
[ODE] fix(auth,session): Use OAuth token ttl for sessions ttl in Redis

### DIFF
--- a/session/src/main/java/org/entcore/session/ActivityManager.java
+++ b/session/src/main/java/org/entcore/session/ActivityManager.java
@@ -7,9 +7,9 @@ public interface ActivityManager {
 
     long LAST_ACTIVITY_DELAY = 3 * 60000l;
 
-    void updateLastActivity(String sessionId, String userId, boolean secureLocation, Handler<AsyncResult<Void>> handler);
+    void updateLastActivity(String sessionId, String userId, final SessionMetadata sessionMetadata, Handler<AsyncResult<Void>> handler);
 
-    void getLastActivity(String sessionId, boolean secureLocation, Handler<AsyncResult<Long>> handler);
+    void getLastActivity(String sessionId, final SessionMetadata sessionMetadata, Handler<AsyncResult<Long>> handler);
 
     void removeLastActivity(String sessionId, Handler<AsyncResult<Void>> handler);
 

--- a/session/src/main/java/org/entcore/session/MapActivityManager.java
+++ b/session/src/main/java/org/entcore/session/MapActivityManager.java
@@ -1,19 +1,18 @@
 package org.entcore.session;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import static fr.wseduc.webutils.Utils.getOrElse;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.spi.cluster.ClusterManager;
-import io.vertx.core.impl.VertxInternal;
 
-import static fr.wseduc.webutils.Utils.getOrElse;
+import java.util.HashMap;
+import java.util.Map;
 
 public class MapActivityManager implements ActivityManager {
 
@@ -35,7 +34,7 @@ public class MapActivityManager implements ActivityManager {
     }
 
     @Override
-    public void updateLastActivity(String sessionId, String userId, boolean secureLocation, Handler<AsyncResult<Void>> handler) {
+    public void updateLastActivity(String sessionId, String userId, final SessionMetadata sessionMetadata, Handler<AsyncResult<Void>> handler) {
         final long now = System.currentTimeMillis();
         final Long lastActivity = activity.get(sessionId);
         if (lastActivity == null || (lastActivity + LAST_ACTIVITY_DELAY) < now) {
@@ -45,7 +44,7 @@ public class MapActivityManager implements ActivityManager {
     }
 
     @Override
-    public void getLastActivity(String sessionId, boolean secureLocation, Handler<AsyncResult<Long>> handler) {
+    public void getLastActivity(String sessionId, final SessionMetadata sessionMetadata, Handler<AsyncResult<Long>> handler) {
         handler.handle(Future.succeededFuture(activity.get(sessionId)));
     }
 

--- a/session/src/main/java/org/entcore/session/SessionMetadata.java
+++ b/session/src/main/java/org/entcore/session/SessionMetadata.java
@@ -1,0 +1,43 @@
+package org.entcore.session;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Some of the metadata used to create a session.
+ */
+public class SessionMetadata {
+    /** {@code true} if the user signed in from a secure location (session lives should be extended).*/
+    private final boolean secureLocation;
+    /**
+     *  When present and positive, this value should override the ttl of a session defined in the underlying store. It
+     *  is in milliseconds.
+     * */
+    private final Long ttl;
+
+    public boolean isSecureLocation() {
+        return secureLocation;
+    }
+
+    public Long getTtl() {
+        return ttl;
+    }
+
+    public SessionMetadata(final boolean secureLocation, final Long ttl) {
+
+        this.secureLocation = secureLocation;
+        this.ttl = ttl;
+    }
+
+    public static SessionMetadata fromJsonObject(final JsonObject jsonObject) {
+        final boolean sl;
+        final Long ttl;
+        if(jsonObject == null) {
+            sl = false;
+            ttl = null;
+        } else {
+            sl = jsonObject.getBoolean("secureLocation", false);
+            ttl = jsonObject.getLong("ttl");
+        }
+        return new SessionMetadata(sl, ttl);
+    }
+}

--- a/session/src/main/java/org/entcore/session/SessionStore.java
+++ b/session/src/main/java/org/entcore/session/SessionStore.java
@@ -33,7 +33,7 @@ public interface SessionStore {
 
     void getSessionByUserId(String userId, Handler<AsyncResult<JsonObject>> handler);
 
-    void putSession(String userId, String sessionId, JsonObject infos, boolean secureLocation, Handler<AsyncResult<Void>> handler);
+    void putSession(String userId, String sessionId, JsonObject infos,final SessionMetadata metadata, Handler<AsyncResult<Void>> handler);
 
     void dropSession(String sessionId, Handler<AsyncResult<JsonObject>> handler);
 


### PR DESCRIPTION
# Description

Maintenant qu'une session est créée pour l'environnement mobile, il faut synchroniser le temps de vie d'une session dans Redis avec le temps de vie du token OAuth renvoyé.

Lors de la validation des identifiants OAuth, on récupère donc le ttl du token dans le champ `expires_in` puis on le redescend jusque dans `SessionStore.putSession` et les différentes implems de `ActivityManager`.

On met aussi ce champ en session, dans le sous-objet sessionMetadata, afin de pouvoir le réutiliser lors de la recréation de la session.

Afin de ne pas surcharger les fonctions en ajoutant encore un paramètre de plus, j'ai pris le parti d'encapsuler secureLocation et ttl dans un object SessionMetadata. À terme il faudrait y migrer SessionIndex et NameID, mais ce n'est pas l'objet du dev actuel.

## Fixes

WB-1659

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [x] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Avoir ça dans le springboard (session redis avec 1 minute de temps de vie de session)
```
    {
      "name": "com.opendigitaleducation~session-redis~1.3-SNAPSHOT",
      "config": {
        "listen-expired-session": false,
        "session_timeout": 60000,
        "redis-pool-size": 50,
          "redisConfig": {
              "host": "localhost",
              "port": 6379
          }
      }
    },
```
2. Authentifier catherine.bailly en mode mobile
3. Appeler la route `auth/user/requirements` et constater qu'il n'y a aucun problème
4. Attendre 2 minutes
5. Appeler la route `auth/user/requirements` et constater qu'il n'y a aucun problème
6. Sur la base Neo4J exécuter la requête suivante 
`match (u:User{login:'catherine.bailly'}) set u.mobileState = NULL`
7. Attendre 2 minutes
8. Appeler la route `request validation of a mobile phone number (send an sms)` 
9. Attendre 2 minutes
10. Envoyer le code de validation en appelant la route `try validating a mobile phone number` et constater que le retour est ok
11. Attendre 2 minutes
12. Appeler la route `auth/user/requirements` et constater qu'on a 
```
"needRevalidateMobile": false,
"needMfa": false
```

# Reminder

- Security flaws (bros before security holes)
- Unit tests were replayed

- [x] All done ! :smiley: