### PR TITLE
[ODE] Rendre otp désactivable

### DIFF
--- a/auth/deployment/auth/conf.j2
+++ b/auth/deployment/auth/conf.j2
@@ -4,6 +4,7 @@
     "config": {
         "main": "org.entcore.auth.Auth",
         "port": 8009,
+        "otp-disabled": {{ authOtpDisabled|default(false) }},
         {% if ha and authInstance is defined %}
         "instances": {{ authInstance }},
         {% endif %}

--- a/auth/src/main/java/org/entcore/auth/Auth.java
+++ b/auth/src/main/java/org/entcore/auth/Auth.java
@@ -68,7 +68,6 @@ public class Auth extends BaseServer {
 		final EventStore eventStore = EventStoreFactory.getFactory().getEventStore(Auth.class.getSimpleName());
 		final UserAuthAccount userAuthAccount = new DefaultUserAuthAccount(vertx, config, eventStore);
 		SafeRedirectionService.getInstance().init(vertx, config.getJsonObject("safeRedirect", new JsonObject()));
-
 		final JsonObject oic = config.getJsonObject("openid-connect");
 		final OpenIdConnectService openIdConnectService = (oic != null)
 				? new DefaultOpendIdConnectService(oic.getString("iss"), vertx, oic.getString("keys"))
@@ -77,7 +76,8 @@ public class Auth extends BaseServer {
 		final OAuthDataHandlerFactory oauthDataFactory = new OAuthDataHandlerFactory(
 				openIdConnectService, checkFederatedLogin, config.getInteger("maxRetry", 5), config.getLong("banDelay", 900000L),
 				config.getString("password-event-min-date"), config.getInteger("password-event-sync-default-value", 0),
-				config.getJsonArray("oauth2-pw-client-enable-saml2"), eventStore);
+				config.getJsonArray("oauth2-pw-client-enable-saml2"), eventStore,
+				config.getBoolean("otp-disabled", false));
 
 		final LocalMap<Object, Object> server = vertx.sharedData().getLocalMap("server");
 		final Optional<Object> emailValidation = Optional.ofNullable(server.get("emailValidationConfig"));

--- a/auth/src/main/java/org/entcore/auth/oauth/OAuthDataHandlerFactory.java
+++ b/auth/src/main/java/org/entcore/auth/oauth/OAuthDataHandlerFactory.java
@@ -45,11 +45,14 @@ public class OAuthDataHandlerFactory implements DataHandlerFactory {
 	private final String passwordEventMinDate;
 	private final int defaultSyncValue;
 	private final JsonArray clientPWSupportSaml2;
+	private final boolean otpDisabled;
 	private SamlHelper samlHelper;
 
 	public OAuthDataHandlerFactory(
 			OpenIdConnectService openIdConnectService, boolean cfl, int pwMaxRetry, long pwBanDelay,
-			String passwordEventMinDate, int defaultSyncValue, JsonArray clientPWSupportSaml2, EventStore eventStore) {
+			String passwordEventMinDate, int defaultSyncValue, JsonArray clientPWSupportSaml2, EventStore eventStore,
+			final boolean otpDisabled) {
+		this.otpDisabled = otpDisabled;
 		this.neo = Neo4j.getInstance();
 		this.mongo = MongoDb.getInstance();
 		this.openIdConnectService = openIdConnectService;
@@ -66,7 +69,8 @@ public class OAuthDataHandlerFactory implements DataHandlerFactory {
 	@Override
 	public DataHandler create(Request request) {
 		return new OAuthDataHandler(request, neo, mongo, redisClient, openIdConnectService, checkFederatedLogin,
-				pwMaxRetry, pwBanDelay, passwordEventMinDate, defaultSyncValue, clientPWSupportSaml2, eventStore, samlHelper);
+				pwMaxRetry, pwBanDelay, passwordEventMinDate, defaultSyncValue, clientPWSupportSaml2, eventStore, samlHelper,
+				otpDisabled);
 	}
 
 	public void setSamlHelper(SamlHelper samlHelper) {

--- a/auth/src/main/resources/i18n/fr.json
+++ b/auth/src/main/resources/i18n/fr.json
@@ -18,6 +18,7 @@
     "auth.mail": "Courriel",
     "auth.phone": "Téléphone mobile",
     "auth.error.authenticationFailed": "L'identifiant ou le mot de passe est incorrect.",
+    "auth.error.otpDisabled": "Mode d'authentification non autorisé",
     "auth.error.blockedUser" : "L'administrateur de votre établissement a bloqué votre accès à votre réseau éducatif. Veuillez le contacter.",
     "auth.error.blockedProfileType": "L'accès à votre réseau éducatif est temporairement bloqué pour votre profil d'utilisateur.",
     "auth.error.ban": "Pour des raisons de sécurité, votre compte est bloqué temporairement suite à un trop grand nombre de tentatives de connexion. Veuillez réessayer ultérieurement.",


### PR DESCRIPTION
# Description

Ajout de la config "otp-disabled" dans le module auth permettant de désactiver l'auth otp
Par défaut otp-disabled=false

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ X] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

- ajout d'un otp et otpiat à un user sur recette-rd
- la config otp-disabled=false
- je me connecte avec succès
- changement de la config otp => otp-disable=true
- je rajoute un otp et otpiat à un user sur recette-rd
- je ne peux pas me connecter le message suivant s'affiche: Mode d'authentification non autorisé
- par contre je me connecte avec mon password avec succès 

# Reminder

- Security flaws (bros before security holes)
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ X] All done ! :smiley: