### PR TITLE
feat: #WB2-644, enable apps to crud folders in explorer

### DIFF
--- a/common/src/main/java/org/entcore/common/explorer/IExplorerPlugin.java
+++ b/common/src/main/java/org/entcore/common/explorer/IExplorerPlugin.java
@@ -6,6 +6,7 @@ import io.vertx.core.Future;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.entcore.common.explorer.to.*;
 import org.entcore.common.share.ShareService;
 import org.entcore.common.user.UserInfos;
 
@@ -83,6 +84,12 @@ public interface IExplorerPlugin {
     Future<Void> notifyDelete(UserInfos user, JsonObject source);
 
     Future<Void> notifyDelete(UserInfos user, List<JsonObject> sources);
+
+    Future<List<FolderResponse>> listFolder(UserInfos user, FolderListRequest request);
+
+    Future<FolderResponse> upsertFolder(UserInfos user, FolderUpsertRequest sources);
+
+    Future<FolderDeleteResponse> deleteFolder(UserInfos user, FolderDeleteRequest sources);
 
     default Future<String> create(UserInfos user, JsonObject source, boolean isCopy){
         return create(user, source, isCopy, Optional.empty());

--- a/common/src/main/java/org/entcore/common/explorer/to/FolderDeleteRequest.java
+++ b/common/src/main/java/org/entcore/common/explorer/to/FolderDeleteRequest.java
@@ -1,0 +1,51 @@
+package org.entcore.common.explorer.to;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.entcore.common.user.UserInfos;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FolderDeleteRequest {
+    /**
+     * User that trigger action
+     */
+    private final String userId;
+    /**
+     * Id to delete in explorer
+     */
+    private final Set<Long> toDelete;
+    /**
+     * Application that trigger upsert
+     */
+    private final String application;
+
+    @JsonCreator
+    public FolderDeleteRequest(@JsonProperty("userId") final String userId,
+                               @JsonProperty("toDelete") final Collection<Long> toDelete,
+                               @JsonProperty("application") final String application) {
+        this.userId = userId;
+        this.toDelete = new HashSet<>(toDelete);
+        this.application = application;
+    }
+
+    public FolderDeleteRequest(final UserInfos user, final Collection<Long> toDelete, final String application) {
+        this(user.getUserId(), toDelete, application);
+    }
+
+    public String getApplication() {
+        return application;
+    }
+
+    public Set<Long> getToDelete() {
+        return toDelete;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+}

--- a/common/src/main/java/org/entcore/common/explorer/to/FolderDeleteResponse.java
+++ b/common/src/main/java/org/entcore/common/explorer/to/FolderDeleteResponse.java
@@ -1,0 +1,26 @@
+package org.entcore.common.explorer.to;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FolderDeleteResponse {
+    /**
+     * Id to delete in explorer
+     */
+    private final Set<Long> deleted;
+
+    @JsonCreator
+    public FolderDeleteResponse(@JsonProperty("deleted") final Collection<Long> deleted) {
+        this.deleted = new HashSet<>(deleted);
+    }
+
+    public Set<Long> getDeleted() {
+        return deleted;
+    }
+}

--- a/common/src/main/java/org/entcore/common/explorer/to/FolderListRequest.java
+++ b/common/src/main/java/org/entcore/common/explorer/to/FolderListRequest.java
@@ -1,0 +1,47 @@
+package org.entcore.common.explorer.to;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.entcore.common.user.UserInfos;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FolderListRequest {
+    /**
+     * User id that trigger action
+     */
+    private final String userId;
+    /**
+     * User name that trigger action
+     */
+    private final String userName;
+    /**
+     * Application that initiated request
+     */
+    private final String application;
+
+    @JsonCreator
+    public FolderListRequest(@JsonProperty("userId") final String userId,
+                             @JsonProperty("userName") final String userName,
+                             @JsonProperty("application") final String application) {
+        this.userId = userId;
+        this.userName = userName;
+        this.application = application;
+    }
+
+    public FolderListRequest(final UserInfos user, final String application) {
+        this(user.getUserId(), user.getUsername(), application);
+    }
+
+    public String getApplication() {
+        return application;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+}

--- a/common/src/main/java/org/entcore/common/explorer/to/FolderResponse.java
+++ b/common/src/main/java/org/entcore/common/explorer/to/FolderResponse.java
@@ -1,0 +1,114 @@
+package org.entcore.common.explorer.to;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FolderResponse {
+    /**
+     * Id in the explorer.
+     */
+    private final Long id;
+    /**
+     * Current name of the folder
+     */
+    private final String name;
+    /**
+     * Current uuid in the ent.
+     */
+    private final String entId;
+    /**
+     * Current id of the parent.
+     */
+    private final Long parentId;
+    /**
+     * {@code true} if we folder is trashed.
+     */
+    private final Boolean trashed;
+    /**
+     * List of resources in this folder
+     */
+    private final List<String> entResourceIds;
+    /**
+     * Owner id of the folder
+     */
+    private final String ownerUserId;
+    /**
+     * Owner name of the folder
+     */
+    private final String ownerUserName;
+    /**
+     * Creation timestamp
+     */
+    private final Long created;
+    /**
+     * Modification timestamp
+     */
+    private final Long modified;
+
+    @JsonCreator
+    public FolderResponse(@JsonProperty("id") final Long id,
+                          @JsonProperty("name") String name,
+                          @JsonProperty("entId") final String entId,
+                          @JsonProperty("parentId") final Long parentId,
+                          @JsonProperty("trashed") final Boolean trashed,
+                          @JsonProperty("entResourceIds") final List<String> entResourceIds,
+                          @JsonProperty("ownerUserId") String ownerUserId,
+                          @JsonProperty("ownerUserName") String ownerUserName,
+                          @JsonProperty("created") Long created,
+                          @JsonProperty("modified") Long modified) {
+        this.id = id;
+        this.name = name;
+        this.entId = entId;
+        this.parentId = parentId;
+        this.trashed = trashed;
+        this.entResourceIds = entResourceIds;
+        this.ownerUserId = ownerUserId;
+        this.ownerUserName = ownerUserName;
+        this.created = created;
+        this.modified = modified;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEntId() {
+        return entId;
+    }
+
+    public Long getParentId() {
+        return parentId;
+    }
+
+    public Boolean getTrashed() {
+        return trashed;
+    }
+
+    public List<String> getEntResourceIds() {
+        return entResourceIds;
+    }
+
+    public String getOwnerUserId() {
+        return ownerUserId;
+    }
+
+    public String getOwnerUserName() {
+        return ownerUserName;
+    }
+
+    public Long getCreated() {
+        return created;
+    }
+
+    public Long getModified() {
+        return modified;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/common/src/main/java/org/entcore/common/explorer/to/FolderUpsertRequest.java
+++ b/common/src/main/java/org/entcore/common/explorer/to/FolderUpsertRequest.java
@@ -1,0 +1,91 @@
+package org.entcore.common.explorer.to;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.entcore.common.user.UserInfos;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FolderUpsertRequest {
+    /**
+     * Id in the explorer.
+     */
+    private final Long id;
+    /**
+     * Current id of the parent.
+     */
+    private final Long parentId;
+    /**
+     * name of the folder
+     */
+    private final String name;
+    /**
+     * {@code true} if we folder is trashed.
+     */
+    private final Boolean trashed;
+    /**
+     * User id that trigger action
+     */
+    private final String userId;
+    /**
+     * User name that trigger action
+     */
+    private final String userName;
+    /**
+     * Application that trigger upsert
+     */
+    private final String application;
+
+    @JsonCreator
+    public FolderUpsertRequest(@JsonProperty("userId") final String userId,
+                               @JsonProperty("userName") final String userName,
+                               @JsonProperty("id") final Long id,
+                               @JsonProperty("parentId") final Long parentId,
+                               @JsonProperty("name") String name,
+                               @JsonProperty("trashed") final Boolean trashed,
+                               @JsonProperty("application") String application) {
+        this.id = id;
+        this.parentId = parentId;
+        this.name = name;
+        this.trashed = trashed;
+        this.userId = userId;
+        this.userName = userName;
+        this.application = application;
+    }
+
+    public FolderUpsertRequest(final UserInfos user, final Long id, final Long parentId, final Boolean trashed, String application, String name) {
+        this(user.getUserId(), user.getUsername(), id, parentId, name, trashed, application);
+    }
+
+    public FolderUpsertRequest(final UserInfos user, final Long parentId, String application, String name) {
+        this(user.getUserId(), user.getUsername(), null, parentId, name, false, application);
+    }
+
+    public String getApplication() {
+        return application;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getParentId() {
+        return parentId;
+    }
+
+    public Boolean getTrashed() {
+        return trashed;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/test/src/main/java/org/entcore/test/HttpTestHelper.java
+++ b/test/src/main/java/org/entcore/test/HttpTestHelper.java
@@ -203,6 +203,25 @@ public class HttpTestHelper {
             return this;
         }
 
+        public TestHttpServerResponse jsonArrayHandler(Handler<JsonArray> bufferHandler) {
+            bodyHandler = e->{
+                bufferHandler.handle(new JsonArray(e.toString()));
+            };
+            return this;
+        }
+
+
+        public TestHttpServerResponse endJsonArrayHandler(Handler<JsonArray> bufferHandler) {
+            final JsonArray res = new JsonArray();
+            jsonArrayHandler(json ->{
+                res.addAll(json);
+            });
+            endHandler(e->{
+                bufferHandler.handle(res);
+            });
+            return this;
+        }
+
         @Override
         public HttpServerResponse write(Buffer buffer) {
             bodyHandler.handle(buffer);


### PR DESCRIPTION
# Description

L'objectif est de pouvoir requêter les API de l'explorateur depuis le bus afin de 
- lister les dossiers pour un utilisateur
- créer un nouveau dossier
- mettre à jour un dossier
- supprimer un dossier

Pour celà une route "explorer.folders" a été mis en place de l'ExplorerPlugin avec les 3 actions suivantes:
- Upsert,
- Delete,
- List

Ces routes permettent de contacter directement FolderService de l'epxlorateur


## Fixes

Ticket jira #WB2-644

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ X] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace


## Tests

Des TU sont dispo dans le module blog:
- Création d'arbo de dossiers
- Crud de dossiers
- Récupération de dossier par utilisateur
- Récupération des ressources rattachés aux dossiers

# Reminder

- Security flaws (bros before security holes)
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ X] All done ! :smiley: