### PR TITLE
feat(SSOJira): #COE-6 add attributes for specifics groups

### DIFF
--- a/auth/src/main/java/org/entcore/auth/services/impl/SSOJira.java
+++ b/auth/src/main/java/org/entcore/auth/services/impl/SSOJira.java
@@ -1,0 +1,59 @@
+package org.entcore.auth.services.impl;
+
+import fr.wseduc.webutils.Either;
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.entcore.common.neo4j.Neo4j;
+import org.entcore.common.neo4j.Neo4jResult;
+import org.entcore.common.user.UserUtils;
+import org.opensaml.saml2.core.Assertion;
+
+public class SSOJira extends AbstractSSOProvider {
+    @Override
+    public void generate(EventBus eb, String userId, String host, String serviceProviderEntityId, Handler<Either<String, JsonArray>> handler) {
+        String query = "MATCH (u:User {id:{userId}})-[:IN]->(:ProfileGroup)-[:DEPENDS]->(s:Structure) " +
+                "RETURN u.login as login, u.displayName as displayName, COALESCE(u.emailInternal, u.email) as email, " +
+                "collect(DISTINCT s.UAI + ' - ' + s.name) AS structures, collect(DISTINCT 'Académie de ' + s.academy) AS academies";
+        Neo4j.getInstance().execute(query, new JsonObject().put("userId", userId), Neo4jResult.validUniqueResultHandler(evt -> {
+            if (evt.isLeft()) {
+                handler.handle(new Either.Left<>(evt.left().getValue()));
+                return;
+            }
+
+            JsonArray result = new JsonArray();
+            JsonObject user = evt.right().getValue();
+            result.add(new JsonObject().put("login", user.getString("login", "")));
+            result.add(new JsonObject().put("displayName", user.getString("displayName", "")));
+            result.add(new JsonObject().put("email", user.getString("email", "")));
+
+            //Add groups for Jira
+            result.add(new JsonObject().put("group", "jira-software-users-ent"));
+            addingGroups(user, "structures", result);
+            addingGroups(user, "academies", result);
+
+            UserUtils.getUserInfos(eb, userId, userInfo -> {
+                String userType = userInfo.getType();
+                if (userType != null && (userInfo.isADML())) {
+                    result.add(new JsonObject().put("group", "jira-administrateur-ent"));
+                } else if (userType != null && (userType.equals("Teacher") || userType.equals("Personnel"))) {
+                    result.add(new JsonObject().put("group", "jira-personnel-ent"));
+                }
+                handler.handle(new Either.Right<>(result));
+            });
+        }));
+    }
+
+    private static void addingGroups(JsonObject user, String key, JsonArray result) {
+        user.getJsonArray(key, new JsonArray()).stream()
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .forEach(value -> result.add(new JsonObject().put("group", value)));
+    }
+
+    @Override
+    public void execute(Assertion assertion, Handler<Either<String, Object>> handler) {
+        handler.handle(new Either.Left<>("execute function ot available on SSO Jira Implementation"));
+    }
+}


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue.

Added attribute to SSOJira authentication :
- if the user is a "Teacher" or "Personnel", "jira-personnel-ent" group will be added to the response.
- if the user is an "ADML", "jira-administrateur-ent" group will be added to the response.

## Fixes

(Enter here Jira or Redmine ticket(s) links)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [x] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

You need to test the response with a "Teacher" user, a "Personnel" user and an "ADML" user
- If the user is a "Teacher" or "Personnel" you will see <cas:jira-personnel-ent></cas:jira-personnel-ent>
- If the user is an "ADML" you will see <cas:jira-administrateur-ent></cas:jira-administrateur-ent>

# Reminder

- Security flaws (bros before security holes)
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: