### PR TITLE
[ODE] Indexer les ressources importées depuis workspace

### DIFF
--- a/common/src/main/java/org/entcore/common/explorer/IExplorerFolderTree.java
+++ b/common/src/main/java/org/entcore/common/explorer/IExplorerFolderTree.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonObject;
 import org.entcore.common.user.UserInfos;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -12,5 +13,5 @@ import java.util.Optional;
 public interface IExplorerFolderTree {
     String FOLDER_TYPE = "folder";
 
-    Future<JsonObject> reindex(final Optional<Long> from, final Optional<Long> to);
+    Future<JsonObject> reindex(final Date from, final Date to);
 }

--- a/common/src/main/java/org/entcore/common/explorer/IExplorerPluginClient.java
+++ b/common/src/main/java/org/entcore/common/explorer/IExplorerPluginClient.java
@@ -6,6 +6,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.entcore.common.explorer.impl.ExplorerPluginClient;
 import org.entcore.common.explorer.impl.ExplorerPluginClientDefault;
+import org.entcore.common.explorer.to.ExplorerReindexResourcesRequest;
 import org.entcore.common.user.UserInfos;
 
 import java.util.*;
@@ -18,17 +19,7 @@ public interface IExplorerPluginClient {
         return new ExplorerPluginClientDefault(vertx, application);
     }
 
-    Future<IndexResponse> getForIndexation(Optional<Date> from, Optional<Date> to);
-
-    Future<IndexResponse> getForIndexation(Optional<Date> from, Optional<Date> to, Set<String> apps);
-
-    Future<IndexResponse> getForIndexation(Optional<Date> from, Optional<Date> to, Set<String> apps, boolean includeFolders);
-
-    Future<IndexResponse> getForIndexation(UserInfos user, Optional<Date> from, Optional<Date> to);
-
-    Future<IndexResponse> getForIndexation(UserInfos user, Optional<Date> from, Optional<Date> to, Set<String> apps);
-
-    Future<IndexResponse> getForIndexation(UserInfos user, Optional<Date> from, Optional<Date> to, Set<String> apps, boolean includeFolders);
+    Future<IndexResponse> reindex(UserInfos user, ExplorerReindexResourcesRequest request);
 
     Future<List<String>> createAll(UserInfos user, List<JsonObject> json, boolean isCopy);
 

--- a/common/src/main/java/org/entcore/common/explorer/IExplorerPluginClient.java
+++ b/common/src/main/java/org/entcore/common/explorer/IExplorerPluginClient.java
@@ -19,6 +19,12 @@ public interface IExplorerPluginClient {
         return new ExplorerPluginClientDefault(vertx, application);
     }
 
+    /**
+     * Reindex resources.
+     * @param user User requesting the reindexation
+     * @param request Filter for the resources to reindex
+     * @return A swift report of the indexation process
+     */
     Future<IndexResponse> reindex(UserInfos user, ExplorerReindexResourcesRequest request);
 
     Future<List<String>> createAll(UserInfos user, List<JsonObject> json, boolean isCopy);

--- a/common/src/main/java/org/entcore/common/explorer/IExplorerSubResource.java
+++ b/common/src/main/java/org/entcore/common/explorer/IExplorerSubResource.java
@@ -2,9 +2,11 @@ package org.entcore.common.explorer;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
+import org.entcore.common.explorer.to.ExplorerReindexSubResourcesRequest;
 import org.entcore.common.user.UserInfos;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -35,7 +37,7 @@ public interface IExplorerSubResource {
 
     Future<Void> notifyDelete(UserInfos user, List<JsonObject> sources);
 
-    Future<JsonObject> reindex(final Optional<Long> from, final Optional<Long> to);
+    Future<JsonObject> reindex(final ExplorerReindexSubResourcesRequest subResourcesRequest);
 
     Future<Void> onDeleteParent(final Collection<String> parentIds);
 

--- a/common/src/main/java/org/entcore/common/explorer/IExplorerSubResource.java
+++ b/common/src/main/java/org/entcore/common/explorer/IExplorerSubResource.java
@@ -6,10 +6,8 @@ import org.entcore.common.explorer.to.ExplorerReindexSubResourcesRequest;
 import org.entcore.common.user.UserInfos;
 
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 public interface IExplorerSubResource {
 
@@ -37,6 +35,10 @@ public interface IExplorerSubResource {
 
     Future<Void> notifyDelete(UserInfos user, List<JsonObject> sources);
 
+    /**
+     * @param subResourcesRequest Filter that sub-resources to reindex should match
+     * @return A swift report of the reindexation
+     */
     Future<JsonObject> reindex(final ExplorerReindexSubResourcesRequest subResourcesRequest);
 
     Future<Void> onDeleteParent(final Collection<String> parentIds);
@@ -52,7 +54,7 @@ public interface IExplorerSubResource {
     /**
      * Methods call by Ingest Job to notify a plugin that a batch of messages have a status update.
      * @param messages Messages whose status has changed
-     * @return A future which will succeed if all messages are ack-ed, false otherwise
+     * @return A future which will succeed if all messages are ack-ed
      */
     Future<Void> onJobStateUpdatedMessageReceived(final List<IngestJobStateUpdateMessage> messages);
 }

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerFolderTree.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerFolderTree.java
@@ -42,7 +42,7 @@ public abstract class ExplorerFolderTree implements IExplorerFolderTree {
     }
 
     @Override
-    public Future<JsonObject> reindex(final Optional<Long> from, final Optional<Long> to) {
+    public Future<JsonObject> reindex(final Date from, final Date to) {
         final Integer reindexBatchSize = this.parent.reindexBatchSize;
         final ExplorerStream<JsonObject> stream = new ExplorerStream<>(reindexBatchSize, bulk -> {
             final List<ExplorerMessage> messages =  toMessages(bulk);
@@ -50,7 +50,7 @@ public abstract class ExplorerFolderTree implements IExplorerFolderTree {
         }, metricsEnd -> {
             log.info(String.format("Ending indexation for app=%s type=%s from=%s to=%s metrics=%s",getApplication(), getFolderResourceType(), from, to, metricsEnd));
         });
-        this.doFetchForIndex(stream, from.map(e -> new Date(e)), to.map(e -> new Date(e)));
+        this.doFetchForIndex(stream, from, to);
         return stream.getEndFuture();
     }
 
@@ -95,5 +95,5 @@ public abstract class ExplorerFolderTree implements IExplorerFolderTree {
 
     protected abstract Date getCreatedAtForModel(final JsonObject json);
 
-    protected abstract void doFetchForIndex(final ExplorerStream<JsonObject> stream, final Optional<Date> from, final Optional<Date> to);
+    protected abstract void doFetchForIndex(final ExplorerStream<JsonObject> stream, final Date from, final Date to);
 }

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerFolderTreeMongo.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerFolderTreeMongo.java
@@ -79,17 +79,17 @@ public abstract class ExplorerFolderTreeMongo extends ExplorerFolderTree{
     }
 
     @Override
-    protected void doFetchForIndex(final ExplorerStream<JsonObject> stream, final Optional<Date> from, final Optional<Date> to) {
+    protected void doFetchForIndex(final ExplorerStream<JsonObject> stream, final Date from, final Date to) {
         final QueryBuilder query = QueryBuilder.start();
-        if (from.isPresent() || to.isPresent()) {
-            if (from.isPresent()) {
-                final LocalDateTime localFrom = Instant.ofEpochMilli(from.get().getTime())
+        if (from != null || to != null) {
+            if (from != null) {
+                final LocalDateTime localFrom = Instant.ofEpochMilli(from.getTime())
                         .atZone(ZoneId.systemDefault())
                         .toLocalDateTime();
                 query.and(getCreatedAtColumn()).greaterThanEquals(toMongoDate(localFrom));
             }
-            if (to.isPresent()) {
-                final LocalDateTime localTo = Instant.ofEpochMilli(to.get().getTime())
+            if (to != null) {
+                final LocalDateTime localTo = Instant.ofEpochMilli(to.getTime())
                         .atZone(ZoneId.systemDefault())
                         .toLocalDateTime();
                 query.and(getCreatedAtColumn()).lessThan(toMongoDate(localTo));

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerFolderTreeSql.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerFolderTreeSql.java
@@ -77,7 +77,7 @@ public abstract class ExplorerFolderTreeSql extends ExplorerFolderTree{
     }
 
     @Override
-    protected void doFetchForIndex(final ExplorerStream<JsonObject> stream, final Optional<Date> from, final Optional<Date> to) {
+    protected void doFetchForIndex(final ExplorerStream<JsonObject> stream, final Date from, final Date to) {
         final Tuple tuple = Tuple.tuple();
         final StringBuilder query = new StringBuilder();
         if(getUserTableName().isPresent()){
@@ -98,24 +98,24 @@ public abstract class ExplorerFolderTreeSql extends ExplorerFolderTree{
             }
         }
         //WHERE
-        if (from.isPresent() && to.isPresent()) {
-            final LocalDateTime localFrom = Instant.ofEpochMilli(from.get().getTime())
+        if (from != null && to != null) {
+            final LocalDateTime localFrom = Instant.ofEpochMilli(from.getTime())
                     .atZone(ZoneId.systemDefault())
                     .toLocalDateTime();
-            final LocalDateTime localTo = Instant.ofEpochMilli(to.get().getTime())
+            final LocalDateTime localTo = Instant.ofEpochMilli(to.getTime())
                     .atZone(ZoneId.systemDefault())
                     .toLocalDateTime();
             tuple.addValue(localFrom);
             tuple.addValue(localTo);
             query.append(String.format("WHERE f.%s >= $1 AND f.%s < $2 ",getCreatedAtColumn(),getCreatedAtColumn()));
-        } else if (from.isPresent()) {
-            final LocalDateTime localFrom = Instant.ofEpochMilli(from.get().getTime())
+        } else if (from != null) {
+            final LocalDateTime localFrom = Instant.ofEpochMilli(from.getTime())
                     .atZone(ZoneId.systemDefault())
                     .toLocalDateTime();
             tuple.addValue(localFrom);
             query.append(String.format("WHERE f.%s >= $1 ",getCreatedAtColumn()));
-        } else if (to.isPresent()) {
-            final LocalDateTime localTo = Instant.ofEpochMilli(to.get().getTime())
+        } else if (to != null) {
+            final LocalDateTime localTo = Instant.ofEpochMilli(to.getTime())
                     .atZone(ZoneId.systemDefault())
                     .toLocalDateTime();
             tuple.addValue(localTo);

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPlugin.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPlugin.java
@@ -17,7 +17,6 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
-import static java.util.Collections.singletonList;
 import org.entcore.common.explorer.ExplorerMessage;
 import org.entcore.common.explorer.ExplorerStream;
 import org.entcore.common.explorer.IExplorerFolderTree;
@@ -350,7 +349,7 @@ public abstract class ExplorerPlugin implements IExplorerPlugin {
 
     @Override
     public Future<Map<String, JsonArray>> getShareInfo(Set<String> ids) {
-        final JsonArray payload = new JsonArray(singletonList(ids));
+        final JsonArray payload = new JsonArray(new ArrayList(ids));
         final Promise<Map<String,JsonArray>> promise = Promise.promise();
         final DeliveryOptions deliveryOptions = new DeliveryOptions().addHeader("action", ResourceActions.GetShares.name());
         communication.vertx().eventBus().request(RESOURCES_ADDRESS, payload, deliveryOptions, message -> {

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPlugin.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPlugin.java
@@ -274,7 +274,7 @@ public abstract class ExplorerPlugin implements IExplorerPlugin {
     protected void onReindexAction(final Message<JsonObject> message, final ExplorerReindexResourcesRequest request){
         final long now = currentTimeMillis();
         final Set<String> apps = request.getApps();
-        if(apps !=  null && !apps.contains(getApplication())){
+        if(apps !=  null && !apps.isEmpty() && !apps.contains(getApplication())){
             log.info(String.format("Skip indexation for app=%s filter=%s", getApplication(), apps));
             reply(message, new ExplorerReindexResourcesResponse(0, 0, emptyMap()));
             return;

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPluginClient.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPluginClient.java
@@ -6,7 +6,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import static java.util.Collections.emptySet;
 import org.entcore.common.explorer.IExplorerPluginClient;
 import org.entcore.common.explorer.to.ExplorerReindexResourcesRequest;
 import org.entcore.common.explorer.to.ExplorerReindexResourcesResponse;
@@ -14,10 +13,7 @@ import org.entcore.common.user.UserInfos;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -36,12 +32,13 @@ public abstract class ExplorerPluginClient implements IExplorerPluginClient {
                 headers.add("userName", user.getUsername());
             }
         }
-        final Future<ExplorerReindexResourcesResponse> future = send(headers, JsonObject.mapFrom(request), Duration.ofDays(100));
+        final Future<JsonObject> future = send(headers, JsonObject.mapFrom(request), Duration.ofDays(100));
         log.info("Trigger indexation " + request);
         return future.map(res->{
             log.info(String.format("End trigger indexation " + res));
-            final int nb_message = res.getNbMessages();
-            final int nb_batch = res.getNbBatch();
+            final ExplorerReindexResourcesResponse response = res.mapTo(ExplorerReindexResourcesResponse.class);
+            final int nb_message = response.getNbMessages();
+            final int nb_batch = response.getNbBatch();
             return new IndexResponse(nb_batch, nb_message);
         });
     }

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPluginResourceMongo.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPluginResourceMongo.java
@@ -17,6 +17,7 @@ import org.entcore.common.explorer.ExplorerStream;
 import org.entcore.common.explorer.IExplorerPluginCommunication;
 import org.entcore.common.explorer.IngestJobState;
 import org.entcore.common.explorer.IngestJobStateUpdateMessage;
+import org.entcore.common.explorer.to.ExplorerReindexResourcesRequest;
 import org.entcore.common.user.UserInfos;
 
 import java.time.Instant;
@@ -76,17 +77,22 @@ public abstract class ExplorerPluginResourceMongo extends ExplorerPluginResource
     }
 
     @Override
-    protected void doFetchForIndex(final ExplorerStream<JsonObject> stream, final Optional<Date> from, final Optional<Date> to) {
+    protected void doFetchForIndex(final ExplorerStream<JsonObject> stream, final ExplorerReindexResourcesRequest request) {
         final QueryBuilder query = QueryBuilder.start();
-        if (from.isPresent() || to.isPresent()) {
-            if (from.isPresent()) {
-                final LocalDateTime localFrom = Instant.ofEpochMilli(from.get().getTime())
+        final Date from = request.getFrom();
+        final Date to = request.getTo();
+        if(request.getIds() != null && !request.getIds().isEmpty()) {
+            query.and(getIdColumn()).in(request.getIds());
+        }
+        if (from != null || to != null) {
+            if (from != null) {
+                final LocalDateTime localFrom = Instant.ofEpochMilli(from.getTime())
                         .atZone(ZoneId.systemDefault())
                         .toLocalDateTime();
                 query.and(getCreatedAtColumn()).greaterThanEquals(toMongoDate(localFrom));
             }
-            if (to.isPresent()) {
-                final LocalDateTime localTo = Instant.ofEpochMilli(to.get().getTime())
+            if (to != null) {
+                final LocalDateTime localTo = Instant.ofEpochMilli(to.getTime())
                         .atZone(ZoneId.systemDefault())
                         .toLocalDateTime();
                 query.and(getCreatedAtColumn()).lessThan(toMongoDate(localTo));

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerRepositoryEvents.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerRepositoryEvents.java
@@ -18,21 +18,20 @@
 
 package org.entcore.common.explorer.impl;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.entcore.common.explorer.IExplorerPluginClient;
 import org.entcore.common.explorer.to.ExplorerReindexResourcesRequest;
 import org.entcore.common.user.RepositoryEvents;
-
-import io.vertx.core.Handler;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import org.entcore.common.user.UserInfos;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * This implementation of the RepositoryEvents follows the proxy pattern.
@@ -42,16 +41,17 @@ public class ExplorerRepositoryEvents implements RepositoryEvents {
 
 	private static final Logger log = LoggerFactory.getLogger(ExplorerRepositoryEvents.class);
 
-	private RepositoryEvents realRepositoryEvents;
-	private Map<String, IExplorerPluginClient> pluginClientsForApp;
+	/** Proxyfied events repository that will be used to import/export resources.*/
+	private final RepositoryEvents realRepositoryEvents;
+	/**
+	 * Associates the table or collection imported to the plugin to use to reindex the associated resources.
+	 */
+	private final Map<String, IExplorerPluginClient> pluginClientsForApp;
 
-	public ExplorerRepositoryEvents(final RepositoryEvents realRepositoryEvents) {
+	public ExplorerRepositoryEvents(final RepositoryEvents realRepositoryEvents,
+									final Map<String, IExplorerPluginClient> pluginClientsForApp) {
 		this.realRepositoryEvents = realRepositoryEvents;
-	}
-
-	public ExplorerRepositoryEvents setPlugin(IExplorerPluginClient plugin, final Map<String, IExplorerPluginClient> pluginClientsForApp) {
 		this.pluginClientsForApp = pluginClientsForApp;
-		return this;
 	}
 
 	@Override
@@ -90,7 +90,7 @@ public class ExplorerRepositoryEvents implements RepositoryEvents {
 					if(idsToReindex.isEmpty()) {
 						log.info("Nothing to reindex in EUR");
 					} else {
-						log.info("Reindexing " + idsToReindex.size() + " resources in EUR");
+						log.info("Reindexing " + idsToReindex.size() + " resources in EUR of type " + collection);
 						final IExplorerPluginClient pluginClient = pluginClientsForApp.get(collection);
 						final UserInfos userInfos = new UserInfos();
 						userInfos.setUserId(userId);

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerRepositoryEvents.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerRepositoryEvents.java
@@ -58,7 +58,7 @@ public class ExplorerRepositoryEvents implements RepositoryEvents {
 	public void exportResources(boolean exportDocuments, boolean exportSharedResources, String exportId, String userId, JsonArray groups, String exportPath,
 						 String locale, String host, Handler<Boolean> handler) {
 		realRepositoryEvents.exportResources(exportDocuments, exportSharedResources, exportId, userId, groups, exportPath, locale, host, handler);
-	};
+	}
 
 	@Override
 	public void exportResources(JsonArray resourcesIds, boolean exportDocuments, boolean exportSharedResources, String exportId, String userId,
@@ -79,9 +79,10 @@ public class ExplorerRepositoryEvents implements RepositoryEvents {
 		});
 	}
 
-	private void reindexResourcesAfterImport(final String userId, final String userLogin, final String userName, final JsonObject jo) {
-		if( pluginClientsForApp != null && jo.containsKey("resourcesIdsMap")) {
-			final JsonObject resourcesIdsMap = jo.getJsonObject("resourcesIdsMap");
+	private void reindexResourcesAfterImport(final String userId, final String userLogin, final String userName,
+											 final JsonObject reindexationReport) {
+		if( pluginClientsForApp != null && reindexationReport.containsKey("resourcesIdsMap")) {
+			final JsonObject resourcesIdsMap = reindexationReport.getJsonObject("resourcesIdsMap");
 			resourcesIdsMap.stream().forEach(e -> {
 				final String collection = e.getKey();
 				final JsonObject idsMapForApp = (JsonObject) e.getValue();
@@ -102,7 +103,7 @@ public class ExplorerRepositoryEvents implements RepositoryEvents {
 			});
 		} else {
 			log.debug("Nothing to do as no plugin client is defined (" + (pluginClientsForApp == null) +
-					") and/or resourcesIdsMap is not set (" + (jo.containsKey("resourcesIdsMap")) + ")");
+					") and/or resourcesIdsMap is not set (" + (reindexationReport.containsKey("resourcesIdsMap")) + ")");
 		}
 	}
 

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerSubResource.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerSubResource.java
@@ -12,6 +12,7 @@ import org.entcore.common.explorer.IExplorerPlugin;
 import org.entcore.common.explorer.IExplorerPluginCommunication;
 import org.entcore.common.explorer.IExplorerSubResource;
 import org.entcore.common.explorer.IdAndVersion;
+import org.entcore.common.explorer.to.ExplorerReindexSubResourcesRequest;
 import org.entcore.common.user.UserInfos;
 
 import java.util.ArrayList;
@@ -148,7 +149,7 @@ public abstract class ExplorerSubResource implements IExplorerSubResource {
     }
 
     @Override
-    public Future<JsonObject> reindex(final Optional<Long> from, final Optional<Long> to) {
+    public Future<JsonObject> reindex(final ExplorerReindexSubResourcesRequest subResourcesRequest) {
         final long now = currentTimeMillis();
         final Integer reindexBatchSize = this.parent.reindexBatchSize;
         final ExplorerStream<JsonObject> stream = new ExplorerStream<>(reindexBatchSize, bulk -> {
@@ -167,9 +168,9 @@ public abstract class ExplorerSubResource implements IExplorerSubResource {
                 return getCommunication().pushMessage(messages);
             });
         }, metricsEnd -> {
-            log.info(String.format("Ending indexation for app=%s type=%s from=%s to=%s metrics=%s",getApplication(), getResourceType(), from, to, metricsEnd));
+            log.info(String.format("Ending indexation for app=%s type=%s %s metrics=%s",getApplication(), getResourceType(), subResourcesRequest, metricsEnd));
         });
-        this.doFetchForIndex(stream, from.map(e -> new Date(e)), to.map(e -> new Date(e)));
+        this.doFetchForIndex(stream, subResourcesRequest);
         return stream.getEndFuture();
     }
 
@@ -191,7 +192,7 @@ public abstract class ExplorerSubResource implements IExplorerSubResource {
 
     protected abstract Future<ExplorerMessage> doToMessage(final ExplorerMessage message, final JsonObject source);
 
-    protected abstract void doFetchForIndex(final ExplorerStream<JsonObject> stream, final Optional<Date> from, final Optional<Date> to);
+    protected abstract void doFetchForIndex(final ExplorerStream<JsonObject> stream, final ExplorerReindexSubResourcesRequest subResourcesRequest);
 
 
     public void start() {

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerSubResourceSql.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerSubResourceSql.java
@@ -6,6 +6,7 @@ import io.vertx.sqlclient.Tuple;
 import static java.lang.Long.parseLong;
 import org.entcore.common.explorer.ExplorerStream;
 import org.entcore.common.explorer.IngestJobStateUpdateMessage;
+import org.entcore.common.explorer.to.ExplorerReindexSubResourcesRequest;
 import org.entcore.common.postgres.IPostgresClient;
 import org.entcore.common.postgres.PostgresClient;
 import org.entcore.common.sql.SqlResult;
@@ -15,9 +16,11 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public abstract class ExplorerSubResourceSql extends ExplorerSubResource{
     protected final IPostgresClient postgresClient;
@@ -58,9 +61,11 @@ public abstract class ExplorerSubResourceSql extends ExplorerSubResource{
     }
 
     @Override
-    protected void doFetchForIndex(final ExplorerStream<JsonObject> stream, final Optional<Date> from, final Optional<Date> to) {
+    protected void doFetchForIndex(final ExplorerStream<JsonObject> stream, final ExplorerReindexSubResourcesRequest request) {
         final Tuple tuple = Tuple.tuple();
         final StringBuilder query = new StringBuilder();
+        final Date from = request.getFrom();
+        final Date to = request.getTo();
         if(getShareTableName().isPresent()){
             final String schema = getTableName().split("\\.")[0];
             final String shareTable = getShareTableName().get();
@@ -73,28 +78,47 @@ public abstract class ExplorerSubResourceSql extends ExplorerSubResource{
         }else{
             query.append(String.format("SELECT * FROM %s ", getTableName()));
         }
-        if (from.isPresent() && to.isPresent()) {
-            final LocalDateTime localFrom = Instant.ofEpochMilli(from.get().getTime())
+        int nbParams = 0;
+        final List<String> filters = new ArrayList<>();
+        if (from != null && to != null) {
+            final LocalDateTime localFrom = Instant.ofEpochMilli(from.getTime())
                     .atZone(ZoneId.systemDefault())
                     .toLocalDateTime();
-            final LocalDateTime localTo = Instant.ofEpochMilli(to.get().getTime())
+            final LocalDateTime localTo = Instant.ofEpochMilli(to.getTime())
                     .atZone(ZoneId.systemDefault())
                     .toLocalDateTime();
             tuple.addValue(localFrom);
             tuple.addValue(localTo);
-            query.append(String.format("WHERE %s >= $1 AND %s < $2 ",getCreatedAtColumn(),getCreatedAtColumn()));
-        } else if (from.isPresent()) {
-            final LocalDateTime localFrom = Instant.ofEpochMilli(from.get().getTime())
+            filters.add(String.format(" %s >= $1 AND %s < $2 ",getCreatedAtColumn(),getCreatedAtColumn()));
+            nbParams += 2;
+        } else if (from != null) {
+            final LocalDateTime localFrom = Instant.ofEpochMilli(from.getTime())
                     .atZone(ZoneId.systemDefault())
                     .toLocalDateTime();
             tuple.addValue(localFrom);
-            query.append(String.format("WHERE %s >= $1 ",getCreatedAtColumn()));
-        } else if (to.isPresent()) {
-            final LocalDateTime localTo = Instant.ofEpochMilli(to.get().getTime())
+            filters.add(String.format(" %s >= $1 ",getCreatedAtColumn()));
+            nbParams ++;
+        } else if (to != null) {
+            final LocalDateTime localTo = Instant.ofEpochMilli(to.getTime())
                     .atZone(ZoneId.systemDefault())
                     .toLocalDateTime();
             tuple.addValue(localTo);
-            query.append(String.format("WHERE %s < $1 ",getCreatedAtColumn()));
+            filters.add(String.format(" %s < $1 ",getCreatedAtColumn()));
+            nbParams ++;
+        }
+        if(request.getIds() != null && !request.getIds().isEmpty()) {
+            nbParams ++;
+            filters.add(getIdColumn() + " in $" + nbParams);
+            tuple.addValue(request.getIds());
+        }
+        if(request.getParentIds() != null && !request.getParentIds().isEmpty()) {
+            nbParams ++;
+            filters.add(getParentIdColumn() + " in $" + nbParams);
+            tuple.addValue(request.getParentIds());
+        }
+        if(!filters.isEmpty()) {
+            query.append(" WHERE ");
+            query.append(filters.stream().collect(Collectors.joining(" AND ")));
         }
         if(getShareTableName().isPresent()){
             query.append(" GROUP BY t.id ");
@@ -131,6 +155,7 @@ public abstract class ExplorerSubResourceSql extends ExplorerSubResource{
     protected String getIdColumn() {
         return "id";
     }
+    protected abstract String getParentIdColumn();
 
     protected int getBatchSize() { return 50; }
 

--- a/common/src/main/java/org/entcore/common/explorer/to/ExplorerReindexResourcesRequest.java
+++ b/common/src/main/java/org/entcore/common/explorer/to/ExplorerReindexResourcesRequest.java
@@ -3,18 +3,24 @@ package org.entcore.common.explorer.to;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import static java.util.Collections.emptySet;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.Set;
 
+/**
+ * Filter for resources to be reindexed in EUR.
+ */
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class ExplorerReindexResourcesRequest {
+    /** Earliest creation date of the sub-resources to reindex.*/
     private final Date from;
+    /** Latest creation date of the sub-resources to reindex.*/
     private final Date to;
+    /** Identifier of the apps of the resources to reindex.*/
     private final Set<String> apps;
+    /** {@code true} if folders should also be reindexed.*/
     private final boolean includeFolders;
+    /** Ids of the resources to reindex.*/
     private final Set<String> ids;
 
 

--- a/common/src/main/java/org/entcore/common/explorer/to/ExplorerReindexResourcesRequest.java
+++ b/common/src/main/java/org/entcore/common/explorer/to/ExplorerReindexResourcesRequest.java
@@ -1,0 +1,70 @@
+package org.entcore.common.explorer.to;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import static java.util.Collections.emptySet;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class ExplorerReindexResourcesRequest {
+    private final Date from;
+    private final Date to;
+    private final Set<String> apps;
+    private final boolean includeFolders;
+    private final Set<String> ids;
+
+
+    @JsonCreator
+    public ExplorerReindexResourcesRequest(@JsonProperty("from") final Date from,
+                                           @JsonProperty("to") final Date to,
+                                           @JsonProperty("apps") final Set<String> apps,
+                                           @JsonProperty("includeFolders") final boolean includeFolders,
+                                           @JsonProperty("ids") final Set<String> ids) {
+        this.from = from;
+        this.to = to;
+        this.apps = apps;
+        this.includeFolders = includeFolders;
+        this.ids = ids;
+    }
+    public ExplorerReindexResourcesRequest(final Set<String> ids) {
+        this(null, null, null, false, ids);
+    }
+    public ExplorerReindexResourcesRequest() {
+        this(null, null, null, false, null);
+    }
+
+    public Date getFrom() {
+        return from;
+    }
+
+    public Date getTo() {
+        return to;
+    }
+
+    public Set<String> getApps() {
+        return apps;
+    }
+
+    public boolean isIncludeFolders() {
+        return includeFolders;
+    }
+
+    public Set<String> getIds() {
+        return ids;
+    }
+
+    @Override
+    public String toString() {
+        return "ExplorerReindexRequest{" +
+                "from=" + from +
+                ", to=" + to +
+                ", apps=" + apps +
+                ", includeFolders=" + includeFolders +
+                ", ids=" + ids +
+                '}';
+    }
+}

--- a/common/src/main/java/org/entcore/common/explorer/to/ExplorerReindexResourcesResponse.java
+++ b/common/src/main/java/org/entcore/common/explorer/to/ExplorerReindexResourcesResponse.java
@@ -3,18 +3,19 @@ package org.entcore.common.explorer.to;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.vertx.core.json.JsonObject;
+
+import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class ExplorerReindexResourcesResponse {
     private final int nbMessages;
     private final int nbBatch;
-    private final JsonObject metrics;
+    private final Map<String, Object> metrics;
 
     @JsonCreator
     public ExplorerReindexResourcesResponse(@JsonProperty("nbMessages") final int nbMessages,
                                             @JsonProperty("nbBatch") final int nbBatch,
-                                            @JsonProperty("metrics") final JsonObject metrics) {
+                                            @JsonProperty("metrics") final Map<String, Object> metrics) {
         this.nbBatch = nbBatch;
         this.nbMessages = nbMessages;
         this.metrics = metrics;
@@ -28,7 +29,7 @@ public class ExplorerReindexResourcesResponse {
         return nbBatch;
     }
 
-    public JsonObject getMetrics() {
+    public Map<String, Object> getMetrics() {
         return metrics;
     }
 

--- a/common/src/main/java/org/entcore/common/explorer/to/ExplorerReindexResourcesResponse.java
+++ b/common/src/main/java/org/entcore/common/explorer/to/ExplorerReindexResourcesResponse.java
@@ -1,0 +1,42 @@
+package org.entcore.common.explorer.to;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.vertx.core.json.JsonObject;
+
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class ExplorerReindexResourcesResponse {
+    private final int nbMessages;
+    private final int nbBatch;
+    private final JsonObject metrics;
+
+    @JsonCreator
+    public ExplorerReindexResourcesResponse(@JsonProperty("nbMessages") final int nbMessages,
+                                            @JsonProperty("nbBatch") final int nbBatch,
+                                            @JsonProperty("metrics") final JsonObject metrics) {
+        this.nbBatch = nbBatch;
+        this.nbMessages = nbMessages;
+        this.metrics = metrics;
+    }
+
+    public int getNbMessages() {
+        return nbMessages;
+    }
+
+    public int getNbBatch() {
+        return nbBatch;
+    }
+
+    public JsonObject getMetrics() {
+        return metrics;
+    }
+
+    @Override
+    public String toString() {
+        return "ExplorerReindexResponse{" +
+                "nbMessages=" + nbMessages +
+                ", nbBatch=" + nbBatch +
+                '}';
+    }
+}

--- a/common/src/main/java/org/entcore/common/explorer/to/ExplorerReindexSubResourcesRequest.java
+++ b/common/src/main/java/org/entcore/common/explorer/to/ExplorerReindexSubResourcesRequest.java
@@ -7,11 +7,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Date;
 import java.util.Set;
 
+/**
+ * Filter for sub resources to be reindexed in EUR.
+ */
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class ExplorerReindexSubResourcesRequest {
+    /** Earliest creation date of the sub-resources to reindex.*/
     private final Date from;
+    /** Latest creation date of the sub-resources to reindex.*/
     private final Date to;
+    /** Ids of the parent resources whose sub-resources should be reindexed.*/
     private final Set<String> parentIds;
+    /** Ids of the sub-resources to reindex.*/
     private final Set<String> ids;
 
     @JsonCreator

--- a/common/src/main/java/org/entcore/common/explorer/to/ExplorerReindexSubResourcesRequest.java
+++ b/common/src/main/java/org/entcore/common/explorer/to/ExplorerReindexSubResourcesRequest.java
@@ -1,0 +1,53 @@
+package org.entcore.common.explorer.to;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Date;
+import java.util.Set;
+
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class ExplorerReindexSubResourcesRequest {
+    private final Date from;
+    private final Date to;
+    private final Set<String> parentIds;
+    private final Set<String> ids;
+
+    @JsonCreator
+    public ExplorerReindexSubResourcesRequest(@JsonProperty("from") final Date from,
+                                              @JsonProperty("to") final Date to,
+                                              @JsonProperty("parentIds") final Set<String> parentIds,
+                                              @JsonProperty("ids") final Set<String> ids) {
+        this.from = from;
+        this.to = to;
+        this.parentIds = parentIds;
+        this.ids = ids;
+    }
+
+    public Date getFrom() {
+        return from;
+    }
+
+    public Date getTo() {
+        return to;
+    }
+
+    public Set<String> getParentIds() {
+        return parentIds;
+    }
+
+    public Set<String> getIds() {
+        return ids;
+    }
+
+    @Override
+    public String toString() {
+        return "ExplorerReindexSubResourcesRequest{" +
+                "from=" + from +
+                ", to=" + to +
+                ", parentIds=" + parentIds +
+                ", ids=" + ids +
+                '}';
+    }
+}

--- a/common/src/test/java/org/entcore/common/explorer/ExplorerRepositoryEventsTest.java
+++ b/common/src/test/java/org/entcore/common/explorer/ExplorerRepositoryEventsTest.java
@@ -1,0 +1,208 @@
+package org.entcore.common.explorer;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.entcore.common.explorer.impl.ExplorerRepositoryEvents;
+import org.entcore.common.explorer.to.ExplorerReindexResourcesRequest;
+import org.entcore.common.user.RepositoryEvents;
+import org.entcore.common.user.UserInfos;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@RunWith(VertxUnitRunner.class)
+public class ExplorerRepositoryEventsTest {
+
+
+    @Test
+    public void testImportNoResources(TestContext context) {
+        final Async async = context.async();
+        final Map<String, IExplorerPluginClient> pluginMap = new HashMap<>();
+        final RecordingReindexPluginClient plugin = new RecordingReindexPluginClient();
+        pluginMap.put("toto", plugin);
+        final ExplorerRepositoryEvents explorerRepositoryEvents = new ExplorerRepositoryEvents(
+                new RepositoryEventsWithSuppliedImportReport(new JsonObject()),
+                pluginMap);
+        explorerRepositoryEvents.importResources("importId", "userId", "userLogin",
+                "userName", "importPath", "locale", "host", false, e -> {
+            context.assertTrue(plugin.requests.isEmpty(), "Reindex should not have been called");
+            async.complete();
+        });
+    }
+
+    @Test
+    public void testImportNullResources(TestContext context) {
+        final Map<String, IExplorerPluginClient> pluginMap = new HashMap<>();
+        final RecordingReindexPluginClient plugin = new RecordingReindexPluginClient();
+        pluginMap.put("toto", plugin);
+        final ExplorerRepositoryEvents explorerRepositoryEvents = new ExplorerRepositoryEvents(
+                new RepositoryEventsWithSuppliedImportReport(null),
+                pluginMap);
+        explorerRepositoryEvents.importResources("importId", "userId", "userLogin", "userName",
+                "importPath", "locale", "host", false, e -> {
+                context.assertTrue(plugin.requests.isEmpty(), "Reindex should not have been called");
+        });
+    }
+
+    @Test
+    public void testImportResourcesNotConcernedByThePlugin(TestContext context) {
+        final Map<String, IExplorerPluginClient> pluginMap = new HashMap<>();
+        final RecordingReindexPluginClient plugin = new RecordingReindexPluginClient();
+        pluginMap.put("toto", plugin);
+        final ExplorerRepositoryEvents explorerRepositoryEvents = new ExplorerRepositoryEvents(
+                new RepositoryEventsWithSuppliedImportReport(populateImportedResourcesForApp("tata")),
+                pluginMap);
+        explorerRepositoryEvents.importResources("importId", "userId", "userLogin", "userName",
+        "importPath", "locale", "host", false, e -> {
+            context.assertTrue(plugin.requests.isEmpty(), "Reindex should not have been called because no data were of a type handled by the plugin");
+        });
+    }
+
+    @Test
+    public void testImportResourcesConcernedByThePlugin(TestContext context) {
+        final Map<String, IExplorerPluginClient> pluginMap = new HashMap<>();
+        final RecordingReindexPluginClient plugin = new RecordingReindexPluginClient();
+        pluginMap.put("toto", plugin);
+        final ExplorerRepositoryEvents explorerRepositoryEvents = new ExplorerRepositoryEvents(
+            new RepositoryEventsWithSuppliedImportReport(populateImportedResourcesForApp("toto")),
+            pluginMap);
+        explorerRepositoryEvents.importResources("importId", "userId", "userLogin", "userName",
+                "importPath", "locale", "host", false, e -> {
+            context.assertEquals(1, plugin.requests.size(), "Reindex should have been called once for imported data");
+            final ExplorerReindexResourcesRequest reindexRequest = plugin.requests.get(0);
+            final Set<String> ids = reindexRequest.getIds();
+            context.assertEquals(3, ids.size(), "all resources should have been reindexed");
+            context.assertTrue(ids.contains("toto-id1"), "id 1 should have been reindexed");
+            context.assertTrue(ids.contains("toto-id2"), "id 2 should have been reindexed");
+            context.assertTrue(ids.contains("toto-id4"), "id 4 should have been reindexed");
+        });
+    }
+
+    private JsonObject populateImportedResourcesForApp(final String appName) {
+        return populateImportedResourcesForApp(appName, new JsonObject());
+    }
+    private JsonObject populateImportedResourcesForApp(final String appName, final JsonObject report) {
+        final JsonObject resourcesIdsMap = report.getJsonObject("resourcesIdsMap", new JsonObject());
+        final JsonObject idsMapForApp = new JsonObject()
+                .put("id1", appName + "-id1")
+                .put("id2", appName + "-id2")
+                .put("id3", appName + "-id4"); // Case of an id collision
+        resourcesIdsMap.put(appName, idsMapForApp);
+        report.put("resourcesIdsMap", resourcesIdsMap);
+        return report;
+    }
+
+
+    public static class RecordingReindexPluginClient extends DummyPluginClient {
+        private final List<ExplorerReindexResourcesRequest> requests = new ArrayList<>();
+        @Override
+        public Future<IndexResponse> reindex(final UserInfos user, final ExplorerReindexResourcesRequest request) {
+            requests.add(request);
+            return super.reindex(user, request);
+        }
+    }
+
+
+    public static class DummyPluginClient implements IExplorerPluginClient {
+
+        @Override
+        public Future<IndexResponse> reindex(final UserInfos user, final ExplorerReindexResourcesRequest request) {
+            return Future.succeededFuture(new IndexResponse(0, 0));
+        }
+
+        @Override
+        public Future<List<String>> createAll(final UserInfos user, final List<JsonObject> json, final boolean isCopy) {
+            return Future.succeededFuture(Collections.emptyList());
+        }
+
+        @Override
+        public Future<DeleteResponse> deleteById(final UserInfos user, final Set<String> ids) {
+            return Future.succeededFuture(new DeleteResponse());
+        }
+
+        @Override
+        public Future<ShareResponse> shareByIds(final UserInfos user, final Set<String> ids, final JsonObject shares) {
+            return Future.succeededFuture(new ShareResponse(0, new JsonObject()));
+        }
+
+        @Override
+        public Future<JsonObject> getMetrics(final UserInfos user) {
+            return Future.succeededFuture(new JsonObject());
+        }
+    }
+
+    public static class RepositoryEventsWithSuppliedImportReport implements RepositoryEvents {
+        private final JsonObject report;
+
+        public RepositoryEventsWithSuppliedImportReport(final JsonObject report) {
+            this.report = report;
+        }
+        @Override
+        public void exportResources(final boolean exportDocuments, final boolean exportSharedResources, final String exportId, final String userId, final JsonArray groups, final String exportPath, final String locale, final String host, final Handler<Boolean> handler) {
+            handler.handle(true);
+        }
+
+        @Override
+        public void exportResources(final JsonArray resourcesIds, final boolean exportDocuments, final boolean exportSharedResources, final String exportId, final String userId, final JsonArray groups, final String exportPath, final String locale, final String host, final Handler<Boolean> handler) {
+            handler.handle(true);
+        }
+
+        @Override
+        public void importResources(final String importId, final String userId, final String userLogin, final String userName, final String importPath, final String locale, final String host, final boolean forceImportAsDuplication, final Handler<JsonObject> handler) {
+            handler.handle(report);
+        }
+
+        @Override
+        public void deleteGroups(final JsonArray groups) {
+        }
+
+        @Override
+        public void deleteGroups(final JsonArray groups, final Handler<List<JsonObject>> handler) {
+            handler.handle(Collections.emptyList());
+        }
+
+        @Override
+        public void deleteUsers(final JsonArray users) {
+        }
+
+        @Override
+        public void deleteUsers(final JsonArray users, final Handler<List<JsonObject>> handler) {
+            handler.handle(Collections.emptyList());
+        }
+
+        @Override
+        public void usersClassesUpdated(final JsonArray updates) {
+        }
+
+        @Override
+        public void transition(final JsonObject structure) {
+        }
+
+        @Override
+        public void mergeUsers(final String keepedUserId, final String deletedUserId) {
+        }
+
+        @Override
+        public void removeShareGroups(final JsonArray oldGroups) {
+        }
+
+        @Override
+        public void tenantsStructuresUpdated(final JsonArray addedTenantsStructures, final JsonArray deletedTenantsStructures) {
+        }
+
+        @Override
+        public void timetableImported(final String uai) {
+        }
+    };
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ vertxVersion=3.9.5
 junitVersion=4.10
 
 # compile lib
-webUtilsVersion=2.10-dev-produit-SNAPSHOT
+webUtilsVersion=2.10-SNAPSHOT
 mongodbHelperVersion=2.4.0
 opencsvVersion=3.9
 juniversalchardetVersion=1.0.3


### PR DESCRIPTION
# Description

Permettre aux apps branchées à l'EUR d'automatiquement réindexer les ressources importées via `ExplorerRepositoryEvents`.
- remplacements de toutes les fonctions `getForIndexation` par une unique fonction `reindex`
- regroupement des critères de réindexation dans un unique objet `ExplorerReindexResourcesRequest` (et suppression au passage des `Optional` en tant que types de champs de classe ou d'arguments de méthodes pour respecter l'esprit des [Optional](https://blog.joda.org/2014/11/optional-in-java-se-8.html)
- Ajout aux routes de réindexation la possibilité de réindexer par (ids)
- Mise à jour de la version de `web-utils`

Lié à
- https://github.com/opendigitaleducation/web-utils/pull/17
- https://github.com/opendigitaleducation/explorer/pull/13

## Fixes

WB2-959

## Type of change

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Export an archive containing blogs from recette or preprod
2. Import this archive in the targeted ENT
3. Imported resources are visible in Blog homepage

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: