### PR TITLE
[ODE] WB-1700 cipher codes for sms/email validation, and MFA, in DB

### DIFF
--- a/common/src/main/java/org/entcore/common/datavalidation/impl/DefaultUserValidationService.java
+++ b/common/src/main/java/org/entcore/common/datavalidation/impl/DefaultUserValidationService.java
@@ -50,8 +50,8 @@ public class DefaultUserValidationService implements UserValidationService {
     //---------------------------------------------------------------
     private class MobileField extends AbstractDataValidationService {
     //---------------------------------------------------------------
-        MobileField(io.vertx.core.Vertx vertx, io.vertx.core.json.JsonObject config) {
-            super("mobile", "mobileState", vertx, config);
+        MobileField(io.vertx.core.Vertx vertx, io.vertx.core.json.JsonObject config, io.vertx.core.json.JsonObject params) {
+            super("mobile", "mobileState", vertx, config, params);
         }
 
         @Override
@@ -67,8 +67,8 @@ public class DefaultUserValidationService implements UserValidationService {
     //---------------------------------------------------------------
         private EmailSender emailSender = null;
 
-        EmailField(io.vertx.core.Vertx vertx, io.vertx.core.json.JsonObject config) {
-            super("email", "emailState", vertx, config);
+        EmailField(io.vertx.core.Vertx vertx, io.vertx.core.json.JsonObject config, io.vertx.core.json.JsonObject params) {
+            super("email", "emailState", vertx, config, params);
             emailSender = new EmailFactory(this.vertx, config).getSenderWithPriority(EmailFactory.PRIORITY_HIGH);
         }
 
@@ -158,8 +158,8 @@ public class DefaultUserValidationService implements UserValidationService {
             retryNumber     = params.getInteger("retryNumber",  5);
             waitInSeconds   = params.getInteger("waitInSeconds", 10);
         }
-        emailSvc = new EmailField(vertx, config);
-        mobileSvc= new MobileField(vertx, config);
+        emailSvc = new EmailField(vertx, config, params);
+        mobileSvc= new MobileField(vertx, config, params);
     }
 
 	public DefaultUserValidationService setEventStore(EventStore eventStore, String eventType) {

--- a/infra/deployment/infra/conf.j2
+++ b/infra/deployment/infra/conf.j2
@@ -98,6 +98,7 @@
         },
         "emailValidationConfig": {
             "active": {{ emailValidationActive | default('true') }},
+            "encryptKey": "{{ emailValidationEncryptKey | default('') }}"
       	    "ttlInSeconds": {{ emailValidationTtl|default('600') }},
       	    "retryNumber": {{ emailValidationRetry|default('5') }},
       	    "waitInSeconds": {{ emailValidationWait|default('10') }}


### PR DESCRIPTION
# Description

Les codes de validation des données ou de MFA ne devraient pas être stockés en clair dans la base de données, même s'ils sont temporaires.
L'implémentation proposée ici consiste à supporter un nouveau paramètre (clé de cryptage) et à l'utiliser lors de l'écriture / lecture d'un code en BDD.

## Fixes

WB-1700

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [X] auth
- [ ] cas
- [X] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Validation d'un numéro mobile + MFA, en vérifiant manuellement les codes reçus pas SMS et leurs cryptages dans Neo4j.

# Reminder

- Security flaws (bros before security holes)
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: