### PR TITLE
[ODE] Pouvoir défusionner un compte depuis le menu personnes "non-rattachées"

### DIFF
--- a/admin/src/main/ts/src/app/admc/search/unlinked/details/user-details.component.html
+++ b/admin/src/main/ts/src/app/admc/search/unlinked/details/user-details.component.html
@@ -107,8 +107,7 @@
 
       <ode-form-field label="mergedLogins" *ngIf="details.mergedWith && details.mergedWith.length" >
         <div>
-          <button type="button" class="noflex"
-                  (click)="showMergedWithDetails()">
+          <button type="button" class="noflex" (click)="showMergedWithDetails()">
             <s5l>mergedLogins.view</s5l>
             <i class="fa fa-eye"></i>
           </button>

--- a/admin/src/main/ts/src/app/admc/search/unlinked/details/user-details.component.html
+++ b/admin/src/main/ts/src/app/admc/search/unlinked/details/user-details.component.html
@@ -120,7 +120,7 @@
               </div>
               <ul>
                 <li>
-                  <div class="is-display-flex has-space-between has-align-items-center">
+                  <div *ngIf="mergedWithDetails" class="is-display-flex has-space-between has-align-items-center">
                     <a *ngIf="mergedWithDetails.structureNodes && mergedWithDetails.structureNodes.length"
                        [routerLink]="['/', 'admin', mergedWithDetails.structureNodes[0].id, 'users', 'list', mergedWithDetails.id, 'details']">
                       {{ mergedWithDetails.displayName }} ({{mergedWithDetails.login}})

--- a/admin/src/main/ts/src/app/admc/search/unlinked/details/user-details.component.html
+++ b/admin/src/main/ts/src/app/admc/search/unlinked/details/user-details.component.html
@@ -121,7 +121,13 @@
               <ul>
                 <li>
                   <div class="is-display-flex has-space-between has-align-items-center">
-                    <div>{{ mergedWithDetails }}</div>
+                    <a *ngIf="mergedWithDetails.structureNodes && mergedWithDetails.structureNodes.length"
+                       [routerLink]="['/', 'admin', mergedWithDetails.structureNodes[0].id, 'users', 'list', mergedWithDetails.id, 'details']">
+                      {{ mergedWithDetails.displayName }} ({{mergedWithDetails.login}})
+                    </a>
+                    <div *ngIf="!mergedWithDetails.structureNodes || !mergedWithDetails.structureNodes.length">
+                      {{ mergedWithDetails.displayName }} ({{mergedWithDetails.login}})
+                    </div>
                     <button type="button" class="button is-primary" (click)="unmerge()">
                       <s5l>mergedLogins.unmerge</s5l>
                       <i class="fa fa-scissors"></i>

--- a/admin/src/main/ts/src/app/admc/search/unlinked/details/user-details.component.html
+++ b/admin/src/main/ts/src/app/admc/search/unlinked/details/user-details.component.html
@@ -104,6 +104,37 @@
       <ode-form-field label="login"><span>{{ details.login }}</span></ode-form-field>
       <ode-form-field label="source"><span>{{ details.source | translate }}</span></ode-form-field>
       <ode-form-field label="activation.code" *ngIf="details.activationCode"><span>{{ details.activationCode }}</span></ode-form-field>
+
+      <ode-form-field label="mergedLogins" *ngIf="details.mergedWith && details.mergedWith.length" >
+        <div>
+          <button type="button" class="noflex"
+                  (click)="showMergedWithDetails()">
+            <s5l>mergedLogins.view</s5l>
+            <i class="fa fa-eye"></i>
+          </button>
+
+          <ode-lightbox class="merge-info" [show]="showMergedLogins" (onClose)="showMergedLogins = false">
+            <h2><s5l [s5l-params]="{displayName: details.displayName}">mergedLogins.box.title</s5l></h2>
+            <div>
+              <div class="message is-info">
+                <div class="message-body">&nbsp;<s5l>mergedLogins.box.content</s5l></div>
+              </div>
+              <ul>
+                <li>
+                  <div class="is-display-flex has-space-between has-align-items-center">
+                    <div>{{ mergedWithDetails }}</div>
+                    <button type="button" class="button is-primary" (click)="unmerge()">
+                      <s5l>mergedLogins.unmerge</s5l>
+                      <i class="fa fa-scissors"></i>
+                    </button>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </ode-lightbox>
+        </div>
+      </ode-form-field>
+
     </fieldset>
   </form>
 </ode-panel-section>

--- a/admin/src/main/ts/src/app/admc/search/unlinked/details/user-details.component.ts
+++ b/admin/src/main/ts/src/app/admc/search/unlinked/details/user-details.component.ts
@@ -71,9 +71,8 @@ export class UnlinkedUserDetailsComponent extends OdeComponent implements OnInit
       this.spinner.perform("portal-content",
         this.svc.getMergedWithDetails(this.details.mergedWith).then( desc => {
           this.mergedWithDetails = desc;
-          if( this.mergedWithDetails ) {
-            this.showMergedLogins = true;
-          }
+          this.showMergedLogins = true;
+          this.changeDetector.markForCheck();
         })
       );
     }
@@ -84,6 +83,7 @@ export class UnlinkedUserDetailsComponent extends OdeComponent implements OnInit
       this.svc.unmerge(this.details.mergedWith, this.details.login)
       .then( ()=> {
         if( this.details.mergedWith ) delete this.details.mergedWith;
+        this.changeDetector.markForCheck();
       })
     );
   }

--- a/admin/src/main/ts/src/app/admc/search/unlinked/details/user-details.component.ts
+++ b/admin/src/main/ts/src/app/admc/search/unlinked/details/user-details.component.ts
@@ -5,7 +5,7 @@ import { OdeComponent } from "ngx-ode-core";
 import { SpinnerService } from "ngx-ode-ui";
 import { NotifyService } from "src/app/core/services/notify.service";
 import { Config } from "src/app/core/resolvers/Config";
-import { UnlinkedUserDetails, UnlinkedUserService } from "../unlinked.service";
+import { MergedWithDescription, UnlinkedUserDetails, UnlinkedUserService } from "../unlinked.service";
 import { AbstractControl, NgForm } from "@angular/forms";
 import { catchError, tap } from "rxjs/operators";
 
@@ -31,7 +31,7 @@ export class UnlinkedUserDetailsComponent extends OdeComponent implements OnInit
 //  public showPersEducNatBlockingConfirmation = false;
   public showMergedLogins: boolean = false;
   public details: UnlinkedUserDetails;
-  public mergedWithDetails: string|null = null;
+  public mergedWithDetails: MergedWithDescription|null = null;
   public imgSrc: string;
   public imgLoaded: boolean = false;
   public editMode: boolean = false;

--- a/admin/src/main/ts/src/app/admc/search/unlinked/details/user-details.component.ts
+++ b/admin/src/main/ts/src/app/admc/search/unlinked/details/user-details.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, Injector, OnDestroy, OnInit, ViewChild, Input, Output, EventEmitter } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
 import { Data, NavigationEnd } from "@angular/router";
 import { OdeComponent } from "ngx-ode-core";
 import { SpinnerService } from "ngx-ode-ui";
@@ -6,6 +7,7 @@ import { NotifyService } from "src/app/core/services/notify.service";
 import { Config } from "src/app/core/resolvers/Config";
 import { UnlinkedUserDetails, UnlinkedUserService } from "../unlinked.service";
 import { AbstractControl, NgForm } from "@angular/forms";
+import { catchError, tap } from "rxjs/operators";
 
 @Component({
   selector: "ode-unlinked-user-details",
@@ -27,7 +29,9 @@ export class UnlinkedUserDetailsComponent extends OdeComponent implements OnInit
 
   public showRemoveUserConfirmation = false;
 //  public showPersEducNatBlockingConfirmation = false;
+  public showMergedLogins: boolean = false;
   public details: UnlinkedUserDetails;
+  public mergedWithDetails: string|null = null;
   public imgSrc: string;
   public imgLoaded: boolean = false;
   public editMode: boolean = false;
@@ -35,8 +39,9 @@ export class UnlinkedUserDetailsComponent extends OdeComponent implements OnInit
   constructor(
     injector: Injector,
     public spinner: SpinnerService,
+    private http: HttpClient,
     private ns: NotifyService,
-    private svc:UnlinkedUserService
+    private svc:UnlinkedUserService,
   ) {
     super(injector);
   }
@@ -59,6 +64,28 @@ export class UnlinkedUserDetailsComponent extends OdeComponent implements OnInit
       if (!(evt instanceof NavigationEnd)) return;
       window.scrollTo(0, 0);
     });
+  }
+
+  showMergedWithDetails() {
+    if( this.details.mergedWith ) {
+      this.spinner.perform("portal-content",
+        this.svc.getMergedWithDetails(this.details.mergedWith).then( desc => {
+          this.mergedWithDetails = desc;
+          if( this.mergedWithDetails ) {
+            this.showMergedLogins = true;
+          }
+        })
+      );
+    }
+  }
+
+  unmerge() {
+    this.spinner.perform("portal-content", 
+      this.svc.unmerge(this.details.mergedWith, this.details.login)
+      .then( ()=> {
+        if( this.details.mergedWith ) delete this.details.mergedWith;
+      })
+    );
   }
 
   restoreUser() {

--- a/admin/src/main/ts/src/app/admc/search/unlinked/unlinked.service.ts
+++ b/admin/src/main/ts/src/app/admc/search/unlinked/unlinked.service.ts
@@ -137,6 +137,7 @@ export class UnlinkedUserService {
                 return {
                     id: response.id, 
                     displayName: response.displayName, 
+                    login: response.login, 
                     profiles: response.profiles,
                     structureNodes: response.structureNodes
                 };

--- a/admin/src/main/ts/src/app/admc/search/unlinked/unlinked.service.ts
+++ b/admin/src/main/ts/src/app/admc/search/unlinked/unlinked.service.ts
@@ -33,6 +33,14 @@ export type ListSearchParameters = {
     searchTerm?: string;
 };
 
+export type MergedWithDescription = {
+    id: string;
+    displayName: string;
+    login: string;
+    profiles: string[];
+    structureNodes?: { id: string, source: string, type: string, name: string }[];
+};
+
 @Injectable()
 export class UnlinkedUserService {
     constructor( private notify:NotifyService ) {
@@ -119,13 +127,20 @@ export class UnlinkedUserService {
         });
     }
 
-    public getMergedWithDetails(userId: string): Promise<string|null> {
+    public getMergedWithDetails(userId: string): Promise<MergedWithDescription|null> {
         return http.get<BackendDirectoryUserResponse>(`/directory/user/${userId}`)
             .then( response => {
                 if( response.status===200 ) return response.data;
                 throw response.statusText;
             })
-            .then( response => `${response.displayName} (${response.login})` )
+            .then( response => {
+                return {
+                    id: response.id, 
+                    displayName: response.displayName, 
+                    profiles: response.profiles,
+                    structureNodes: response.structureNodes
+                };
+            })
             .catch( () => {
                 this.notify.error("user.root.error", "user.root.error.text");
                 return null;

--- a/admin/src/main/ts/src/app/users/users.service.ts
+++ b/admin/src/main/ts/src/app/users/users.service.ts
@@ -29,7 +29,7 @@ export interface BackendDirectoryUserResponse {
     mobilePhone: string[];
     workPhone: string;
     activationCode: string;
-    structureNodes: { source: string, type: string, name: string }[];
+    structureNodes: { id: string, source: string, type: string, name: string }[];
     type: string[];
 }
 


### PR DESCRIPTION
# Description

Dans la console admin, sur la page ADMC "personnes non-rattachées", indiquer pour les comptes qui sont en fusion, avec quel compte ils sont fusionnés (avec un lien direct vers la fiche profil)

## Fixes

WB-1769

## Type of change

Développement front (adminv2)

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [X] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Fusion par clé de 2 comptes parents
2. Accès à l'écran Personnes non-rattachées
3. Ouverture du compte fusionné
4. Test de la feature

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: