### PR TITLE
fix(register): #COE-3 add login to response

### DIFF
--- a/cas/src/main/java/org/entcore/cas/services/ElmsRegisteredService.java
+++ b/cas/src/main/java/org/entcore/cas/services/ElmsRegisteredService.java
@@ -23,6 +23,7 @@ public class ElmsRegisteredService extends AbstractCas20ExtensionRegisteredServi
     private static final Logger log = LoggerFactory.getLogger(ElmsRegisteredService.class);
 
     private static final String ID = "id";
+    private static final String LOGIN = "login";
     private static final String FIRSTNAME = "firstName";
     private static final String LASTNAME = "lastName";
     private static final String STRUCTURE = "structure";
@@ -32,7 +33,7 @@ public class ElmsRegisteredService extends AbstractCas20ExtensionRegisteredServi
     private static final String UAI = "UAI";
     private static final String IN_GAR_GROUP = "inGarGroup";
     private static final String IN_GAR_GROUPS = "inGarGroups";
-    private static final String IN_VALIDATEUR_GROUPS = "inValidateurGroups";
+    private static final String IN_VALIDATEUR_GROUP = "inValidateurGroup";
     private static final String GROUPS = "groups";
     private static final String VALIDEUR_GROUP = "Valideur de commande";
     private static final String GROUPDISPLAYNAME = "groupDisplayName";
@@ -72,6 +73,7 @@ public class ElmsRegisteredService extends AbstractCas20ExtensionRegisteredServi
 
                     User user = new User();
                     JsonObject userData = new JsonObject()
+                            .put(principalAttributeName, data.getString(principalAttributeName))
                             .put(ID, data.getString(ID))
                             .put(FIRSTNAME, data.getString(FIRSTNAME))
                             .put(LASTNAME, data.getString(LASTNAME))
@@ -83,7 +85,7 @@ public class ElmsRegisteredService extends AbstractCas20ExtensionRegisteredServi
                     userHandler.handle(user);
                 }).onFailure((err) -> {
                     log.error(String.format("[entcoreCAS@%s::getUser] " +
-                            "Failed to get User for eLMS. %s", this.getClass().getName(), err.getMessage()));
+                            "Failed to get User for eMLS. %s", this.getClass().getName(), err.getMessage()));
                     userHandler.handle(null);
                 });
     }
@@ -128,7 +130,7 @@ public class ElmsRegisteredService extends AbstractCas20ExtensionRegisteredServi
                                 .filter(JsonObject.class::isInstance)
                                 .map(JsonObject.class::cast)
                                 .anyMatch(group -> VALIDEUR_GROUP.equals(group.getString(GROUPDISPLAYNAME)));
-                        rootElement.appendChild(createTextElement(IN_VALIDATEUR_GROUPS, String.valueOf(isInValidateurGroup), doc));
+                        rootElement.appendChild(createTextElement(IN_VALIDATEUR_GROUP, String.valueOf(isInValidateurGroup), doc));
                     }
 
                     additionalAttributes.add(rootElement);

--- a/cas/src/main/resources/i18n/en.json
+++ b/cas/src/main/resources/i18n/en.json
@@ -47,6 +47,6 @@
   "AtNormandieRegisteredService.description": "AtoutNormandie",
   "SpipRegisteredService.name": "SPIP",
   "SpipRegisteredService.description": "SPIP",
-  "ElmsRegisteredService.name": "eLMS",
-  "ElmsRegisteredService.description": "eLMS"
+  "ElmsRegisteredService.name": "eMLS",
+  "ElmsRegisteredService.description": "Service CAS spécifique pour le libraire eMLS"
 }

--- a/cas/src/main/resources/i18n/fr.json
+++ b/cas/src/main/resources/i18n/fr.json
@@ -57,6 +57,6 @@
   "AtNormandieRegisteredService.description": "Service CAS spécifique de la région Normandie pour accompagner tous les 15-25 ans dans leur quotidien avec un dispositif d'aides conçu pour répondre à leurs besoins et à leurs envies.",
   "SpipRegisteredService.name": "SPIP",
   "SpipRegisteredService.description": "Service CAS spécifique pour le <a href='https://www.site.ac-aix-marseille.fr/' target='blank'>SPIP de l'Académie Aix-Marseille</a>",
-  "ElmsRegisteredService.name": "eLMS",
-  "ElmsRegisteredService.description": "eLMS"
+  "ElmsRegisteredService.name": "eMLS",
+  "ElmsRegisteredService.description": "Service CAS spécifique pour le libraire eMLS"
 }


### PR DESCRIPTION
# Description

Adaptations needed for version 2.0 of the CAS:
- add login to tags
- rename eLMS to eMLS
- change tag inValidateurGroup to inValidateurGroups

## Fixes

https://support.web-education.net/issues/62131

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests
On the admin console:
1. create an eMLS connector for a structure
2. assign it to a group where there is an user account you can connect with

On Postman:
1. log into the platform with the previoulsly noted user account (expected response: 302)
2. call ```/cas/login?service=[your_connector_url]&gateway=true``` (expected response: 302)
3. call ```/cas/serviceValidate?service=[your_connector_url]&[your_apptoken]``` 
expected response: 200 with body
body example :
```
<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
    <cas:authenticationSuccess>
        <cas:user>[your_user_login]</cas:user>
        <cas:id>[user_id]</cas:id>
        <cas:firstName>[first_name]</cas:firstName>
        <cas:lastName>[last_name]</cas:lastName>
        <cas:profil>[profile_type]</cas:profil>
        <cas:structure>
            <cas:UAI>[structure1_uai]</cas:UAI>
            <cas:inGarGroup>false</cas:inGarGroup>
            <cas:inValidateurGroup>false</cas:inValidateurGroup>
        </cas:structure>
        <cas:structure>
            <cas:UAI>[structure2_uai]</cas:UAI>
            <cas:inGarGroup>false</cas:inGarGroup>
            <cas:inValidateurGroup>false</cas:inValidateurGroup>
        </cas:structure>
    </cas:authenticationSuccess>
</cas:serviceResponse>
``` 

# Reminder

- Security flaws (bros before security holes)
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: