### PR TITLE
[ODE] Diminuer le temps de la recherche transverse d'utilisateurs

### DIFF
--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -36,6 +36,8 @@
 
   "search.structure": "Rechercher un établissement",
   "search.user": "Rechercher un utilisateur",
+  "search.user.firstname": "Prénom",
+  "search.user.lastname": "Nom",
   "search.group": "Rechercher un groupe",
   "search.broadcast.list": "Rechercher une liste",
   "search.class": "Rechercher une classe",

--- a/admin/src/main/ts/src/app/admc/search/admc-search.module.ts
+++ b/admin/src/main/ts/src/app/admc/search/admc-search.module.ts
@@ -9,6 +9,8 @@ import { ConfigResolver } from "src/app/core/resolvers/config.resolver";
 import { AdmcSearchComponent } from "./admc-search.component";
 import { routes } from "./admc-search.routing";
 import { AdmcSearchService } from "./admc-search.service";
+import { AdmcUserSearchListComponent } from "./components/user-search-list/user-search-list.component";
+import { AdmcUserSearchInputComponent } from "./components/user-search-input/user-search-input.component";
 import { AdmcSearchTransverseComponent } from "./transverse/admc-search-transverse.component";
 import { AdmcSearchUnlinkedComponent } from "./unlinked/admc-search-unlinked.component";
 import { UnlinkedUserDetailsComponent } from "./unlinked/details/user-details.component";
@@ -17,6 +19,7 @@ import { UnlinkedUserService } from "./unlinked/unlinked.service";
 import { UnlinkedUserStructuresSectionComponent } from "./unlinked/structures-section/user-structures-section.component";
 import { UsersModule } from "src/app/users/users.module";
 import { UsersStore } from "src/app/users/users.store";
+import { InfiniteScrollModule } from "ngx-infinite-scroll";
 
 @NgModule({
     imports: [
@@ -25,12 +28,15 @@ import { UsersStore } from "src/app/users/users.store";
         RouterModule.forChild(routes),
         NgxOdeSijilModule.forChild(),
         NgxOdeUiModule,
+        InfiniteScrollModule,
         UsersModule
     ],
     declarations: [
         AdmcSearchComponent,
         AdmcSearchTransverseComponent,
         AdmcSearchUnlinkedComponent,
+        AdmcUserSearchListComponent,
+        AdmcUserSearchInputComponent,
         UnlinkedUserDetailsComponent,
         UnlinkedUserStructuresSectionComponent
     ],

--- a/admin/src/main/ts/src/app/admc/search/admc-search.service.ts
+++ b/admin/src/main/ts/src/app/admc/search/admc-search.service.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
+import { SearchTypeValue } from "src/app/core/enum/SearchTypeEnum";
 import { UserModel } from "src/app/core/store/models/user.model";
 
 @Injectable()
@@ -7,13 +8,14 @@ export class AdmcSearchService {
     constructor(private http: HttpClient) {
     }
 
-    public async search(searchTerm: string, searchType: string): Promise<Array<UserModel>> {
+    public async search(searchTerm: Array<string>, searchType: SearchTypeValue): Promise<Array<UserModel>> {
         if (!searchTerm) return [];
-        
-        const res = await this.http.
-            get<Array<UserModel>>(`/directory/user/admin/list?searchTerm=${searchTerm}&searchType=${searchType}`).
-            toPromise();
 
+        let request = (searchType==='displayName' && searchTerm.length>=2)
+            ? `/directory/user/admin/list?firstName=${searchTerm[0]}&lastName=${searchTerm[1]}&searchType=${searchType}`
+            : `/directory/user/admin/list?searchTerm=${searchTerm[0]}&searchType=${searchType}`;
+        
+        const res = await this.http.get<Array<UserModel>>(request).toPromise();
         return res;
     }
 }

--- a/admin/src/main/ts/src/app/admc/search/components/user-search-input/user-search-input.component.html
+++ b/admin/src/main/ts/src/app/admc/search/components/user-search-input/user-search-input.component.html
@@ -1,0 +1,25 @@
+<form
+    class="search-container"
+    (ngSubmit)="searchInput && handleSubmit()">
+    <input
+        #searchBox1
+        [placeholder]="searchPlaceholders[0] | translate"
+        class="search-input"
+        name="searchFirstNameTerm"
+        type="search"
+        (input)="search([searchBox1.value, searchBox2.value || ''])" />
+    <input
+        #searchBox2
+        [hidden]="!showSearchByFullname"
+        [placeholder]="searchPlaceholders[1] | translate"
+        ngClass="{}"
+        class="search-input"
+        name="searchLastNameTerm"
+        type="search"
+        (input)="search([searchBox1.value, searchBox2.value || ''])" />
+    <button class="search-button" *ngIf="searchInput" [attr.disabled]="isSearchButtonDisabled ? true : null">
+        <i class="fa fa-search is-size-4 search-icon"></i>
+    </button>
+</form>
+
+<!-- <input *ngIf="!searchInput" type="search" #searchBox (input)="search(searchBox.value)"/> -->

--- a/admin/src/main/ts/src/app/admc/search/components/user-search-input/user-search-input.component.scss
+++ b/admin/src/main/ts/src/app/admc/search/components/user-search-input/user-search-input.component.scss
@@ -1,0 +1,20 @@
+form input[hidden] {
+  display: none!important;
+}
+
+:host .search {
+  &-container {
+    margin: 0;
+    display: flex;
+  }
+  
+  &-icon {
+    padding-left: 0;
+  }
+
+  &-button {
+    margin: 0;
+    background: #ff8352;
+    color: white;
+  }
+}

--- a/admin/src/main/ts/src/app/admc/search/components/user-search-input/user-search-input.component.ts
+++ b/admin/src/main/ts/src/app/admc/search/components/user-search-input/user-search-input.component.ts
@@ -1,0 +1,104 @@
+import { OdeComponent } from 'ngx-ode-core';
+import { Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, Renderer2, ViewChild, Injector } from '@angular/core';
+import {Observable, Subject, Subscription} from 'rxjs';
+import {debounceTime, distinctUntilChanged} from 'rxjs/operators';
+import { SearchTypeEnum } from 'src/app/core/enum/SearchTypeEnum';
+
+export type UserSearchTerms = Array<string>;
+
+@Component({
+    selector: 'admc-user-search-input',
+    templateUrl: './user-search-input.component.html',
+    styleUrls: ['./user-search-input.component.scss']
+})
+export class AdmcUserSearchInputComponent extends OdeComponent implements OnInit, OnDestroy {
+
+    constructor(injector: Injector,
+                private _elRef: ElementRef,
+                private _renderer: Renderer2) {
+        super(injector);
+    }
+
+    /* Inputs / Outputs / View */
+    @Input() isSearchActive: boolean = false;
+    @Input() isSearchButtonDisabled: boolean = false;
+    @Input() searchInput: boolean = false;
+    @Input() searchSubmit: () => void;
+    @Input() set delay(d: number) {
+        this._delay = d;
+        this.observable = this.$searchTerms.pipe(debounceTime(this.delay), distinctUntilChanged());
+        if (this.observer) {
+            this.observer.unsubscribe();
+        }
+        this.observer = this.observable.subscribe(val => {
+            this.onChange.emit(val);
+        });
+    }
+    get delay() {
+        return this._delay;
+    }
+    private _delay = 200;
+
+    @Input() searchType:SearchTypeEnum = SearchTypeEnum.DISPLAY_NAME;
+    @Output() onChange: EventEmitter<UserSearchTerms> = new EventEmitter<UserSearchTerms>();
+
+    @ViewChild('searchBox1') searchBox1: ElementRef;
+    @ViewChild('searchBox2') searchBox2: ElementRef;
+
+    /* Internal logic */
+
+    private $searchTerms = new Subject<UserSearchTerms>();
+    private observable: Observable<UserSearchTerms>;
+    private observer: Subscription;
+
+    private evalAttributes() {
+        const element = this._elRef.nativeElement;
+        [this.searchBox1, this.searchBox2].forEach( box => {
+            if (element && box) {
+                for (let i = 0; i < element.attributes.length; i++) {
+                    const attr = element.attributes[i];
+                    this._renderer.setAttribute(box.nativeElement, attr.name, attr.value);
+                }
+            }
+        });
+    }
+
+    ngOnInit(): void {
+        super.ngOnInit();
+        if (!this.observable) {
+            this.observable = this.$searchTerms
+                .pipe(
+                    debounceTime(this.delay),
+                    distinctUntilChanged()
+                );
+            this.observer = this.observable.subscribe(val => {
+                this.onChange.emit(val);
+            });
+        }
+        setTimeout(() => this.evalAttributes(), 20);
+    }
+
+    ngOnDestroy(): void {
+        super.ngOnDestroy();
+        this.observer.unsubscribe();
+    }
+
+    get showSearchByFullname(): boolean {
+        return this.searchType === SearchTypeEnum.DISPLAY_NAME;
+    }
+    
+    get searchPlaceholders(): Array<string> {
+        return this.showSearchByFullname 
+            ? ['search.user.firstname', 'search.user.lastname'] 
+            : ['search.user'];
+    }
+
+    search(s:UserSearchTerms) {
+        this.$searchTerms.next( s );
+    }
+
+    handleSubmit() {
+        this.searchSubmit();
+    }
+
+}

--- a/admin/src/main/ts/src/app/admc/search/components/user-search-list/user-search-list.component.html
+++ b/admin/src/main/ts/src/app/admc/search/components/user-search-list/user-search-list.component.html
@@ -1,0 +1,44 @@
+<admc-user-search-input
+  *ngIf="isSearchActive"
+  [searchType]="searchType"
+  [isSearchButtonDisabled]="isSearchButtonDisabled"
+  [searchInput]="searchInput"
+  [searchSubmit]="searchSubmit"
+  [delay]="searchDelay"
+  (onChange)="inputChange.emit($event)"
+>
+</admc-user-search-input>
+
+<div class="toolbar">
+  <ng-content select="[toolbar]"></ng-content>
+</div>
+
+<div
+  class="list-wrapper"
+  infiniteScroll
+  [scrollWindow]="false"
+  (scrolled)="scrolledDown.emit()"
+  [infiniteScrollThrottle]="50"
+>
+  <ul>
+    <li
+      *ngFor="let item of model | filter: filters | filter: inputFilter | store:self:'storedElements' | orderBy: sort | slice: 0:limit"
+      (click)="onSelect.emit(item)"
+      [class.selected]="isSelected(item)"
+      [class.disabled]="isDisabled(item)"
+      [ngClass]="ngClass(item)"
+      class="lct-list-item"
+    >
+      <ng-template [ngTemplateOutlet]="templateRef" [ngTemplateOutletContext]="{$implicit: item}">
+      </ng-template>
+    </li>
+  </ul>
+
+  <ul *ngIf="storedElements && storedElements.length === 0">
+    <li class="no-results">{{ noResultsLabel | translate }}</li>
+  </ul>
+
+  <ul *ngIf="!model">
+    <li class="placeholder">{{ placeholder | translate }}</li>
+  </ul>
+</div>

--- a/admin/src/main/ts/src/app/admc/search/components/user-search-list/user-search-list.component.scss
+++ b/admin/src/main/ts/src/app/admc/search/components/user-search-list/user-search-list.component.scss
@@ -1,0 +1,35 @@
+ul {
+  margin: 0;
+  padding: 0px;
+  font-size: 0.9em;
+}
+
+ul li {
+  cursor: pointer;
+  border-top: 1px solid #ddd;
+  padding: 10px 10px;
+
+  &.no-results {
+    padding: 50px;
+    text-align: center;
+    font-style: italic;
+    &:hover {
+      cursor: default !important;
+      background-color: inherit !important;
+    }
+  }
+
+  &.placeholder {
+    color: #aaa;
+    padding: 2rem;
+    text-align: left;
+    &:hover {
+      cursor: default !important;
+      background-color: inherit !important;
+    }
+  }
+}
+
+ul li.disabled {
+  pointer-events: none;
+}

--- a/admin/src/main/ts/src/app/admc/search/components/user-search-list/user-search-list.component.ts
+++ b/admin/src/main/ts/src/app/admc/search/components/user-search-list/user-search-list.component.ts
@@ -1,0 +1,52 @@
+import { OdeComponent } from 'ngx-ode-core';
+import { Component, ContentChild, EventEmitter, Input, Output, TemplateRef, Injector } from '@angular/core';
+import { SearchTypeEnum } from 'src/app/core/enum/SearchTypeEnum';
+
+@Component({
+    selector: 'admc-user-search-list',
+    templateUrl: './user-search-list.component.html',
+    styleUrls: ['./user-search-list.component.scss']
+})
+export class AdmcUserSearchListComponent extends OdeComponent {
+
+    set storedElements(list) {
+        this._storedElements = list;
+        this.listChange.emit(list);
+    }
+
+    get storedElements() {
+        return this._storedElements;
+    }
+
+    /* Store pipe */
+    self = this;
+    _storedElements = [];
+
+    @Input() model;
+    @Input() filters;
+    @Input() inputFilter;
+    @Input() sort;
+    @Input() limit: number;
+    @Input() noResultsLabel = 'list.results.no.items';
+    @Input() placeholder = 'list.placeholder';
+    @Input() searchType:SearchTypeEnum = SearchTypeEnum.DISPLAY_NAME;
+    @Input() isSearchActive = true;
+    @Input() isSearchButtonDisabled: boolean = false;
+    @Input() searchInput: boolean = false;
+    @Input() searchDelay: number;
+    @Input() searchSubmit: () => void;
+
+    @Output() inputChange: EventEmitter<string> = new EventEmitter<string>();
+    @Output() onSelect: EventEmitter<any> = new EventEmitter();
+    @Output() listChange: EventEmitter<any> = new EventEmitter();
+    @Output() scrolledDown: EventEmitter<any> = new EventEmitter();
+
+    @ContentChild(TemplateRef) templateRef: TemplateRef<any>;
+    @Input() isSelected = (arg?: any) => false;
+    @Input() isDisabled = (arg?: any) => false;
+    @Input() ngClass = (arg?: any) => ({});
+
+    constructor(injector: Injector) {
+        super(injector);
+    }
+}

--- a/admin/src/main/ts/src/app/admc/search/transverse/admc-search-transverse.component.html
+++ b/admin/src/main/ts/src/app/admc/search/transverse/admc-search-transverse.component.html
@@ -1,19 +1,18 @@
 <ode-side-layout [showCompanion]="true">
   <div side-card>
-    <ode-list
+    <admc-user-search-list
       [model]="userlist"
       [inputFilter]="userListService.filterByInput"
       [sort]="userListService.sorts"
-      searchPlaceholder="search.user"
       noResultsLabel="list.results.no.users"
-      placeholder="list.placeholder"
+      [searchType]="selectedSearchTypeValue"
       [isSelected]="isSelected"
       [limit]="userListService.limit"
       [searchSubmit]="search"
       [searchInput]="true"
-      [isSearchButtonDisabled]="searchTerm?.trim().length < 3"
+      [isSearchButtonDisabled]="disableSearch"
       [searchDelay]="0"
-      (inputChange)="searchTerm = $event"
+      (inputChange)="searchTerms = $event"
       (onSelect)="handleSelectUser($event)"
       (scrolledDown)="userListService.addPageDown()"
       (listChange)="refreshListCount($event)"
@@ -72,7 +71,7 @@
         </span>
         <span class="structures">{{ userStructures(item) }}</span>
       </ng-template>
-    </ode-list>
+    </admc-user-search-list>
   </div>
   <div side-companion>
     <router-outlet></router-outlet>

--- a/admin/src/main/ts/src/app/admc/search/transverse/admc-search-transverse.component.ts
+++ b/admin/src/main/ts/src/app/admc/search/transverse/admc-search-transverse.component.ts
@@ -2,11 +2,12 @@ import { Component, EventEmitter, Injector, Input, Output } from "@angular/core"
 import { OdeComponent } from "ngx-ode-core";
 import { BundlesService } from "ngx-ode-sijil";
 import { SpinnerService } from "ngx-ode-ui";
-import { SearchTypeEnum } from "src/app/core/enum/SearchTypeEnum";
+import { SearchTypeEnum, SearchTypeValue } from "src/app/core/enum/SearchTypeEnum";
 import { UserListService } from "src/app/core/services/userlist.service";
 import { UserModel } from "src/app/core/store/models/user.model";
 import { UsersStore } from "src/app/users/users.store";
 import { AdmcSearchService } from "../admc-search.service";
+import { UserSearchTerms } from "../components/user-search-input/user-search-input.component";
 
 @Component({
     selector: 'ode-admc-search-transverse',
@@ -16,10 +17,10 @@ import { AdmcSearchService } from "../admc-search.service";
 export class AdmcSearchTransverseComponent extends OdeComponent {
     
     nbUser: number;
-    searchTerm: string;
+    searchTerms: UserSearchTerms;
     userlist: UserModel[];
     searchTypes: Array<{label: string, value: SearchTypeEnum}>;
-    selectedSearchTypeValue: string;
+    selectedSearchTypeValue: SearchTypeValue;
 
     // Selection
     @Input() selectedUser: UserModel;
@@ -47,6 +48,7 @@ export class AdmcSearchTransverseComponent extends OdeComponent {
             }
         ];
         this.selectedSearchTypeValue = SearchTypeEnum.DISPLAY_NAME;
+        this.searchTerms = [];
     }
 
     refreshListCount(list): void {
@@ -59,7 +61,7 @@ export class AdmcSearchTransverseComponent extends OdeComponent {
         return this.selectedUser && user && this.selectedUser.id === user.id;
     }
 
-    handleSelectSearchType(searchTypeValue: string): void {
+    handleSelectSearchType(searchTypeValue: SearchTypeValue): void {
         this.selectedSearchTypeValue = searchTypeValue;
     }
 
@@ -74,9 +76,19 @@ export class AdmcSearchTransverseComponent extends OdeComponent {
         return "";
     }
 
+    get disableSearch():boolean {
+        return !(
+            this.searchTerms && (
+                (this.searchTerms[0] && this.searchTerms[0].trim().length >= 3)
+                    ||
+                (this.searchTerms[1] && this.searchTerms[1].trim().length >= 3)
+            )
+        );
+    }
+
     search = (): void => {
         this.spinner.perform('portal-content', 
-            this.admcSearchService.search(this.searchTerm, this.selectedSearchTypeValue).then(data => {
+            this.admcSearchService.search(this.searchTerms, this.selectedSearchTypeValue).then(data => {
                 this.userlist = data;
                 this.refreshListCount(data);
                 this.changeDetector.markForCheck();

--- a/admin/src/main/ts/src/app/core/enum/SearchTypeEnum.ts
+++ b/admin/src/main/ts/src/app/core/enum/SearchTypeEnum.ts
@@ -2,3 +2,5 @@ export enum SearchTypeEnum {
     DISPLAY_NAME = 'displayName',
     EMAIL = 'email'
 }
+
+export type SearchTypeValue = 'displayName'|'email';

--- a/directory/src/main/java/org/entcore/directory/controllers/UserController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/UserController.java
@@ -726,7 +726,7 @@ public class UserController extends BaseController {
 		if(TransversalSearchType.NAME.equals(type)) {
 			searchQuery = new TransversalSearchQuery(params.get("lastName"), params.get("firstName"));
 		} else if(TransversalSearchType.EMAIL.equals(type)) {
-			searchQuery = new TransversalSearchQuery(params.get("email"));
+			searchQuery = new TransversalSearchQuery(params.get("searchTerm"));
 		} else {
 			searchQuery = null;
 		}

--- a/directory/src/main/java/org/entcore/directory/pojo/TransversalSearchQuery.java
+++ b/directory/src/main/java/org/entcore/directory/pojo/TransversalSearchQuery.java
@@ -1,0 +1,39 @@
+package org.entcore.directory.pojo;
+
+public class TransversalSearchQuery {
+    public static final TransversalSearchQuery EMPTY = new TransversalSearchQuery(null);
+    private final String email;
+    private final String lastName;
+    private final String firstName;
+    private final TransversalSearchType searchType;
+
+    public TransversalSearchQuery(final String lastName, final String firstName) {
+        this.lastName = lastName;
+        this.firstName = firstName;
+        this.searchType = TransversalSearchType.NAME;
+        this.email = null;
+    }
+
+    public TransversalSearchQuery(final String email) {
+        this.email = email;
+        this.lastName = null;
+        this.firstName = null;
+        this.searchType = TransversalSearchType.EMAIL;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public TransversalSearchType getSearchType() {
+        return searchType;
+    }
+}

--- a/directory/src/main/java/org/entcore/directory/pojo/TransversalSearchType.java
+++ b/directory/src/main/java/org/entcore/directory/pojo/TransversalSearchType.java
@@ -1,0 +1,22 @@
+package org.entcore.directory.pojo;
+
+public enum TransversalSearchType {
+    EMAIL("email"),
+    NAME("displayName"),
+    NONE("");
+    private final String code;
+
+    TransversalSearchType(final String code) {
+        this.code = code;
+    }
+
+    public static TransversalSearchType fromCode(final String searchType) {
+        if(EMAIL.code.equals(searchType)) {
+            return EMAIL;
+        }
+        if(NAME.code.equals(searchType)) {
+            return NAME;
+        }
+        return NONE;
+    }
+}

--- a/directory/src/main/java/org/entcore/directory/services/UserService.java
+++ b/directory/src/main/java/org/entcore/directory/services/UserService.java
@@ -26,6 +26,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.entcore.directory.pojo.TransversalSearchQuery;
 
 import java.util.List;
 
@@ -87,7 +88,7 @@ public interface UserService {
 			UserInfos userInfos, Handler<Either<String, JsonArray>> results);
 
 	void listAdmin(String structureId, boolean includeSubStructure, String classId, String groupId, JsonArray expectedProfiles,
-			String filterActivated, String searchTerm, String searchType, UserInfos userInfos, Handler<Either<String, JsonArray>> results);
+				   String filterActivated, final TransversalSearchQuery searchQuery, UserInfos userInfos, Handler<Either<String, JsonArray>> results);
 
 	void delete(List<String> users, Handler<Either<String, JsonObject>> result);
 

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
@@ -585,7 +585,7 @@ public class DefaultUserService implements UserService {
 			if(isEmpty(lastNameSearchTerm)) {
 				hasLastName = false;
 			} else {
-				sbuilder.append("u.lastNameSearchField STARTS WITH {lastName}");
+				sbuilder.append(" u.lastNameSearchField STARTS WITH {lastName} ");
 				params.put("lastName", lastNameSearchTerm);
 				hasLastName = true;
 			}
@@ -593,7 +593,7 @@ public class DefaultUserService implements UserService {
 				if(hasLastName) {
 					sbuilder.append(" and ");
 				}
-				sbuilder.append("u.firstNameSearchField STARTS WITH {firstName}");
+				sbuilder.append(" u.firstNameSearchField STARTS WITH {firstName} ");
 				params.put("firstName", firstNameSearchTerm);
 			}
 			condition += sbuilder.toString();


### PR DESCRIPTION
# Description

Modification de la requête Cypher utilisée pour réaliser la recherche transverse afin d'en diminuer le temps d'exécution.
Cette requête était longue principalement à cause du filtre `...WHERE AND u.displayNameSearchField CONTAINS {searchTerm}...` car la clause `CONTAINS` ne peut s'appuyer sur aucun index. Nous avons donc scinder le champ de recherche en 2 champs `firstName` et `lastName` qui vont chercher dans les champs `firstNameSearchField` et `lastNameSearchField` à l'aide d'un `STARTS WITH` qui lui peut s'appuyer sur les indexes.

**NB :**  Le fait de passer d'une recherche avec `contains` à une recherche avec `starts with` entraîne une régression fonctionnelle mais celle-ci est assumée.

## Fixes

WB-1368

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [x] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Se connecter avec un ADMC
2. Accéder à `/admin/admc/search/transverse`
3. Chercher des utilisateurs *rattachés à des structures* par nom seulement
4. Chercher des utilisateurs *rattachés à des structures* par prénom seulement
5. Chercher des utilisateurs *rattachés à des structures* par nom et prénom
6. Chercher des utilisateurs *rattachés à des structures* par email

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: