### PR TITLE
[ODE] do not read http body multiple times

### DIFF
--- a/common/src/main/java/org/entcore/common/http/filter/MandatoryUserValidationFilter.java
+++ b/common/src/main/java/org/entcore/common/http/filter/MandatoryUserValidationFilter.java
@@ -98,6 +98,7 @@ public class MandatoryUserValidationFilter implements Filter {
             return;
         }
 
+        request.pause();
         UserUtils.getSession(this.eventBus, request, true, session -> {
             final UserInfos userInfos = UserUtils.sessionToUserInfos(session);
             if (userInfos == null) {

--- a/common/src/main/java/org/entcore/common/http/response/DefaultResponseHandler.java
+++ b/common/src/main/java/org/entcore/common/http/response/DefaultResponseHandler.java
@@ -204,7 +204,7 @@ public class DefaultResponseHandler {
 				final String sessionIdentifier = getSessionIdOrTokenId(request).orElse(null);
 				if (event.isRight()) {
 					if (caller.getUserId().equals(targetUserId)) {
-						UserUtils.reCreateSession(eventBus, targetUserId, request).onComplete(recreationResult -> {
+						UserUtils.reCreateSession(eventBus, targetUserId, request, false).onComplete(recreationResult -> {
 							if (recreationResult.succeeded()) {
 								final JsonObject session = recreationResult.result();
 								// If no session id is returned it means that the session could not be retrieved or has


### PR DESCRIPTION
# Description

## Problème
Lorsque, connecté en mode oauth client_credentials, on tente de publier sur la timeline, on récupère une erreur 500 au lieu d'un OK 201.

## Analyse

L'erreur rencontrée est la suivante :

`java.lang.IllegalStateException: Request has already been read`


Elle était due à une mauvaise gestion des pause/resume dans le filtre  du MFA ainsi que lors de la recréation de la session.

## Fixes

WB-1667

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Integration tests

# Reminder

- Security flaws (bros before security holes)
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: