### PR TITLE
[ODE] Insert or update a session in mongodb if a sessionid was specified

### DIFF
--- a/auth/src/main/java/org/entcore/auth/controllers/AuthController.java
+++ b/auth/src/main/java/org/entcore/auth/controllers/AuthController.java
@@ -421,10 +421,11 @@ public class AuthController extends BaseController {
 							futureUserId.future().onSuccess(userId -> {
 								createSessionForMobile(userId, response, request);
 							}).onFailure(th -> {
-								log.warn("Could not create a session for the user", th);
+								log.warn("[OAuthToken] Could not create a session for the user", th);
 								renderJson(request, new JsonObject(response.getBody()), response.getCode());
 							});
 						} else {
+							log.info("[OAuthToken] Log in failed for user : [" + response.getCode() + "] " + response.getBody());
 							renderJson(request, new JsonObject(response.getBody()), response.getCode());
 						}
 					}


### PR DESCRIPTION
# Description

Lorsque le temps de vie des tickets OAuth est supérieur à ceux des sessions Redis, une session Redis périmée ne peut être recrée (erreur :`Session not found. 4`).
Ceci provient du fait que les sessions mobiles n'étaient jamais inscrites dans Mongo car dans AuthManager on partait du principe que si un id de session est spécifié, alors on n'a juste à faire un update.
J'ai changé ce comprotement pour que si l'id de session est spécifié et que l'update remonte 0 changements alors on fait un insert.

De plus, des logs à la validation des identifiants OAuth ont été ajoutés pour débugguer plus facilement.

## Fixes

WB-1659

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [x] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [x] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Avoir ça dans le springboard (session redis avec 1 minute de temps de vie de session)
```
    {
      "name": "com.opendigitaleducation~session-redis~1.3-SNAPSHOT",
      "config": {
        "listen-expired-session": false,
        "session_timeout": 60000,
        "redis-pool-size": 50,
          "redisConfig": {
              "host": "localhost",
              "port": 6379
          }
      }
    },
```
2. Authentifier catherine.bailly en mode mobile
3. Appeler la route `auth/user/requirements` et constater qu'il n'y a aucun problème
4. Attendre 2 minutes
5. Appeler la route `auth/user/requirements` et constater qu'il n'y a aucun problème
6. Sur la base Neo4J exécuter la requête suivante 
`match (u:User{login:'catherine.bailly'}) set u.mobileState = NULL`
7. Attendre 2 minutes
8. Appeler la route `request validation of a mobile phone number (send an sms)` 
9. Attendre 2 minutes
10. Envoyer le code de validation en appelant la route `try validating a mobile phone number` et constater que le retour est ok
11. Appeler la route `auth/user/requirements` et constater qu'on a 
```
"needRevalidateMobile": false,
"needMfa": false
```
12. Attendre 2 minutes
13. Appeler la route `auth/user/requirements` et constater qu'on a 
```
"needRevalidateMobile": true,
"needMfa": true
```

# Reminder

- Security flaws (bros before security holes)
- Unit tests were replayed

- [x] All done ! :smiley: