### PR TITLE
[ODE] Log CSP violation reports

### DIFF
--- a/infra/src/main/java/org/entcore/infra/controllers/MonitoringController.java
+++ b/infra/src/main/java/org/entcore/infra/controllers/MonitoringController.java
@@ -21,6 +21,7 @@ package org.entcore.infra.controllers;
 
 import fr.wseduc.mongodb.MongoDb;
 import fr.wseduc.rs.Get;
+import fr.wseduc.rs.Post;
 import fr.wseduc.security.ActionType;
 import fr.wseduc.security.SecuredAction;
 import fr.wseduc.webutils.http.BaseController;
@@ -36,14 +37,19 @@ import io.vertx.core.eventbus.Message;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import org.vertx.java.core.http.RouteMatcher;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static fr.wseduc.webutils.request.RequestUtils.bodyToJson;
+
 
 public class MonitoringController extends BaseController {
+	private static final Logger log = LoggerFactory.getLogger(MonitoringController.class);
 
 	private boolean postgresql;
 	private long dbCheckTimeout;
@@ -146,6 +152,19 @@ public class MonitoringController extends BaseController {
 				}
 			}
 		};
+	}
+
+	/**
+	 * This endpoint receives CSP reports objects.
+	 * See https://www.w3.org/TR/CSP2/#violation-reports
+	 */
+	@Post("/monitoring/csp")
+	public void cspReport(final HttpServerRequest request) {
+		bodyToJson(request, pathPrefix + "cspReport", body -> {
+			final JsonObject report = body.getJsonObject("csp-report");
+			log.warn("[cspReport] violating iframe source "+ report.getString("blocked-uri") +" loaded from "+ report.getString("document-uri"));
+			Renders.ok(request);
+		});
 	}
 
 }

--- a/infra/src/main/resources/jsonschema/cspReport.json
+++ b/infra/src/main/resources/jsonschema/cspReport.json
@@ -1,0 +1,60 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "title": "JSON Schema for Content Security Policy (Level 2) violation reports",
+    "description": "https://www.w3.org/TR/CSP2/#violation-reports",
+    "properties": {
+        "csp-report": {
+            "type": "object",
+            "required": [
+                "blocked-uri", "document-uri"
+            ],
+            "properties": {
+                "blocked-uri": {
+                    "type": "string",
+                    "description": "The originally requested URL of the resource that was prevented from loading, stripped for reporting, or the empty string if the resource has no URL (inline script and inline style, for example)."
+                },
+                "document-uri": {
+                    "type": "string",
+                    "description": "The address of the protected resource, stripped for reporting."
+                },
+                "effective-directive": {
+                    "type": "string",
+                    "description": "The name of the policy directive that was violated. This will contain the directive whose enforcement triggered the violation (e.g. \"script-src\") even if that directive does not explicitly appear in the policy, but is implicitly activated via the default-src directive."
+                },
+                "original-policy": {
+                    "type": "string",
+                    "description": "The original policy, as received by the user agent."
+                },
+                "referrer": {
+                    "type": "string",
+                    "description": "The referrer attribute of the protected resource, or the empty string if the protected resource has no referrer."
+                },
+                "status-code": {
+                    "type": "number",
+                    "description": "The status-code of the HTTP response that contained the protected resource, if the protected resource was obtained over HTTP. Otherwise, the number 0."
+                },
+                "violated-directive": {
+                    "type": "string",
+                    "description": "The policy directive that was violated, as it appears in the policy. This will contain the default-src directive in the case of violations caused by falling back to the default sources when enforcing a directive."
+                },
+                "source-file": {
+                    "type": "string",
+                    "description": "The URL of the resource where the violation occurred, stripped for reporting."
+                },
+                "line-number": {
+                    "type": "number",
+                    "description": "The line number in source-file on which the violation occurred."
+                },
+                "column-number": {
+                    "type": "number",
+                    "description": "The column number in source-file on which the violation occurred."
+                }
+            }
+        }
+    },
+    "required": [
+        "csp-report"
+    ]
+}


### PR DESCRIPTION
# Description

On doit générer un log à partir des rapports de violation de règle CSP, contenant la source non-souhaitable de l'iframe et l'URL de l'application qui l'a affichée.
Ces logs permettront de monitoring les contenus tiers embarqués dans les contenus riches.

## Fixes

WB-744

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [X] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. testé sur un ENT local à partir d'un rapport généré via Postman
2. pas de conf nginx en local...

# Reminder

- Security flaws (bros before security holes)
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: