### PR TITLE
fix-WB-1635 add user to class with unique relation to structure

### DIFF
--- a/feeder/src/main/java/org/entcore/feeder/ManualFeeder.java
+++ b/feeder/src/main/java/org/entcore/feeder/ManualFeeder.java
@@ -631,11 +631,13 @@ public class ManualFeeder extends BusModBase {
 						"WITH u, p " +
 						"MATCH (s:Class { id : {classId}})<-[:DEPENDS]-(cpg:ProfileGroup)-[:DEPENDS]->" +
 						"(pg:ProfileGroup)-[:HAS_PROFILE]->p, s-[:BELONGS]->(struct:Structure) " +
-						"CREATE UNIQUE pg<-[:IN {source:'MANUAL'}]-u, cpg<-[:IN {source:'MANUAL'}]-u " +
+						"MERGE (pg)<-[inProfileGroup:IN]-(u) " +
+						"CREATE UNIQUE (cpg)<-[:IN {source:'MANUAL'}]-(u) " +
 						"SET u.classes = CASE WHEN s.externalId IN u.classes THEN " +
 						"u.classes ELSE coalesce(u.classes, []) + s.externalId END, " +
 						"u.structures = CASE WHEN struct.externalId IN u.structures THEN " +
-						"u.structures ELSE coalesce(u.structures, []) + struct.externalId END " +
+						"u.structures ELSE coalesce(u.structures, []) + struct.externalId END, " +
+						"inProfileGroup.source = CASE WHEN inProfileGroup.source = 'MANUAL' THEN 'MANUAL' ELSE null END " +
 						"RETURN DISTINCT u.id as id";
 		statementsBuilder.add(query, params);
 		neo4j.executeTransaction(statementsBuilder.build(), transactionId, commit.booleanValue(), new Handler<Message<JsonObject>>() {

--- a/feeder/src/test/java/org/entcore/feeder/test/integration/java/FeederTest.java
+++ b/feeder/src/test/java/org/entcore/feeder/test/integration/java/FeederTest.java
@@ -5,6 +5,7 @@ import io.vertx.core.Context;
 import io.vertx.core.eventbus.DeliveryContext;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -89,6 +90,50 @@ public class FeederTest {
                             async.complete();
                         });
                     }));
+                });
+            });
+        }));
+    }
+
+    /**
+     * This test aims at verifying that, when a user is manually added to a class :
+     * - a relation between the user and the class profile group is created and marked with a MANUAL source
+     * - no additional relation between the user and the structure profile group is created if one already exists
+     * @param context test context to handle assertion in asynchronous environment
+     */
+    @Test
+    public void testShouldAddUserToClass(final TestContext context) {
+        final String prepareDatabaseQuery = "" +
+                "MERGE (u:User {id : {userId}})-[inStructureProfileGroup:IN {labelForCurrentTest : 'originalRelation'}]->(spg:ProfileGroup)-[:DEPENDS]->(s:Structure {id: {structureId}}) " +
+                "WITH spg, s " +
+                "MERGE (cpg:ProfileGroup)-[:DEPENDS]->(spg)-[:HAS_PROFILE]->(p:Profile) " +
+                "WITH cpg, s " +
+                "MERGE (cpg)-[:DEPENDS]->(c:Class  {id : {classId}})-[:BELONGS]->(s) " +
+                "RETURN cpg";
+        final JsonObject params = new JsonObject().put("userId", "user-id-1").put("classId", "class-id-1").put("structureId", "structure-id-1");
+        // prepare database
+        test.database().executeNeo4j(prepareDatabaseQuery, params).onComplete(context.asyncAssertSuccess(preparedDatabaseResult -> {
+            // execute method to be tested
+            test.vertx().eventBus().send(Feeder.FEEDER_ADDRESS, new JsonObject().put("action", "manual-add-user").put("userId", "user-id-1").put("classId", "class-id-1"), (AsyncResult<Message<JsonObject>> feederResponse) -> {
+                context.assertEquals("ok", feederResponse.result().body().getString("status"));
+                context.assertEquals(1, feederResponse.result().body().getJsonArray("results").getJsonArray(0).size());
+                // wait for query to complete
+                test.vertx().setTimer(300, timerComplete -> {
+                    final String verificationQuery = "" +
+                            "MATCH (u:User {id : {userId}})-[newlyCreatedIn:IN]->(cpg:ProfileGroup)-[:DEPENDS]->(c:Class {id : {classId}}) " +
+                            "WITH u, newlyCreatedIn, c " +
+                            "MATCH (u)-[inStructureProfileGroup]->(spg:ProfileGroup)-[:DEPENDS]->(s:Structure{id : {structureId}}) " +
+                            "RETURN u, newlyCreatedIn, c, inStructureProfileGroup";
+                    test.database().executeNeo4j(verificationQuery, params).onComplete(context.asyncAssertSuccess(verificationQueryResults -> {
+                        // verify method execution
+                        context.assertEquals(1, verificationQueryResults.size());
+                        context.assertEquals(4, verificationQueryResults.getJsonObject(0).size());
+                        context.assertEquals("user-id-1", verificationQueryResults.getJsonObject(0).getJsonObject("u").getJsonObject("data").getString("id"));
+                        context.assertEquals("MANUAL", verificationQueryResults.getJsonObject(0).getJsonObject("newlyCreatedIn").getJsonObject("data").getString("source"));
+                        context.assertEquals("class-id-1", verificationQueryResults.getJsonObject(0).getJsonObject("c").getJsonObject("data").getString("id"));
+                        context.assertEquals("originalRelation", verificationQueryResults.getJsonObject(0).getJsonObject("inStructureProfileGroup").getJsonObject("data").getString("labelForCurrentTest"));
+                    }));
+                    context.async().complete();
                 });
             });
         }));


### PR DESCRIPTION
# Description

Fix : when manually adding a user to a **class profile group**, it doesn't create a relation to the **structure profile group** if it already exists. If the relation to the structure profile group didn't exist before, it is created and marked as `MANUAL`.

The associated test covers :
- the creation of the relation between user and class profile group
- the non-creation of the relation between user and structure profile group, because already existing.

## Fixes

https://opendigitaleducation.atlassian.net/browse/WB-1635

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [x] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

- Semi-unit tests with an embedded neo4j database.
- Manual dev tests 

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: