### PR TITLE
Feat trashed by

### DIFF
--- a/common/src/main/java/org/entcore/common/explorer/ExplorerMessage.java
+++ b/common/src/main/java/org/entcore/common/explorer/ExplorerMessage.java
@@ -174,6 +174,11 @@ public class ExplorerMessage {
         return this;
     }
 
+    public ExplorerMessage withTrashedBy(String userId, boolean trashed) {
+        message.put("trashedBy", new JsonObject().put(userId, trashed));
+        return this;
+    }
+
     public ExplorerMessage withForceApplication(final String application) {
         message.put("application", application);
         return this;
@@ -376,6 +381,13 @@ public class ExplorerMessage {
             return new JsonObject();
         }
         return mute;
+    }
+    public JsonObject getTrashedBy() {
+        final JsonObject trashedBy = this.message.getJsonObject("trashedBy");
+        if (trashedBy == null) {
+            return new JsonObject();
+        }
+        return trashedBy;
     }
 
     @Override

--- a/common/src/main/java/org/entcore/common/explorer/ExplorerMessage.java
+++ b/common/src/main/java/org/entcore/common/explorer/ExplorerMessage.java
@@ -174,8 +174,8 @@ public class ExplorerMessage {
         return this;
     }
 
-    public ExplorerMessage withTrashedBy(String userId, boolean trashed) {
-        message.put("trashedBy", new JsonObject().put(userId, trashed));
+    public ExplorerMessage withTrashedBy(List<String> trashedBy) {
+        message.put("trashedBy", new JsonArray(trashedBy));
         return this;
     }
 
@@ -382,10 +382,10 @@ public class ExplorerMessage {
         }
         return mute;
     }
-    public JsonObject getTrashedBy() {
-        final JsonObject trashedBy = this.message.getJsonObject("trashedBy");
+    public JsonArray getTrashedBy() {
+        final JsonArray trashedBy = this.message.getJsonArray("trashedBy");
         if (trashedBy == null) {
-            return new JsonObject();
+            return new JsonArray();
         }
         return trashedBy;
     }


### PR DESCRIPTION
# Description

Adding TrashedBy Field Explorer Message to be handled in EUR ingestion process. To be later stored in Elastic Database.

## Fixes

https://opendigitaleducation.atlassian.net/browse/WB2-616

## Type of change

Please check options that are relevant.

- [x] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common > explorer
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Local manual dev test :

1. Creating a resource and share it to reader users
2. Updating the resource by manager
3. Checking that reader users received a notification on update of the shared resource
4. Trashing the resource by a reader user
5. Updating the resource by a manager
6. Checking that reader users didn't receive notification on update of the trashed (then muted) shared resource

# Reminder

- Security flaws (bros before security holes)
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: