### PR TITLE
fix(elmsRegistered): #COE-3 change attributes for eLMS CAS authentication

### DIFF
--- a/cas/src/main/java/org/entcore/cas/services/ElmsRegisteredService.java
+++ b/cas/src/main/java/org/entcore/cas/services/ElmsRegisteredService.java
@@ -3,6 +3,7 @@ package org.entcore.cas.services;
 import fr.wseduc.cas.async.Handler;
 import fr.wseduc.cas.entities.AuthCas;
 import fr.wseduc.cas.entities.User;
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonArray;
@@ -14,10 +15,6 @@ import org.w3c.dom.Element;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static fr.wseduc.webutils.Utils.handlerToAsyncHandler;
 
@@ -30,42 +27,65 @@ public class ElmsRegisteredService extends AbstractCas20ExtensionRegisteredServi
     private static final String LASTNAME = "lastName";
     private static final String STRUCTURE = "structure";
     private static final String STRUCTURES = "structures";
-    private static final String UFUNCTIONS = "ufunctions";
-    private static final String FUNCTION = "function";
+    private static final String TYPE = "type";
+    private static final String PROFIL = "profil";
     private static final String UAI = "UAI";
-    private static final String EXTERNAL_ID = "externalId";
     private static final String IN_GAR_GROUP = "inGarGroup";
     private static final String IN_GAR_GROUPS = "inGarGroups";
+    private static final String IN_VALIDATEUR_GROUPS = "inValidateurGroups";
+    private static final String GROUPS = "groups";
+    private static final String VALIDEUR_GROUP = "Valideur de commande";
+    private static final String GROUPDISPLAYNAME = "groupDisplayName";
+    private static final String ACTION = "action";
+    private static final String MESSAGE = "message";
+    private static final String OK = "ok";
+    private static final String RESULT = "result";
+    private static final String STATUS = "status";
+    private static final String STRUCTUREIDS = "structureIds";
+    private static final String USERID = "userId";
 
+    private Future<JsonObject> getUserInfos(String userId) {
+        JsonObject jo = new JsonObject();
+        jo.put(ACTION, "getUserInfos").put(USERID, userId);
+        Promise<JsonObject> promise = Promise.promise();
+        eb.request("directory", jo, handlerToAsyncHandler(event -> {
+            JsonObject res = event.body().getJsonObject(RESULT);
+            if (OK.equals(event.body().getString(STATUS)) && res != null) {
+                promise.complete(res);
+            } else {
+                promise.fail("user.not.found");
+            }
+        }));
+        return promise.future();
+    }
     @Override
     public void getUser(final AuthCas authCas, final String service, final Handler<User> userHandler) {
         final String userId = authCas.getUser();
 
-        JsonObject jo = new JsonObject();
-        jo.put("action", "getUserInfos").put("userId", userId);
-        eb.send("directory", jo, handlerToAsyncHandler(event -> {
-            JsonObject res = event.body().getJsonObject("result");
+        Future<JsonObject> getUserFuture = getUserInfos(userId);
+        Future<JsonObject> isInGroupFuture = isInGroup(userId, new ArrayList<>(authCas.getStructureIds()));
 
-            if ("ok".equals(event.body().getString("status")) && res != null) {
-                ArrayList<String> structureIds = new ArrayList<>(authCas.getStructureIds());
-                isInGroup(userId, structureIds)
-                        .onSuccess((inGroup) -> {
-                            User user = new User();
-                            JsonObject data = new JsonObject()
-                                    .put(ID, res.getString(ID))
-                                    .put(FIRSTNAME, res.getString(FIRSTNAME))
-                                    .put(LASTNAME, res.getString(LASTNAME))
-                                    .put(UFUNCTIONS, res.getJsonArray(UFUNCTIONS))
-                                    .put(STRUCTURES, res.getJsonArray(STRUCTURES))
-                                    .put(IN_GAR_GROUPS, inGroup);
-                            prepareUser(user, userId, service, data);
-                            userHandler.handle(user);
-                        })
-                        .onFailure(err -> userHandler.handle(null));
-            } else {
-                userHandler.handle(null);
-            }
-        }));
+        CompositeFuture.all(getUserFuture, isInGroupFuture)
+                .onSuccess((res) -> {
+                    JsonObject data = getUserFuture.result();
+                    JsonObject inGroups = isInGroupFuture.result();
+
+                    User user = new User();
+                    JsonObject userData = new JsonObject()
+                            .put(ID, data.getString(ID))
+                            .put(FIRSTNAME, data.getString(FIRSTNAME))
+                            .put(LASTNAME, data.getString(LASTNAME))
+                            .put(TYPE, data.getString(TYPE))
+                            .put(STRUCTURES, data.getJsonArray(STRUCTURES))
+                            .put(IN_GAR_GROUPS, inGroups)
+                            .put(GROUPS, data.getJsonArray(GROUPS));
+                    prepareUser(user, userId, service, userData);
+                    userHandler.handle(user);
+                }).onFailure((err) -> {
+                    log.error(String.format("[entcoreCAS@%s::getUser] " +
+                            "Failed to get User for eLMS. %s", this.getClass().getName(), err.getMessage()));
+                    userHandler.handle(null);
+                });
     }
 
     @Override
@@ -76,6 +96,21 @@ public class ElmsRegisteredService extends AbstractCas20ExtensionRegisteredServi
         additionalAttributes.add(createTextElement(FIRSTNAME, data.getString(FIRSTNAME), doc));
         additionalAttributes.add(createTextElement(LASTNAME, data.getString(LASTNAME), doc));
 
+        switch(data.getString(TYPE)) {
+            case "Student" :
+                additionalAttributes.add(createTextElement(PROFIL, "National_1", doc));
+                break;
+            case "Relative" :
+                additionalAttributes.add(createTextElement(PROFIL, "National_2", doc));
+                break;
+            case "Teacher" :
+                additionalAttributes.add(createTextElement(PROFIL, "National_3", doc));
+                break;
+            case "Personnel" :
+                additionalAttributes.add(createTextElement(PROFIL, "National_4", doc));
+                break;
+        }
+
         final JsonObject inGroups = data.getJsonObject(IN_GAR_GROUPS);
 
         if (data.containsKey(STRUCTURES)) {
@@ -84,14 +119,16 @@ public class ElmsRegisteredService extends AbstractCas20ExtensionRegisteredServi
                 if (structNode != null) {
                     Element rootElement = createElement(STRUCTURE, doc);
                     rootElement.appendChild(createTextElement(UAI, structNode.getString(UAI), doc));
-                    boolean inGroup = inGroups.getBoolean(structNode.getString(ID)) != null ? inGroups.getBoolean(structNode.getString(ID)) : false;
+                    boolean inGroup = inGroups.getBoolean(structNode.getString(ID))
+                            != null && inGroups.getBoolean(structNode.getString(ID));
                     rootElement.appendChild(createTextElement(IN_GAR_GROUP, String.valueOf(inGroup), doc));
 
-                    if (data.getJsonArray(UFUNCTIONS) != null) {
-                        String externalId = structNode.getString(EXTERNAL_ID);
-                        List<String> ufunctions = extractFunctions(data.getJsonArray(UFUNCTIONS), externalId);
-
-                        ufunctions.forEach(f -> rootElement.appendChild(createTextElement(FUNCTION, f, doc)));
+                    if (data.getJsonArray(GROUPS) != null) {
+                        boolean isInValidateurGroup = data.getJsonArray(GROUPS).stream()
+                                .filter(JsonObject.class::isInstance)
+                                .map(JsonObject.class::cast)
+                                .anyMatch(group -> VALIDEUR_GROUP.equals(group.getString(GROUPDISPLAYNAME)));
+                        rootElement.appendChild(createTextElement(IN_VALIDATEUR_GROUPS, String.valueOf(isInValidateurGroup), doc));
                     }
 
                     additionalAttributes.add(rootElement);
@@ -101,57 +138,25 @@ public class ElmsRegisteredService extends AbstractCas20ExtensionRegisteredServi
 
     }
 
-    /**
-     * Extract functions from ufunctions JsonArray
-     * @param ufunctions
-     * @param externalId
-     * @return list of function
-     */
-    private List<String> extractFunctions(JsonArray ufunctions, String externalId) {
-        Predicate<String> byExternalId = ufunction -> {
-            String[] split = ufunction.split("\\$");
-            if (split.length >= 1) {
-                return Objects.equals(split[0], externalId);
-            }
-            return false;
-        };
-        Function<String, String> mapFunctionName = ufunction -> {
-            String[] split = ufunction.split("\\$");
-            String functionName = "";
-            if (split.length >= 3) {
-                functionName += split[2];
-            }
-            if (split.length >= 5) {
-                functionName += " " + split[4];
-            }
-            return functionName;
-        };
-        return ((List<String>) ufunctions
-                .getList())
-                .stream()
-                .filter(byExternalId)
-                .map(mapFunctionName)
-                .collect(Collectors.toList());
-    }
-
     private Future<JsonObject> isInGroup(String userId, ArrayList<String> structureIds) {
         Promise<JsonObject> promise = Promise.promise();
 
         final String GAR_ADDRESS = "openent.mediacentre";
         final JsonObject action = new JsonObject()
-                .put("action", "isInGarGroup")
-                .put("structureIds", new JsonArray(structureIds))
-                .put("userId", userId);
+                .put(ACTION, "isInGarGroup")
+                .put(STRUCTUREIDS, new JsonArray(structureIds))
+                .put(USERID, userId);
 
         eb.send(GAR_ADDRESS, action, handlerToAsyncHandler(event -> {
 
-            if ("ok".equals(event.body().getString("status"))) {
-                promise.complete(event.body().getJsonObject("message"));
+            if (OK.equals(event.body().getString(STATUS))) {
+                promise.complete(event.body().getJsonObject(MESSAGE));
                 return;
             }
 
-            log.error("Failed to retrieve gar resources", event.body().getString("message"));
-            promise.fail("Failed to retrieve gar resources");
+            log.error(String.format("[entcoreCAS@%s::isInGroup] " +
+                    "Failed to retrieve gar resources. %s", this.getClass().getName(), event.body().getString(MESSAGE, "")));;
+            promise.complete(new JsonObject());
         }));
 
         return promise.future();


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue.
Change attributes for ElmsRegisteredService :
- modified tag "fonction" for "profil" to display SDET profil "National_X".
- create tag"inValidateurGroups" return true or false if the user is in manual groupe "Valideur de commande" or not.

Change "isInGroup" future, to avoid error if it can't retreive gar-connector ressources. Now complete promise with empty JsonObject and return "false".

## Fixes

(Enter here Jira or Redmine ticket(s) links)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [x] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

You need to have or create a manual group "Valideur de commande", add someone to this group.
In the response you'll have <cas:profil>National_X</cas:profil> :
National_1 for student
National_2 for relative
National_3 for teacher
National_4 for personnel
Then you will have <cas:inValidateurGroups>true</cas:validateurGroups> :
true if the user is in the group, false if he isn't.

# Reminder

- Security flaws (bros before security holes)
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: