### PR TITLE
[ODE] recreate a session for an oauth-authenticated user

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,6 +212,7 @@ project(':common') {
     }
     compile "io.vertx:vertx-micrometer-metrics:$micrometerMetricsVersion"
     compile "io.micrometer:micrometer-registry-prometheus:$micrometerPrometheusVersion"
+    testCompile project(':test')
   }
 }
 

--- a/common/src/main/java/org/entcore/common/http/request/JsonHttpServerRequest.java
+++ b/common/src/main/java/org/entcore/common/http/request/JsonHttpServerRequest.java
@@ -19,13 +19,21 @@
 
 package org.entcore.common.http.request;
 
-import java.util.Map;
-
 import fr.wseduc.webutils.http.Renders;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.*;
+import io.vertx.core.http.CaseInsensitiveHeaders;
+import io.vertx.core.http.Cookie;
+import io.vertx.core.http.HttpConnection;
+import io.vertx.core.http.HttpFrame;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerFileUpload;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.http.StreamPriority;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
@@ -33,6 +41,7 @@ import io.vertx.core.net.SocketAddress;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
+import java.util.Map;
 
 public class JsonHttpServerRequest implements HttpServerRequest {
 
@@ -135,7 +144,8 @@ public class JsonHttpServerRequest implements HttpServerRequest {
 
 	@Override
 	public String getHeader(String headerName) {
-		return null;
+		final MultiMap headers = headers();
+		return headers == null ? null : headers.get(headerName);
 	}
 
 	@Override

--- a/common/src/main/java/org/entcore/common/http/response/DefaultResponseHandler.java
+++ b/common/src/main/java/org/entcore/common/http/response/DefaultResponseHandler.java
@@ -206,11 +206,12 @@ public class DefaultResponseHandler {
 					if (caller.getUserId().equals(targetUserId)) {
 						UserUtils.reCreateSession(eventBus, targetUserId, request).onComplete(recreationResult -> {
 							if (recreationResult.succeeded()) {
-								final String sessionId = recreationResult.result();
+								final JsonObject session = recreationResult.result();
 								// If no session id is returned it means that the session could not be retrieved or has
 								// not changed
 								// Moreover, we only put a cookie if we are not oauth-authenticated (should be redundent
 								// with the fact that sessionId is null).
+								final String sessionId = session == null ? null : session.getString("_id");
 								if (!StringUtils.isEmpty(sessionId) && !getTokenHeader(request).isPresent()) {
 									final long timeout = Long.MIN_VALUE;
 									CookieHelper.getInstance().setSigned("oneSessionId", sessionId, timeout, request);

--- a/common/src/main/java/org/entcore/common/session/SessionRecreationRequest.java
+++ b/common/src/main/java/org/entcore/common/session/SessionRecreationRequest.java
@@ -41,4 +41,5 @@ public class SessionRecreationRequest {
     public boolean isRefreshOnly() {
         return refreshOnly;
     }
+
 }

--- a/common/src/test/java/org/entcore/common/user/UserUtilsTest.java
+++ b/common/src/test/java/org/entcore/common/user/UserUtilsTest.java
@@ -1,0 +1,222 @@
+package org.entcore.common.user;
+
+import fr.wseduc.webutils.request.CookieHelper;
+import fr.wseduc.webutils.security.HmacSha1;
+import fr.wseduc.webutils.security.SecureHttpServerRequest;
+import io.netty.handler.codec.http.Cookie;
+import io.netty.handler.codec.http.DefaultCookie;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import static org.entcore.common.http.filter.AppOAuthResourceProvider.getTokenId;
+import org.entcore.common.session.SessionRecreationRequest;
+import static org.entcore.common.user.UserUtils.SESSION_ADDRESS;
+import org.entcore.test.TestHelper;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RunWith(VertxUnitRunner.class)
+public class UserUtilsTest {
+    protected static final TestHelper test = TestHelper.helper();
+    private static final Map<String, JsonObject> sessionStore = new HashMap<>();
+    private static final AtomicInteger counterOAuthValid = new AtomicInteger();
+    private static final AtomicInteger counterFindSession = new AtomicInteger();
+    private static final AtomicInteger counterRecreateSession = new AtomicInteger();
+
+    @Before
+    public void reset() {
+        sessionStore.clear();
+        counterFindSession.set(0);
+        counterRecreateSession.set(0);
+        counterOAuthValid.set(0);
+    }
+    @BeforeClass
+    public static void setUp(final TestContext context) throws Exception {
+        CookieHelper.getInstance().init("test", LoggerFactory.getLogger(UserUtilsTest.class));
+        /*******************************************
+         * Listen for events to mock
+         * - oauth creds retrieval
+         * - session retrieval
+         * - session recreation
+         *******************************************/
+        final EventBus eb = test.vertx().eventBus();
+        eb.consumer("wse.oauth").handler(message -> {
+            counterOAuthValid.incrementAndGet();
+            message.reply(new JsonObject()
+                    .put("status", "ok")
+                    .put("client_id", "test")
+                    .put("remote_user", "test_user")
+                    .put("scope", "test_scope"));
+        });
+        eb.consumer(SESSION_ADDRESS).handler(message -> {
+            final String action = ((JsonObject)message.body()).getString("action");
+            switch (action) {
+                case "find":
+                    counterFindSession.incrementAndGet();
+                    final String sessionId = ((JsonObject)message.body()).getString("sessionId");
+                    final JsonObject findReply = sessionStore.containsKey(sessionId) ?
+                            new JsonObject()
+                                    .put("status", "ok")
+                                    .put("session", sessionStore.get(sessionId)) :
+                            new JsonObject().put("status", "error").put("message", "Session not found. 4");
+                    message.reply(findReply);
+                    break;
+                case "recreate":
+                    counterRecreateSession.incrementAndGet();
+                    final SessionRecreationRequest request = ((JsonObject)message.body()).mapTo(SessionRecreationRequest.class);
+                    final JsonObject session = new JsonObject()
+                            .put("_id", request.getSessionId())
+                            .put("userId", request.getUserId());
+                    sessionStore.put(request.getSessionId(), session);
+                    message.reply(session);
+                    break;
+                default:
+                    final JsonObject json = new JsonObject().put("status", "error").put("message", "action.unknown");
+                    message.reply(json);
+            }
+        });
+    }
+    /**
+     * Test that a session is recreated for an oauthenticated user who comes with a valid access_token but no session in
+     * Redis.
+     *
+     * @param context Test context
+     */
+    @Test
+    public void testGetSessionCanRecreateSessionForOAuthUserIfSessionIsNotFoundInStore(final TestContext context) {
+        final Async async = context.async();
+        final EventBus eb = test.vertx().eventBus();
+        sessionStore.clear();
+        /*******************************************
+         * Create a fake http request with an OAuth
+         * token and check that getSession retrieves
+         * a session.
+         *******************************************/
+        final String oauthToken = UUID.randomUUID().toString();
+        final HttpServerRequest request = test.http().get("/test").withOAuthToken();
+        UserUtils.getSession(eb, request, true, session -> {
+            context.assertNotNull(session, "Session should have been recreated");
+            final Optional<String> tokenId = getTokenId((SecureHttpServerRequest) request);
+            final String actualSessionId = session.getString("_id");
+            context.assertEquals(tokenId.get(), actualSessionId);
+            context.assertTrue(counterFindSession.get() >= 1, "Should heave at least tried to find session once");
+            context.assertTrue(counterRecreateSession.get() >= 1, "Should heave at least tried to recreate the session once");
+            context.assertEquals(1, counterOAuthValid.get(), "Should heave at least tried to validate oauth credentials");
+            async.complete();
+        });
+    }
+
+
+    /**
+     * Test that a session is not recreated for a web user who comes with a session id but no session in
+     * the store.
+     *
+     * @param context Test context
+     */
+    @Test
+    public void testGetSessionReturnNullIfSessionIsNotFound(final TestContext context) throws Exception {
+        final Async async = context.async();
+        final EventBus eb = test.vertx().eventBus();
+        sessionStore.clear();
+        /*******************************************
+         * Create a fake http request with an OAuth
+         * token and check that getSession retrieves
+         * a session.
+         *******************************************/
+        final String oauthToken = signCookie(new DefaultCookie("oneSessionId", UUID.randomUUID().toString()));
+        final UserInfos user = test.http().sessionUser();
+        final HttpServerRequest request = test.http().get("/test");
+        request.headers().add("Cookie", "oneSessionId=" + oauthToken);
+        UserUtils.getSession(eb, request, true, session -> {
+            context.assertNull(session, "Session should not have been recreated");
+            context.assertEquals(1, counterFindSession.get(), "Should heave at least tried to find session once");
+            context.assertEquals(0, counterRecreateSession.get(), "Should not have tried to recreate the session");
+            context.assertEquals(0, counterOAuthValid.get(), "Should not have tried to validate oauth credentials");
+            async.complete();
+        });
+    }
+
+
+    /**
+     * Test that a session is returned for a web user who has a session in the store.
+     *
+     * @param context Test context
+     */
+    @Test
+    public void testGetSessionReturnSessionIfWebSessionIsFound(final TestContext context) throws Exception {
+        final Async async = context.async();
+        final EventBus eb = test.vertx().eventBus();
+        /*******************************************
+         * Create a fake http request with an OAuth
+         * token and check that getSession retrieves
+         * a session.
+         *******************************************/
+        final String oneSessionId = UUID.randomUUID().toString();
+        final String oauthToken = signCookie(new DefaultCookie("oneSessionId", oneSessionId));
+        final UserInfos user = test.http().sessionUser();
+        final HttpServerRequest request = test.http().get("/test");
+        request.headers().add("Cookie", "oneSessionId=" + oauthToken);
+        sessionStore.put(oneSessionId, new JsonObject().put("_id", oneSessionId).put("userId", user.getUserId()));
+        UserUtils.getSession(eb, request, true, session -> {
+            context.assertNotNull(session, "Session should have been found");
+            context.assertEquals(oneSessionId, session.getString("_id"), "Session should not have changed");
+            context.assertEquals(1, counterFindSession.get(), "Should heave at least tried to find session once");
+            context.assertEquals(0, counterRecreateSession.get(), "Should not have tried to recreate the session");
+            context.assertEquals(0, counterOAuthValid.get(), "Should not have tried to validate oauth credentials");
+            async.complete();
+        });
+    }
+    /**
+     * Test that a session is returned for an oauthenticated user whose session still exists.
+     *
+     * @param context Test context
+     */
+    @Test
+    public void testGetSessionReturnSessionIfFoundInStoreForOauthUsers(final TestContext context) {
+        final Async async = context.async();
+        final EventBus eb = test.vertx().eventBus();
+        sessionStore.clear();
+        /*******************************************
+         * Create a fake http request with an OAuth
+         * token and check that getSession retrieves
+         * a session.
+         *******************************************/
+        final HttpServerRequest request = test.http().get("/test").withOAuthToken();
+        final String tokenId = getTokenId((SecureHttpServerRequest) request).get();
+        sessionStore.put(tokenId, new JsonObject().put("_id", tokenId).put("userId", "test"));
+        UserUtils.getSession(eb, request, true, session -> {
+            context.assertNotNull(session, "Session should have been found");
+            final String actualSessionId = session.getString("_id");
+            context.assertEquals(tokenId, actualSessionId);
+            context.assertEquals(1, counterFindSession.get(), "Should heave at least tried to find session once");
+            context.assertEquals(0, counterRecreateSession.get(), "Should not have tried to recreate the session");
+            context.assertEquals(1, counterOAuthValid.get(), "Should have tried to validate oauth credentials");
+            async.complete();
+        });
+    }
+
+    private String signCookie(Cookie cookie)
+            throws InvalidKeyException, NoSuchAlgorithmException,
+            IllegalStateException, UnsupportedEncodingException {
+        String signature = HmacSha1.sign(
+                cookie.getDomain()+cookie.getName()+
+                        "/"+cookie.getValue(), "test");
+        return cookie.getValue() + ":" + signature;
+    }
+
+}

--- a/session/src/main/java/org/entcore/session/MapSessionStore.java
+++ b/session/src/main/java/org/entcore/session/MapSessionStore.java
@@ -18,20 +18,20 @@
 
 package org.entcore.session;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.spi.cluster.ClusterManager;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.spi.cluster.ClusterManager;
-import io.vertx.core.impl.VertxInternal;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 
 public class MapSessionStore extends AbstractSessionStore {
 

--- a/session/src/main/java/org/entcore/session/SessionStore.java
+++ b/session/src/main/java/org/entcore/session/SessionStore.java
@@ -48,5 +48,4 @@ public interface SessionStore {
     void getSessionsNumber(Handler<AsyncResult<Long>> handler);
 
     boolean inactivityEnabled();
-
 }

--- a/test/src/main/java/org/entcore/test/HttpTestHelper.java
+++ b/test/src/main/java/org/entcore/test/HttpTestHelper.java
@@ -168,6 +168,12 @@ public class HttpTestHelper {
             req.setSession(new JsonObject(mapper.writeValueAsString(user)));
             return req;
         }
+
+        public HttpServerRequest withOAuthToken() {
+            final SecureHttpServerRequest req = new SecureHttpServerRequest(this);
+            req.headers().add("Authorization", "Bearer " + UUID.randomUUID().toString());
+            return req;
+        }
     }
 
     public static class TestHttpServerResponse extends JsonHttpResponse {


### PR DESCRIPTION
# Description

Lorsque le temps de vie des tickets OAuth est supérieur à ceux des sessions Redis, une session Redis périmée ne peut être recrée (erreur :`Session not found. 4`).
Désormais, lorsque l'on tente de récupérer une session pour un utilisateur authentifié via oauth on va tenter de recréer la session si celle-ci n'existe plus dans les stores

## Fixes

WB-1659

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Avoir ça dans le springboard (session redis avec 1 minute de temps de vie de session)
```
    {
      "name": "com.opendigitaleducation~session-redis~1.3-SNAPSHOT",
      "config": {
        "listen-expired-session": false,
        "session_timeout": 60000,
        "redis-pool-size": 50,
          "redisConfig": {
              "host": "localhost",
              "port": 6379
          }
      }
    },
```
2. Authentifier catherine.bailly en mode mobile
3. Appeler la route `auth/user/requirements` et constater qu'il n'y a aucun problème
4. Attendre 2 minutes
5. Appeler la route `auth/user/requirements` et constater qu'il n'y a aucun problème
6. Sur la base Neo4J exécuter la requête suivante 
`match (u:User{login:'catherine.bailly'}) set u.mobileState = NULL`
7. Attendre 2 minutes
8. Appeler la route `request validation of a mobile phone number (send an sms)` 
9. Attendre 2 minutes
10. Envoyer le code de validation en appelant la route `try validating a mobile phone number` et constater que le retour est ok
11. Appeler la route `auth/user/requirements` et constater qu'on a 
```
"needRevalidateMobile": false,
"needMfa": false
```
12. Attendre 2 minutes
13. Appeler la route `auth/user/requirements` et constater qu'on a 
```
"needRevalidateMobile": true,
"needMfa": true
```

# Reminder

- Security flaws (bros before security holes)
- Unit tests were replayed
- 4 Unit tests were added^

- [x] All done ! :smiley: