### PR TITLE
[ODE]  Voir les utilisateurs des autres structures dans les groupes manuels

### DIFF
--- a/admin/src/main/ts/src/app/groups/details/users-list/group-users-list.component.html
+++ b/admin/src/main/ts/src/app/groups/details/users-list/group-users-list.component.html
@@ -30,13 +30,14 @@
   </div>
 
   <ng-template let-item>
-    <span class="display-name">{{item?.lastName.toUpperCase()}} {{item?.firstName}}</span>
+    <span class="display-name" [ngClass]="{isolated: areScopeDisjoint(item?.structures)}">{{item?.lastName.toUpperCase()}} {{item?.firstName}}</span>
 
     <i class="profile" [ngClass]="item.type">{{item.type | translate}}</i>
     <span class="structures">
-                    <ul>
-                        <li *ngFor="let s of item?.structures">{{ s.name }}</li>
-                    </ul>
-                </span>
+        <ul>
+            <li *ngIf="!(item?.structures?.length)">&nbsp;-&nbsp;</li>
+            <li *ngFor="let s of item?.structures">{{ s.name }}</li>
+        </ul>
+    </span>
   </ng-template>
 </ode-list>

--- a/admin/src/main/ts/src/app/groups/details/users-list/group-users-list.component.scss
+++ b/admin/src/main/ts/src/app/groups/details/users-list/group-users-list.component.scss
@@ -1,3 +1,4 @@
 .tools {align-items: center;}
 .tools__tool {flex-grow: 0; flex-shrink: 0; padding: 0 5px;}
 .tools__tool--injected {text-align: right; flex-grow: 1;}
+.display-name.isolated {font-style: italic;}

--- a/admin/src/main/ts/src/app/groups/details/users-list/group-users-list.component.ts
+++ b/admin/src/main/ts/src/app/groups/details/users-list/group-users-list.component.ts
@@ -1,7 +1,9 @@
-import { ChangeDetectionStrategy, Component, Injector, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injector, Input, OnInit } from '@angular/core';
 import { OdeComponent } from 'ngx-ode-core';
 import { UserListService } from '../../../core/services/userlist.service';
 import { UserModel } from '../../../core/store/models/user.model';
+import { Session } from "src/app/core/store/mappings/session";
+import { SessionModel } from "src/app/core/store/models/session.model";
 
 
 @Component({
@@ -11,13 +13,45 @@ import { UserModel } from '../../../core/store/models/user.model';
     providers: [UserListService],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class GroupUsersListComponent extends OdeComponent {
+export class GroupUsersListComponent extends OdeComponent implements OnInit  {
     constructor(injector: Injector, public userLS: UserListService) {
         super(injector);
     }
 
     @Input()
     users: UserModel[];
+
+    isADML:boolean = false;
+    isADMC:boolean = false;
+    scope:Array<string> = [];
+
+    ngOnInit(): void {
+        this.initContext();
+    }
+
+    private initContext = async () => {
+        const session: Session = await SessionModel.getSession();
+
+        this.isADMC = session.isADMC();
+
+        if (session.functions && session.functions["ADMIN_LOCAL"]) {
+            const { code, scope } = session.functions["ADMIN_LOCAL"];
+            this.isADML = code === "ADMIN_LOCAL";
+            if( scope?.length > 0 ) {
+                this.scope = scope;
+            }
+        }
+        this.changeDetector.markForCheck();
+    }
+
+    areScopeDisjoint(ids:Array<string>|null) {
+        if( this.isADMC ) return false;
+        if( !ids ) return true;
+        for( const id in ids ) {
+            if( this.scope.indexOf(id)>=0 ) return false;
+        }
+        return true;
+    }
 
     selectUser(user: UserModel) {
         if (user.structures.length > 0) {

--- a/directory/src/main/java/org/entcore/directory/controllers/UserController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/UserController.java
@@ -707,7 +707,6 @@ public class UserController extends BaseController {
 	}
 
 	private TransversalSearchQuery searchQueryFromRequest(final HttpServerRequest request) {
-		final TransversalSearchQuery searchQuery;
 		final MultiMap params = request.params();
 		final String searchType = params.get("searchType");
 		final String searchTerm = params.get("searchTerm");

--- a/directory/src/main/java/org/entcore/directory/controllers/UserController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/UserController.java
@@ -727,7 +727,7 @@ public class UserController extends BaseController {
 			final TransversalSearchType type = TransversalSearchType.fromCode(searchType);
 			if(TransversalSearchType.EMAIL.equals(type))
 				return TransversalSearchQuery.searchByMail(searchTerm);
-			if(TransversalSearchType.NAME.equals(type))
+			if(TransversalSearchType.DISPLAY_NAME.equals(type))
 				return TransversalSearchQuery.searchByDisplayName(searchTerm);
 		}
 		return TransversalSearchQuery.EMPTY;

--- a/directory/src/main/java/org/entcore/directory/controllers/UserController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/UserController.java
@@ -697,20 +697,8 @@ public class UserController extends BaseController {
 					final String groupId = request.params().get("groupId");
 					final String filterActive = request.params().get("filterActive");
 					final boolean includeSubStructures = "true".equals(request.params().get("includeSubStructures"));
-					final String searchType = request.params().get("searchType"); // searchType possible values: displayName or email
 
-					final String nameFilter = request.params().get("name");
-					if( nameFilter!=null && nameFilter.length()>0 && searchTerm==null && searchType==null) {
-						// Retro-compability : if a "name" parameter is defined, it should be interpreted like a searchTerm (+searchType=displayName)
-						userService.listAdmin(structureId, includeSubStructures, classId, groupId, types, filterActive, new TransversalSearchQuery(nameFilter, ""), user, arrayResponseHandler(request));
-					} else {
-						final Optional<TransversalSearchQuery> maybeSearchQuery = searchQueryFromRequest(request);
-						if(maybeSearchQuery.isPresent()) {
-							userService.listAdmin(structureId, includeSubStructures, classId, groupId, types, filterActive, maybeSearchQuery.get(), user, arrayResponseHandler(request));
-						} else {
-							badRequest(request);
-						}
-					}
+					userService.listAdmin(structureId, includeSubStructures, classId, groupId, types, filterActive, searchQueryFromRequest(request), user, arrayResponseHandler(request));
 				} else {
 					unauthorized(request);
 				}
@@ -718,19 +706,32 @@ public class UserController extends BaseController {
 		});
 	}
 
-	private Optional<TransversalSearchQuery> searchQueryFromRequest(final HttpServerRequest request) {
+	private TransversalSearchQuery searchQueryFromRequest(final HttpServerRequest request) {
 		final TransversalSearchQuery searchQuery;
 		final MultiMap params = request.params();
 		final String searchType = params.get("searchType");
-		final TransversalSearchType type = TransversalSearchType.fromCode(searchType);
-		if(TransversalSearchType.NAME.equals(type)) {
-			searchQuery = new TransversalSearchQuery(params.get("lastName"), params.get("firstName"));
-		} else if(TransversalSearchType.EMAIL.equals(type)) {
-			searchQuery = new TransversalSearchQuery(params.get("searchTerm"));
-		} else {
-			searchQuery = null;
+		final String searchTerm = params.get("searchTerm");
+		final String nameFilter = params.get("name");
+		final String lastNameFilter = params.get("lastName");
+		final String firstNameFilter = params.get("firstName");
+
+		/* Retro-compability : 
+		 * - if a "name" query parameter exists, its value must be used like a displayName.
+		 * - if a "lastName" or "firstName" query parameter exists, make an optimized search by fullname.
+		 * - otherwise, just apply the "searchTerm" and "searchType" query parameter, if any.
+		 */
+		if( nameFilter!=null && nameFilter.length()>0 && searchTerm==null && searchType==null) {
+			return TransversalSearchQuery.searchByDisplayName(nameFilter);
+		} if( !StringUtils.isEmpty(lastNameFilter) || !StringUtils.isEmpty(firstNameFilter) ) {
+			return TransversalSearchQuery.searchByFullName(lastNameFilter, firstNameFilter);
+		} else if( !StringUtils.isEmpty(searchTerm) ) {
+			final TransversalSearchType type = TransversalSearchType.fromCode(searchTerm);
+			if(TransversalSearchType.EMAIL.equals(type))
+				return TransversalSearchQuery.searchByMail(searchTerm);
+			if(TransversalSearchType.NAME.equals(type))
+				return TransversalSearchQuery.searchByDisplayName(searchTerm);
 		}
-		return Optional.ofNullable(searchQuery);
+		return TransversalSearchQuery.EMPTY;
 	}
 
 	@Put("/user/:studentId/related/:relativeId")

--- a/directory/src/main/java/org/entcore/directory/controllers/UserController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/UserController.java
@@ -725,7 +725,7 @@ public class UserController extends BaseController {
 		} if( !StringUtils.isEmpty(lastNameFilter) || !StringUtils.isEmpty(firstNameFilter) ) {
 			return TransversalSearchQuery.searchByFullName(lastNameFilter, firstNameFilter);
 		} else if( !StringUtils.isEmpty(searchTerm) ) {
-			final TransversalSearchType type = TransversalSearchType.fromCode(searchTerm);
+			final TransversalSearchType type = TransversalSearchType.fromCode(searchType);
 			if(TransversalSearchType.EMAIL.equals(type))
 				return TransversalSearchQuery.searchByMail(searchTerm);
 			if(TransversalSearchType.NAME.equals(type))

--- a/directory/src/main/java/org/entcore/directory/pojo/TransversalSearchQuery.java
+++ b/directory/src/main/java/org/entcore/directory/pojo/TransversalSearchQuery.java
@@ -21,7 +21,7 @@ public class TransversalSearchQuery {
 
     public static TransversalSearchQuery searchByFullName(final String lastName, final String firstName) {
         return new TransversalSearchQuery(
-            TransversalSearchType.NAME,
+            TransversalSearchType.FULL_NAME,
             lastName,
             firstName,
             null
@@ -30,7 +30,7 @@ public class TransversalSearchQuery {
 
     public static TransversalSearchQuery searchByDisplayName(final String fullname) {
         return new TransversalSearchQuery(
-            TransversalSearchType.NAME,
+            TransversalSearchType.DISPLAY_NAME,
             null,
             null,
             fullname

--- a/directory/src/main/java/org/entcore/directory/pojo/TransversalSearchQuery.java
+++ b/directory/src/main/java/org/entcore/directory/pojo/TransversalSearchQuery.java
@@ -1,28 +1,57 @@
 package org.entcore.directory.pojo;
 
 public class TransversalSearchQuery {
-    public static final TransversalSearchQuery EMPTY = new TransversalSearchQuery(null);
-    private final String email;
+    public static final TransversalSearchQuery EMPTY = new TransversalSearchQuery(TransversalSearchType.NONE, null, null, null);
+    private final String term;
     private final String lastName;
     private final String firstName;
     private final TransversalSearchType searchType;
 
-    public TransversalSearchQuery(final String lastName, final String firstName) {
+    private TransversalSearchQuery(
+            final TransversalSearchType type,
+            final String lastName, 
+            final String firstName, 
+            final String term 
+            ) {
+        this.searchType = type;
         this.lastName = lastName;
         this.firstName = firstName;
-        this.searchType = TransversalSearchType.NAME;
-        this.email = null;
+        this.term = term;
     }
 
-    public TransversalSearchQuery(final String email) {
-        this.email = email;
-        this.lastName = null;
-        this.firstName = null;
-        this.searchType = TransversalSearchType.EMAIL;
+    public static TransversalSearchQuery searchByFullName(final String lastName, final String firstName) {
+        return new TransversalSearchQuery(
+            TransversalSearchType.NAME,
+            lastName,
+            firstName,
+            null
+        );
+    }
+
+    public static TransversalSearchQuery searchByDisplayName(final String fullname) {
+        return new TransversalSearchQuery(
+            TransversalSearchType.NAME,
+            null,
+            null,
+            fullname
+        );
+    }
+
+    public static TransversalSearchQuery searchByMail(final String email) {
+        return new TransversalSearchQuery(
+            TransversalSearchType.EMAIL,
+            null,
+            null,
+            email
+        );
     }
 
     public String getEmail() {
-        return email;
+        return term;
+    }
+
+    public String getDisplayName() {
+        return term;
     }
 
     public String getLastName() {

--- a/directory/src/main/java/org/entcore/directory/pojo/TransversalSearchType.java
+++ b/directory/src/main/java/org/entcore/directory/pojo/TransversalSearchType.java
@@ -2,7 +2,8 @@ package org.entcore.directory.pojo;
 
 public enum TransversalSearchType {
     EMAIL("email"),
-    NAME("displayName"),
+    FULL_NAME("fullName"),
+    DISPLAY_NAME("displayName"),
     NONE("");
     private final String code;
 
@@ -14,8 +15,11 @@ public enum TransversalSearchType {
         if(EMAIL.code.equals(searchType)) {
             return EMAIL;
         }
-        if(NAME.code.equals(searchType)) {
-            return NAME;
+        if(FULL_NAME.code.equals(searchType)) {
+            return FULL_NAME;
+        }
+        if(DISPLAY_NAME.code.equals(searchType)) {
+            return DISPLAY_NAME;
         }
         return NONE;
     }

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
@@ -572,35 +572,40 @@ public class DefaultUserService implements UserService {
 			}
 		}
 		if(TransversalSearchType.EMAIL.equals(searchQuery.getSearchType()) && isNotEmpty(searchQuery.getEmail())) {
-			final String emailSearchTerm = normalize(searchQuery.getEmail());
-			condition += "AND u.emailSearchField CONTAINS {email} ";
-			params.put("email", searchQuery.getEmail());
-		} else if(TransversalSearchType.NAME.equals(searchQuery.getSearchType()) && (
-				isNotEmpty(searchQuery.getFirstName()) || isNotEmpty(searchQuery.getLastName()))) {
-			final String firstNameSearchTerm = normalize(searchQuery.getFirstName());
-			final String lastNameSearchTerm = normalize(searchQuery.getLastName());
-			final StringBuilder sbuilder = new StringBuilder();
-			sbuilder.append(" AND ");
-			final boolean hasLastName;
-			if(isEmpty(lastNameSearchTerm)) {
-				hasLastName = false;
-			} else {
-				sbuilder.append(" u.lastNameSearchField STARTS WITH {lastName} ");
-				params.put("lastName", lastNameSearchTerm);
-				hasLastName = true;
-			}
-			if(isNotEmpty(firstNameSearchTerm)) {
-				if(hasLastName) {
-					sbuilder.append(" and ");
+			final String searchTerm = normalize(searchQuery.getEmail());
+			condition += " AND u.emailSearchField CONTAINS {email} ";
+			params.put("email", searchTerm);
+		} else if(TransversalSearchType.NAME.equals(searchQuery.getSearchType())) {
+			if( isNotEmpty(searchQuery.getFirstName()) || isNotEmpty(searchQuery.getLastName()) ) {
+				final String firstNameSearchTerm = normalize(searchQuery.getFirstName());
+				final String lastNameSearchTerm = normalize(searchQuery.getLastName());
+				final StringBuilder sbuilder = new StringBuilder();
+				sbuilder.append(" AND ");
+				final boolean hasLastName;
+				if(isEmpty(lastNameSearchTerm)) {
+					hasLastName = false;
+				} else {
+					sbuilder.append(" u.lastNameSearchField STARTS WITH {lastName} ");
+					params.put("lastName", lastNameSearchTerm);
+					hasLastName = true;
 				}
-				sbuilder.append(" u.firstNameSearchField STARTS WITH {firstName} ");
-				params.put("firstName", firstNameSearchTerm);
+				if(isNotEmpty(firstNameSearchTerm)) {
+					if(hasLastName) {
+						sbuilder.append(" AND ");
+					}
+					sbuilder.append(" u.firstNameSearchField STARTS WITH {firstName} ");
+					params.put("firstName", firstNameSearchTerm);
+				}
+				condition += sbuilder.toString();
+			} else if(isNotEmpty(searchQuery.getDisplayName())) {
+				final String searchTerm = normalize(searchQuery.getDisplayName());
+				condition += " AND u.displayNameSearchField CONTAINS {displayName} ";
+				params.put("displayName", searchTerm);
 			}
-			condition += sbuilder.toString();
 		}
 		if(filterActivated != null){
 			if("inactive".equals(filterActivated)){
-				condition += "AND NOT(u.activationCode IS NULL)  ";
+				condition += "AND NOT(u.activationCode IS NULL) ";
 			} else if("active".equals(filterActivated)){
 				condition += "AND u.activationCode IS NULL ";
 			}


### PR DESCRIPTION
# Description

Note: cette branche porte aussi les commits du WB-1368, qui fait l'objet d'une autre PR mais est un pré-requis à celle-ci.

Cette branche porte 3 commits : 
* un refacto de la méthode `DefaultUserService.listAdmin()`
  qui met en relief les 3 parties constituant la requête neo4j finale : `MATCH (u:User) WHERE u...`, suivi de `WITH u MATCH (u)-[]-(Y) WHERE Y...` suivi de `OPTIONAL MATCH Z... RETURN...`
* un correctif du problème initial "dans la console admin v2, on ne voit pas les utilisateurs d'un groupe qui sont rattachés à une  structure dont on n'est pas l'ADML, ou qui ne sont pas rattachés"
* une évolution du frontend pour distinguer ces utilisateurs des autres.

La portée des utilisateurs visibles via cette méthode reste inchangée en cas de recherche transverse, grâce au booléen `restrictResultsToFunction` initialisé dans la partie 1. Autrement, les recherches d'utilisateurs appartenant à des groupes, classes ou structures ont de facto un périmètre déjà limité au groupe, classe ou structure.

A la relecture du refacto, j'ai un petit doute : 
la partie 1 de la requête `MATCH (u:User) WHERE u` applique désormais des conditions dans le WHERE qui n'étaient pas placées à cet endroit auparavant. L'idée est d'appliquer au plus tôt tout filtre permettant de restreindre le jeu de données, afin d'alléger la requête.
Mais les conditions genre `u.emailSearchField CONTAINS {email}` ou `AND u.displayNameSearchField CONTAINS {displayName}` me semblent à la réflexion présenter un risque de régression sur la performance générale de la requête finale.
Il vaut peut-être mieux les conserver dans la partie 2 ?

## Fixes

WB-1139

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [X] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [X] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Comparaison avant/après sur : 
* recherche transverse ADMC,
* recherche transverse ADML,
* affichage d'un groupe manuel transverse à 2 structures ou comportant un utilisateur non-rattaché,
* en tant qu'ADML, recherche globale sans paramétre pour vérification de sa portée (/directory/user/admin/list)
* test du frontend

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: