### PR TITLE
[ODE] do not fail to create session if the user does not exist in Neo4J

### DIFF
--- a/common/src/main/java/org/entcore/common/http/filter/MandatoryUserValidationFilter.java
+++ b/common/src/main/java/org/entcore/common/http/filter/MandatoryUserValidationFilter.java
@@ -98,7 +98,7 @@ public class MandatoryUserValidationFilter implements Filter {
             return;
         }
 
-        UserUtils.getSession(this.eventBus, request, session -> {
+        UserUtils.getSession(this.eventBus, request, true, session -> {
             final UserInfos userInfos = UserUtils.sessionToUserInfos(session);
             if (userInfos == null) {
                 // Mandatory validations for disconnected users :
@@ -114,7 +114,6 @@ public class MandatoryUserValidationFilter implements Filter {
                 final SecureHttpServerRequest sreq = (SecureHttpServerRequest) request;
                 // Chained mandatory validations for connected users.
                 // A failure will deny the filter and then cause a redirection.
-                request.pause();
                 UserValidation.getMandatoryUserValidation(this.eventBus, session)
                 .compose( validations -> {
                     return checkTermsOfUse(sreq, userInfos, validations);
@@ -129,7 +128,6 @@ public class MandatoryUserValidationFilter implements Filter {
                     return checkMfa(sreq, userInfos, validations);
                 })
                 .onComplete( ar -> {
-                    request.resume();
                     if( ar.succeeded() ) {
                         handler.handle(true);
                     } else {

--- a/common/src/main/java/org/entcore/common/user/UserUtils.java
+++ b/common/src/main/java/org/entcore/common/user/UserUtils.java
@@ -644,7 +644,7 @@ public class UserUtils {
 	 * @param eb Event bus to communicate with auth-manager
 	 * @param userId Id of the user who needs a new session
 	 * @param request Http request that generated the need of a new session
-	 * @return The re-created session
+	 * @return The re-created session. Can be null if the user is OAuthSystemUser
 	 */
 	public static Future<JsonObject> reCreateSession(final EventBus eb,
 													 final String userId,
@@ -656,12 +656,7 @@ public class UserUtils {
 			@Override
 			public void handle(AsyncResult<Message<JsonObject>> res) {
 				if (res.succeeded()) {
-					final JsonObject body = res.result().body();
-					if(body == null) {
-						details.fail("session.not.found");
-					} else {
-						details.complete(body);
-					}
+					details.complete( res.result().body() ); // body may be null if no session can be created (for an app)
 				} else {
 					details.fail(String.valueOf(res.result().body()));
 				}

--- a/session/src/main/java/org/entcore/session/AuthManager.java
+++ b/session/src/main/java/org/entcore/session/AuthManager.java
@@ -583,7 +583,9 @@ public class AuthManager extends BusModBase implements Handler<Message<JsonObjec
 	 * @param nameId used in identity federation
 	 * @param secureLocation {@code true} if the session is from a secure location
 	 * @param previousCache Cache of the previous session
-	 * @return The id of the created session object along with its data
+	 * @return The id of the created session object along with its data.<br /><strong><u>NB : </u>NB</strong> Note that
+	 * data may be null if the user could not be found in Neo4J. It is the case for OAuth client_creddentials identification
+	 * for instance.
 	 */
 	private Future<Pair<String, JsonObject>> createSessionAndReturnIdAndData(final String userId, final String sId, final String sessionIndex, final String nameId,
 												  final boolean secureLocation, final JsonObject previousCache) {
@@ -623,7 +625,7 @@ public class AuthManager extends BusModBase implements Handler<Message<JsonObjec
 						});
 					});
 				} else {
-					sessionPromise.fail("session.infos.not.generated");
+					sessionPromise.complete(Pair.of(sessionId, null));
 				}
 			}
 		});


### PR DESCRIPTION
# Description

For some scenarios (like OAuth client credentials authentication), the user for whom we want to create a session does not exist. In such cases, a call to createSession should not fail but return null like before.

## Fixes

WB-1667

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [x] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Tymeline Integration test 

# Reminder

- Security flaws (bros before security holes)
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: