### PR TITLE
[ODE] Ne pas réécrire les droits de partages après la modification des propriétés d'une ressource

### DIFF
--- a/common/src/main/java/org/entcore/common/explorer/ExplorerMessage.java
+++ b/common/src/main/java/org/entcore/common/explorer/ExplorerMessage.java
@@ -268,14 +268,22 @@ public class ExplorerMessage {
     }
 
     public ExplorerMessage withShared(final ShareModel shareModel) {
-        message.put("rights", new JsonArray(shareModel.getSerializedRights()));
+        if(shareModel == null || shareModel.getSerializedRights() == null) {
+            message.put("rights", (JsonArray)null);
+        } else {
+            message.put("rights", new JsonArray(shareModel.getSerializedRights()));
+        }
         return this;
     }
 
     @Deprecated
     public ExplorerMessage withShared(final JsonArray shared, final List<String> rights) {
-        // dont need to push shared to explorer
-        message.put("rights", new JsonArray(rights));
+        if(rights == null) {
+            message.put("rights", (JsonArray)null);
+        } else {
+            // don't need to push shared to explorer
+            message.put("rights", new JsonArray(rights));
+        }
         return this;
     }
 
@@ -321,14 +329,14 @@ public class ExplorerMessage {
     public Optional<JsonArray> getOptionalShared() {
         return Optional.ofNullable(message.getJsonArray("shared"));
     }
-    public Optional<JsonArray> getOptionalRights() {
-        return Optional.ofNullable(message.getJsonArray("rights"));
-    }
+
     public JsonArray getShared() {
         return message.getJsonArray("shared", new JsonArray());
     }
     public JsonArray getRights() {
-        return message.getJsonArray("rights", new JsonArray());
+        // This call should return null when the message holds no pertinent information about the rights and not an
+        // empty array which means `empty the rights, please`
+        return message.getJsonArray("rights");
     }
     public String getCreatorId() {
         return message.getString("creatorId", "");


### PR DESCRIPTION
# Description

Lors de la modification des propriétés d'une resource, les droits de partages sont vidés parce que la valeur par défaut des droits est un tableau vide, qui est interprété par l'EUR comme le fait de vider les droits de partages. La valeur par défaut `[]` a donc été remplacé par un `null` qui a l'effet escompté (ne rien faire sur les partages quand on n'a pas d'informations à leur sujet).

## Fixes

WB2-996

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Le test du ticket

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: