### PR TITLE
Feat wb 1767 backup and merge

### DIFF
--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -1195,7 +1195,7 @@
   "mergedLogins": "Comptes fusionnés",
   "mergedLogins.view": "Voir les comptes rattachés",
   "mergedLogins.box.title": "Parents fusionnés avec le compte de {{displayName}}",
-  "mergedLogins.box.content": "Après détachement, le compte parent détaché retrouvera ses droits le lendemain matin.<br>Un traitement de nuit est nécessaire pour lui réaffecter ses droits initaux.",
+  "mergedLogins.box.content": "Après détachement, le compte parent détaché retrouvera ses droits d’origine.<br>Pour les comptes issus des annuaires académiques, un traitement de nuit pourra ensuite les compléter.<br>Pour les autres comptes, une action manuelle sera requise si des droits complémentaires sont nécessaires.",
   "mergedLogins.unmerge": "Détacher",
   "notify.user.unmerge.title": "Détachement effectué",
   "notify.user.unmerge.content": "Le compte '{{mergedLogin}}' a bien été détaché.",

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
@@ -914,7 +914,7 @@ public class DefaultUserService implements UserService {
 				.put("action", "merge-by-keys")
 				.put("originalUserId", userId)
 				.put("mergeKeys", body.getJsonArray("mergeKeys"));
-		eb.send(Directory.FEEDER, action, handlerToAsyncHandler(validUniqueResultHandler(5, handler)));
+		eb.send(Directory.FEEDER, action, handlerToAsyncHandler(validUniqueResultHandler(13, handler)));
 	}
 
 	@Override

--- a/feeder/src/main/java/org/entcore/feeder/dictionary/structures/DuplicateUsers.java
+++ b/feeder/src/main/java/org/entcore/feeder/dictionary/structures/DuplicateUsers.java
@@ -421,7 +421,7 @@ public class DuplicateUsers {
 		TransactionManager.getNeo4jHelper().execute(
 						"MATCH (u:User {id: {userId}}), (mu:User) " +
 						"WHERE HEAD(u.profiles) = 'Relative' AND HEAD(mu.profiles) = 'Relative' " +
-						"AND (u.source IN ['AAF1D','AAF'] AND mu.source IN ['AAF1D','AAF']) OR (u.source IN ['CSV','MANUAL'] AND mu.source IN ['CSV','MANUAL']) " +
+						"AND ((u.source IN ['AAF1D','AAF'] AND mu.source IN ['AAF1D','AAF']) OR (u.source IN ['CSV','MANUAL'] AND mu.source IN ['CSV','MANUAL'])) " +
 						"AND NOT(HAS(u.mergedWith)) AND mu.mergeKey IN {mergeKeys} " +
 						"RETURN u.mergeKey as mergeKey, COLLECT(mu.id) as mergeUserIds, " +
 							"u.federated as federated, COLLECT(mu.federated) as mergeUserFederated "
@@ -472,7 +472,7 @@ public class DuplicateUsers {
 
 								// Backup users relations before they are merged.
 								// This will allow restoring relations if/when unmerged later.
-								mergeUserIds.stream().forEach( id -> User.backupRelationship(id, tx) );
+								mergeUserIds.forEach(id -> User.backupRelationship(id.toString(), tx));
 
 								// Do merge
 								tx.add(
@@ -537,8 +537,8 @@ public class DuplicateUsers {
 			message.reply(error.put("message", "invalid.original.user"));
 			return;
 		}
-		final JsonArray mergedLogins = message.body().getJsonArray("mergedLogins");
-		if (mergedLogins == null || mergedLogins.size() < 1) {
+		final JsonArray mergedUsersLogins = message.body().getJsonArray("mergedLogins");
+		if (mergedUsersLogins == null || mergedUsersLogins.size() < 1) {
 			message.reply(error.put("message", "invalid.merged.logins"));
 			return;
 		}
@@ -551,8 +551,9 @@ public class DuplicateUsers {
 			"REMOVE u2.mergedWith";
 		try {
 			TransactionHelper tx = TransactionManager.getTransaction();
-			for( int i=0; i<mergedLogins.size(); i++ ) {
-				final String mergedLogin = mergedLogins.getString(i);
+			for( int i=0; i<mergedUsersLogins.size(); i++ ) {
+				final String mergedLogin = mergedUsersLogins.getString(i);
+				User.restoreRelationship(mergedLogin, tx);
 				tx.add(
 					updQuery, 
 					new JsonObject().put("userId", originalUserId).put("mergedLogin", mergedLogin)

--- a/feeder/src/main/java/org/entcore/feeder/dictionary/structures/User.java
+++ b/feeder/src/main/java/org/entcore/feeder/dictionary/structures/User.java
@@ -422,6 +422,55 @@ public class User {
 		transaction.add(query, params);
 	}
 
+	public static void restoreRelationship(String userId, TransactionHelper transaction) {
+		JsonObject params = new JsonObject().put("userId", userId);
+
+		String query =
+			"MATCH (u:User {id: {userId}})-[:HAS_RELATIONSHIPS]->(b:Backup {userId: {userId}}) " +
+			"MATCH (g:Group) WHERE g.id IN b.IN_OUTGOING CREATE UNIQUE u-[:IN]->g";
+		transaction.add(query, params);
+
+		query =
+			"MATCH (u:User {id: {userId}})-[:HAS_RELATIONSHIPS]->(b:Backup {userId: {userId}}) " +
+			"MATCH (g:Group) WHERE g.id IN b.COMMUNIQUE_OUTGOING CREATE UNIQUE u-[:COMMUNIQUE]->g";
+		transaction.add(query, params);
+
+		query =
+			"MATCH (u:User {id: {userId}})-[:HAS_RELATIONSHIPS]->(b:Backup {userId: {userId}}) " +
+			"MATCH (g:Group) WHERE g.id IN b.COMMUNIQUE_INCOMING CREATE UNIQUE u<-[:COMMUNIQUE]-g";
+		transaction.add(query, params);
+
+		query =
+			"MATCH (u:User {id: {userId}})-[:HAS_RELATIONSHIPS]->(b:Backup {userId: {userId}}) " +
+			"MATCH (n:User) WHERE n.id IN b.COMMUNIQUE_DIRECT_OUTGOING CREATE UNIQUE (u)-[:COMMUNIQUE_DIRECT]->(n)";
+		transaction.add(query, params);
+
+		query =
+			"MATCH (u:User {id: {userId}})-[:HAS_RELATIONSHIPS]->(b:Backup {userId: {userId}}) " +
+			"MATCH (n:User) WHERE n.id IN b.COMMUNIQUE_DIRECT_INCOMING CREATE UNIQUE (u)<-[:COMMUNIQUE_DIRECT]-(n)";
+		transaction.add(query, params);
+
+		query =
+			"MATCH (u:User {id: {userId}})-[:HAS_RELATIONSHIPS]->(b:Backup {userId: {userId}}) " +
+			"MATCH (n:User) WHERE n.id IN b.RELATED_OUTGOING CREATE UNIQUE (u)-[:RELATED]->(n)";
+		transaction.add(query, params);
+
+		query =
+			"MATCH (u:User {id: {userId}})-[:HAS_RELATIONSHIPS]->(b:Backup {userId: {userId}}) " +
+			"MATCH (n:User) WHERE n.id IN b.RELATED_INCOMING CREATE UNIQUE (u)<-[:RELATED]-(n)";
+		transaction.add(query, params);
+
+		//TODO il faut faire le détachement backupé par cette fusion :
+		/*
+		query =
+				"MATCH (u:User { id : {userId}})-[:IN]->(pg: ProfileGroup)-[:DEPENDS]->(s: Structure), " +
+				" (u)-[:HAS_RELATIONSHIPS]->(b: Backup) " +
+				"WITH b, COLLECT(s.id) as sIds " +
+				"SET b.structureIds = sIds";
+		transaction.add(query, params);
+		*/
+	}
+
 	public static void preDelete(String userId, TransactionHelper transaction) {
 		JsonObject params = new JsonObject().put("userId", userId);
 		String mQuery =

--- a/feeder/src/main/java/org/entcore/feeder/dictionary/structures/User.java
+++ b/feeder/src/main/java/org/entcore/feeder/dictionary/structures/User.java
@@ -422,53 +422,43 @@ public class User {
 		transaction.add(query, params);
 	}
 
-	public static void restoreRelationship(String userId, TransactionHelper transaction) {
-		JsonObject params = new JsonObject().put("userId", userId);
+	public static void restoreRelationship(String mergedUserLogin, TransactionHelper transaction) {
+		JsonObject params = new JsonObject().put("mergedUserLogin", mergedUserLogin);
 
 		String query =
-			"MATCH (u:User {id: {userId}})-[:HAS_RELATIONSHIPS]->(b:Backup {userId: {userId}}) " +
-			"MATCH (g:Group) WHERE g.id IN b.IN_OUTGOING CREATE UNIQUE u-[:IN]->g";
+			"MATCH (u:User {login: {mergedUserLogin}})-[:HAS_RELATIONSHIPS]->(b:Backup) " +
+			"MATCH (g:Group) WHERE g.id IN b.IN_OUTGOING MERGE (u)-[:IN]->(g)";
 		transaction.add(query, params);
 
 		query =
-			"MATCH (u:User {id: {userId}})-[:HAS_RELATIONSHIPS]->(b:Backup {userId: {userId}}) " +
-			"MATCH (g:Group) WHERE g.id IN b.COMMUNIQUE_OUTGOING CREATE UNIQUE u-[:COMMUNIQUE]->g";
+			"MATCH (u:User {login: {mergedUserLogin}})-[:HAS_RELATIONSHIPS]->(b:Backup) " +
+			"MATCH (g:Group) WHERE g.id IN b.COMMUNIQUE_OUTGOING MERGE (u)-[:COMMUNIQUE]->(g)";
 		transaction.add(query, params);
 
 		query =
-			"MATCH (u:User {id: {userId}})-[:HAS_RELATIONSHIPS]->(b:Backup {userId: {userId}}) " +
-			"MATCH (g:Group) WHERE g.id IN b.COMMUNIQUE_INCOMING CREATE UNIQUE u<-[:COMMUNIQUE]-g";
+			"MATCH (u:User {login: {mergedUserLogin}})-[:HAS_RELATIONSHIPS]->(b:Backup) " +
+			"MATCH (g:Group) WHERE g.id IN b.COMMUNIQUE_INCOMING MERGE (u)<-[:COMMUNIQUE]-(g)";
 		transaction.add(query, params);
 
 		query =
-			"MATCH (u:User {id: {userId}})-[:HAS_RELATIONSHIPS]->(b:Backup {userId: {userId}}) " +
-			"MATCH (n:User) WHERE n.id IN b.COMMUNIQUE_DIRECT_OUTGOING CREATE UNIQUE (u)-[:COMMUNIQUE_DIRECT]->(n)";
+			"MATCH (u:User {login: {mergedUserLogin}})-[:HAS_RELATIONSHIPS]->(b:Backup) " +
+			"MATCH (n:User) WHERE n.id IN b.COMMUNIQUE_DIRECT_OUTGOING MERGE (u)-[:COMMUNIQUE_DIRECT]->(n)";
 		transaction.add(query, params);
 
 		query =
-			"MATCH (u:User {id: {userId}})-[:HAS_RELATIONSHIPS]->(b:Backup {userId: {userId}}) " +
-			"MATCH (n:User) WHERE n.id IN b.COMMUNIQUE_DIRECT_INCOMING CREATE UNIQUE (u)<-[:COMMUNIQUE_DIRECT]-(n)";
+			"MATCH (u:User {login: {mergedUserLogin}})-[:HAS_RELATIONSHIPS]->(b:Backup) " +
+			"MATCH (n:User) WHERE n.id IN b.COMMUNIQUE_DIRECT_INCOMING MERGE (u)<-[:COMMUNIQUE_DIRECT]-(n)";
 		transaction.add(query, params);
 
 		query =
-			"MATCH (u:User {id: {userId}})-[:HAS_RELATIONSHIPS]->(b:Backup {userId: {userId}}) " +
-			"MATCH (n:User) WHERE n.id IN b.RELATED_OUTGOING CREATE UNIQUE (u)-[:RELATED]->(n)";
+			"MATCH (u:User {login: {mergedUserLogin}})-[:HAS_RELATIONSHIPS]->(b:Backup) " +
+			"MATCH (n:User) WHERE n.id IN b.RELATED_OUTGOING MERGE (u)-[:RELATED]->(n)";
 		transaction.add(query, params);
 
 		query =
-			"MATCH (u:User {id: {userId}})-[:HAS_RELATIONSHIPS]->(b:Backup {userId: {userId}}) " +
-			"MATCH (n:User) WHERE n.id IN b.RELATED_INCOMING CREATE UNIQUE (u)<-[:RELATED]-(n)";
+			"MATCH (u:User {login: {mergedUserLogin}})-[:HAS_RELATIONSHIPS]->(b:Backup) " +
+			"MATCH (n:User) WHERE n.id IN b.RELATED_INCOMING MERGE (u)<-[:RELATED]-(n)";
 		transaction.add(query, params);
-
-		//TODO il faut faire le détachement backupé par cette fusion :
-		/*
-		query =
-				"MATCH (u:User { id : {userId}})-[:IN]->(pg: ProfileGroup)-[:DEPENDS]->(s: Structure), " +
-				" (u)-[:HAS_RELATIONSHIPS]->(b: Backup) " +
-				"WITH b, COLLECT(s.id) as sIds " +
-				"SET b.structureIds = sIds";
-		transaction.add(query, params);
-		*/
 	}
 
 	public static void preDelete(String userId, TransactionHelper transaction) {


### PR DESCRIPTION
# Description

This PR implements the following behavior :
- creating a backup node on a user when merged to another, that stores relation data about communication, groups dependencies...
- restoring user relations from the backup node when the user is detached from the user he merged with.

## Fixes

https://opendigitaleducation.atlassian.net/browse/WB-1767

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [x] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [x] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Manual dev tests with AAF profiles

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: