### PR TITLE
fix(eduMediaCas): #COE-16 add missing case when user is a relative

### DIFF
--- a/cas/src/main/java/org/entcore/cas/services/EduMediaRegisteredService.java
+++ b/cas/src/main/java/org/entcore/cas/services/EduMediaRegisteredService.java
@@ -67,6 +67,9 @@ public class EduMediaRegisteredService extends AbstractCas20ExtensionRegisteredS
             case "Student" :
                 additionnalAttributes.add(createTextElement(EM_PROFILES, "National_1", doc));
                 break;
+            case "Relative" :
+                additionnalAttributes.add(createTextElement(EM_PROFILES, "National_2", doc));
+                break;
             case "Teacher" :
                 // Lastname
                 if (data.containsKey("lastName")) {


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue.

Added missing case for EduMediaRegisteredService CAS authentication. The case for user (a relative one) is now managed.

## Fixes

(Enter here Jira or Redmine ticket(s) links)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [x] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

You need to have a relative user :
In the response you'll have <cas:ENTPersonProfils>National_2<cas:ENTPersonProfils>

# Reminder

- Security flaws (bros before security holes)
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: