### PR TITLE
fix(directory): #WB-1368, restore a required retro-compatibilty on admin searches

### DIFF
--- a/directory/src/main/java/org/entcore/directory/controllers/UserController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/UserController.java
@@ -697,20 +697,8 @@ public class UserController extends BaseController {
 					final String groupId = request.params().get("groupId");
 					final String filterActive = request.params().get("filterActive");
 					final boolean includeSubStructures = "true".equals(request.params().get("includeSubStructures"));
-					final String searchType = request.params().get("searchType"); // searchType possible values: displayName or email
 
-					final String nameFilter = request.params().get("name");
-					if( nameFilter!=null && nameFilter.length()>0 && searchTerm==null && searchType==null) {
-						// Retro-compability : if a "name" parameter is defined, it should be interpreted like a searchTerm (+searchType=displayName)
-						userService.listAdmin(structureId, includeSubStructures, classId, groupId, types, filterActive, new TransversalSearchQuery(nameFilter, ""), user, arrayResponseHandler(request));
-					} else {
-						final Optional<TransversalSearchQuery> maybeSearchQuery = searchQueryFromRequest(request);
-						if(maybeSearchQuery.isPresent()) {
-							userService.listAdmin(structureId, includeSubStructures, classId, groupId, types, filterActive, maybeSearchQuery.get(), user, arrayResponseHandler(request));
-						} else {
-							badRequest(request);
-						}
-					}
+					userService.listAdmin(structureId, includeSubStructures, classId, groupId, types, filterActive, searchQueryFromRequest(request), user, arrayResponseHandler(request));
 				} else {
 					unauthorized(request);
 				}
@@ -718,19 +706,32 @@ public class UserController extends BaseController {
 		});
 	}
 
-	private Optional<TransversalSearchQuery> searchQueryFromRequest(final HttpServerRequest request) {
+	private TransversalSearchQuery searchQueryFromRequest(final HttpServerRequest request) {
 		final TransversalSearchQuery searchQuery;
 		final MultiMap params = request.params();
 		final String searchType = params.get("searchType");
-		final TransversalSearchType type = TransversalSearchType.fromCode(searchType);
-		if(TransversalSearchType.NAME.equals(type)) {
-			searchQuery = new TransversalSearchQuery(params.get("lastName"), params.get("firstName"));
-		} else if(TransversalSearchType.EMAIL.equals(type)) {
-			searchQuery = new TransversalSearchQuery(params.get("searchTerm"));
-		} else {
-			searchQuery = null;
+		final String searchTerm = params.get("searchTerm");
+		final String nameFilter = params.get("name");
+		final String lastNameFilter = params.get("lastName");
+		final String firstNameFilter = params.get("firstName");
+
+		/* Retro-compability : 
+		 * - if a "name" query parameter exists, its value must be used like a displayName.
+		 * - if a "lastName" or "firstName" query parameter exists, make an optimized search by fullname.
+		 * - otherwise, just apply the "searchTerm" and "searchType" query parameter, if any.
+		 */
+		if( nameFilter!=null && nameFilter.length()>0 && searchTerm==null && searchType==null) {
+			return TransversalSearchQuery.searchByDisplayName(nameFilter);
+		} if( !StringUtils.isEmpty(lastNameFilter) || !StringUtils.isEmpty(firstNameFilter) ) {
+			return TransversalSearchQuery.searchByFullName(lastNameFilter, firstNameFilter);
+		} else if( !StringUtils.isEmpty(searchTerm) ) {
+			final TransversalSearchType type = TransversalSearchType.fromCode(searchTerm);
+			if(TransversalSearchType.EMAIL.equals(type))
+				return TransversalSearchQuery.searchByMail(searchTerm);
+			if(TransversalSearchType.NAME.equals(type))
+				return TransversalSearchQuery.searchByDisplayName(searchTerm);
 		}
-		return Optional.ofNullable(searchQuery);
+		return TransversalSearchQuery.EMPTY;
 	}
 
 	@Put("/user/:studentId/related/:relativeId")

--- a/directory/src/main/java/org/entcore/directory/pojo/TransversalSearchQuery.java
+++ b/directory/src/main/java/org/entcore/directory/pojo/TransversalSearchQuery.java
@@ -1,28 +1,57 @@
 package org.entcore.directory.pojo;
 
 public class TransversalSearchQuery {
-    public static final TransversalSearchQuery EMPTY = new TransversalSearchQuery(null);
-    private final String email;
+    public static final TransversalSearchQuery EMPTY = new TransversalSearchQuery(TransversalSearchType.NONE, null, null, null);
+    private final String term;
     private final String lastName;
     private final String firstName;
     private final TransversalSearchType searchType;
 
-    public TransversalSearchQuery(final String lastName, final String firstName) {
+    private TransversalSearchQuery(
+            final TransversalSearchType type,
+            final String lastName, 
+            final String firstName, 
+            final String term 
+            ) {
+        this.searchType = type;
         this.lastName = lastName;
         this.firstName = firstName;
-        this.searchType = TransversalSearchType.NAME;
-        this.email = null;
+        this.term = term;
     }
 
-    public TransversalSearchQuery(final String email) {
-        this.email = email;
-        this.lastName = null;
-        this.firstName = null;
-        this.searchType = TransversalSearchType.EMAIL;
+    public static TransversalSearchQuery searchByFullName(final String lastName, final String firstName) {
+        return new TransversalSearchQuery(
+            TransversalSearchType.NAME,
+            lastName,
+            firstName,
+            null
+        );
+    }
+
+    public static TransversalSearchQuery searchByDisplayName(final String fullname) {
+        return new TransversalSearchQuery(
+            TransversalSearchType.NAME,
+            null,
+            null,
+            fullname
+        );
+    }
+
+    public static TransversalSearchQuery searchByMail(final String email) {
+        return new TransversalSearchQuery(
+            TransversalSearchType.EMAIL,
+            null,
+            null,
+            email
+        );
     }
 
     public String getEmail() {
-        return email;
+        return term;
+    }
+
+    public String getDisplayName() {
+        return term;
     }
 
     public String getLastName() {

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
@@ -572,35 +572,40 @@ public class DefaultUserService implements UserService {
 			}
 		}
 		if(TransversalSearchType.EMAIL.equals(searchQuery.getSearchType()) && isNotEmpty(searchQuery.getEmail())) {
-			final String emailSearchTerm = normalize(searchQuery.getEmail());
-			condition += "AND u.emailSearchField CONTAINS {email} ";
-			params.put("email", searchQuery.getEmail());
-		} else if(TransversalSearchType.NAME.equals(searchQuery.getSearchType()) && (
-				isNotEmpty(searchQuery.getFirstName()) || isNotEmpty(searchQuery.getLastName()))) {
-			final String firstNameSearchTerm = normalize(searchQuery.getFirstName());
-			final String lastNameSearchTerm = normalize(searchQuery.getLastName());
-			final StringBuilder sbuilder = new StringBuilder();
-			sbuilder.append(" AND ");
-			final boolean hasLastName;
-			if(isEmpty(lastNameSearchTerm)) {
-				hasLastName = false;
-			} else {
-				sbuilder.append(" u.lastNameSearchField STARTS WITH {lastName} ");
-				params.put("lastName", lastNameSearchTerm);
-				hasLastName = true;
-			}
-			if(isNotEmpty(firstNameSearchTerm)) {
-				if(hasLastName) {
-					sbuilder.append(" and ");
+			final String searchTerm = normalize(searchQuery.getEmail());
+			condition += " AND u.emailSearchField CONTAINS {email} ";
+			params.put("email", searchTerm);
+		} else if(TransversalSearchType.NAME.equals(searchQuery.getSearchType())) {
+			if( isNotEmpty(searchQuery.getFirstName()) || isNotEmpty(searchQuery.getLastName()) ) {
+				final String firstNameSearchTerm = normalize(searchQuery.getFirstName());
+				final String lastNameSearchTerm = normalize(searchQuery.getLastName());
+				final StringBuilder sbuilder = new StringBuilder();
+				sbuilder.append(" AND ");
+				final boolean hasLastName;
+				if(isEmpty(lastNameSearchTerm)) {
+					hasLastName = false;
+				} else {
+					sbuilder.append(" u.lastNameSearchField STARTS WITH {lastName} ");
+					params.put("lastName", lastNameSearchTerm);
+					hasLastName = true;
 				}
-				sbuilder.append(" u.firstNameSearchField STARTS WITH {firstName} ");
-				params.put("firstName", firstNameSearchTerm);
+				if(isNotEmpty(firstNameSearchTerm)) {
+					if(hasLastName) {
+						sbuilder.append(" AND ");
+					}
+					sbuilder.append(" u.firstNameSearchField STARTS WITH {firstName} ");
+					params.put("firstName", firstNameSearchTerm);
+				}
+				condition += sbuilder.toString();
+			} else if(isNotEmpty(searchQuery.getDisplayName())) {
+				final String searchTerm = normalize(searchQuery.getDisplayName());
+				condition += " AND u.displayNameSearchField CONTAINS {displayName} ";
+				params.put("displayName", searchTerm);
 			}
-			condition += sbuilder.toString();
 		}
 		if(filterActivated != null){
 			if("inactive".equals(filterActivated)){
-				condition += "AND NOT(u.activationCode IS NULL)  ";
+				condition += "AND NOT(u.activationCode IS NULL) ";
 			} else if("active".equals(filterActivated)){
 				condition += "AND u.activationCode IS NULL ";
 			}


### PR DESCRIPTION
# Description

Fix a regression in admin console v2 : allow searching without any searchTerms, and with a displayName (it is used when searching on a structure, but no more during transversal searches)

## Fixes

WB-1368

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [X] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Local fix and test.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: