### PR TITLE
Optimization on adding and removing local admin rights

### DIFF
--- a/feeder/src/main/java/org/entcore/feeder/dictionary/structures/User.java
+++ b/feeder/src/main/java/org/entcore/feeder/dictionary/structures/User.java
@@ -705,7 +705,6 @@ public class User {
 		String query =
 				"MATCH (u:User { id : {userId}}) " +
 				"OPTIONAL MATCH (f:Function { externalId : {functionCode}}) " +
-				"WITH u, f " +
 				"MERGE u-[rf:HAS_FUNCTION]->f ";
 
 		JsonArray scope = null;
@@ -723,7 +722,6 @@ public class User {
 					"MATCH (u:User { id : {userId}}) " +
 					"OPTIONAL MATCH (s:Structure) WHERE s.id IN {scope} " +
 					"OPTIONAL MATCH (f:Function { externalId : {functionCode}}) " +
-					"WITH u, s, f " +
 					"MERGE (fg:Group:FunctionGroup { externalId : s.id + '-' + {functionCode}}) " +
 					"ON CREATE SET fg.id = id(fg) + '-' + timestamp(), fg.name = s.name + '-' + f.name, fg.displayNameSearchField = lower(s.name) + lower(f.name), fg.filter = f.name\n" +
 					"CREATE UNIQUE s<-[:DEPENDS]-fg<-[:IN {source:'MANUAL'}]-u " +

--- a/feeder/src/main/java/org/entcore/feeder/dictionary/structures/User.java
+++ b/feeder/src/main/java/org/entcore/feeder/dictionary/structures/User.java
@@ -19,29 +19,14 @@
 
 package org.entcore.feeder.dictionary.structures;
 
-import com.mongodb.QueryBuilder;
 import fr.wseduc.mongodb.MongoDb;
-import fr.wseduc.mongodb.MongoQueryBuilder;
-import fr.wseduc.mongodb.MongoUpdateBuilder;
+import fr.wseduc.webutils.Either;
 import fr.wseduc.webutils.I18n;
 import fr.wseduc.webutils.Server;
 import fr.wseduc.webutils.email.EmailSender;
-import fr.wseduc.webutils.Either;
-
-import org.entcore.common.email.EmailFactory;
-import org.entcore.common.events.EventStore;
-import org.entcore.common.events.EventStoreFactory;
-import org.entcore.common.http.request.JsonHttpServerRequest;
-import org.entcore.common.neo4j.Neo4j;
-import org.entcore.common.neo4j.Neo4jUtils;
-import org.entcore.common.notification.TimelineHelper;
-import org.entcore.common.user.UserInfos;
-import org.entcore.feeder.Feeder;
-import org.entcore.feeder.utils.TransactionHelper;
-import org.entcore.feeder.utils.TransactionManager;
-import io.vertx.core.Vertx;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.http.HttpServerRequest;
@@ -49,8 +34,19 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import org.entcore.feeder.utils.Validator;
+import org.entcore.common.email.EmailFactory;
+import org.entcore.common.events.EventStore;
+import org.entcore.common.events.EventStoreFactory;
+import org.entcore.common.http.request.JsonHttpServerRequest;
+import org.entcore.common.neo4j.Neo4j;
+import org.entcore.common.neo4j.Neo4jUtils;
+import org.entcore.common.notification.TimelineHelper;
 import org.entcore.common.user.UserDataSync;
+import org.entcore.common.user.UserInfos;
+import org.entcore.feeder.Feeder;
+import org.entcore.feeder.utils.TransactionHelper;
+import org.entcore.feeder.utils.TransactionManager;
+import org.entcore.feeder.utils.Validator;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -737,14 +733,9 @@ public class User {
 
 	public static void removeFunction(String userId, String functionCode, TransactionHelper transactionHelper) {
 		String query =
-				"MATCH (u:User { id : {userId}})-[r:HAS_FUNCTION]->(f) " +
-				"WHERE (f:Function OR f:Functions) AND f.externalId = {functionCode} " +
-				"WITH r.scope as scope, r, u, f " +
-				"DELETE r " +
-				"WITH coalesce(scope, []) as ids, u, f " +
-				"UNWIND ids as s " +
-				"MATCH (fg:FunctionGroup {externalId : s + '-' + f.externalId})<-[r:IN|COMMUNIQUE]-u " +
-				"DELETE r";
+				"MATCH (u:User { id : {userId}})-[hasFunction:HAS_FUNCTION]->(f:Function {externalId : {functionCode}}), (u)-[inOrComm:IN|COMMUNIQUE]-(fg:FunctionGroup) " +
+				"WHERE fg.externalId ENDS WITH {functionCode} " +
+				"DELETE hasFunction, inOrComm";
 		JsonObject params = new JsonObject()
 				.put("userId", userId)
 				.put("functionCode", functionCode);

--- a/feeder/src/main/java/org/entcore/feeder/dictionary/structures/User.java
+++ b/feeder/src/main/java/org/entcore/feeder/dictionary/structures/User.java
@@ -704,10 +704,8 @@ public class User {
 			TransactionHelper transactionHelper) {
 		String query =
 				"MATCH (u:User { id : {userId}}) " +
-				"OPTIONAL MATCH (f1:Function { externalId : {functionCode}}) " +
-				"OPTIONAL MATCH (f2:Functions { externalId : {functionCode}}) " +
-				"WITH u, collect (f1) + collect(f2) as c " +
-				"UNWIND c as f " +
+				"OPTIONAL MATCH (f:Function { externalId : {functionCode}}) " +
+				"WITH u, f " +
 				"MERGE u-[rf:HAS_FUNCTION]->f ";
 
 		JsonArray scope = null;
@@ -723,16 +721,12 @@ public class User {
 		if(scope != null){
 			String query2 =
 					"MATCH (u:User { id : {userId}}) " +
-					"OPTIONAL MATCH (n1:Structure) WHERE n1.id IN {scope} " +
-					"OPTIONAL MATCH (n2:Class) WHERE n2.id IN {scope} " +
-					"OPTIONAL MATCH (f1:Function { externalId : {functionCode}}) " +
-					"OPTIONAL MATCH (f2:Functions { externalId : {functionCode}}) " +
-					"WITH u, collect (n1) + collect(n2) as c1 , collect (f1) + collect(f2) as c2 " +
-					"UNWIND c1 as n " +
-					"UNWIND c2 as f " +
-					"MERGE (fg:Group:FunctionGroup { externalId : n.id + '-' + {functionCode}}) " +
-					"ON CREATE SET fg.id = id(fg) + '-' + timestamp(), fg.name = n.name + '-' + f.name, fg.displayNameSearchField = lower(n.name) + lower(f.name), fg.filter = f.name\n" +
-					"CREATE UNIQUE n<-[:DEPENDS]-fg<-[:IN {source:'MANUAL'}]-u " +
+					"OPTIONAL MATCH (s:Structure) WHERE s.id IN {scope} " +
+					"OPTIONAL MATCH (f:Function { externalId : {functionCode}}) " +
+					"WITH u, s, f " +
+					"MERGE (fg:Group:FunctionGroup { externalId : s.id + '-' + {functionCode}}) " +
+					"ON CREATE SET fg.id = id(fg) + '-' + timestamp(), fg.name = s.name + '-' + f.name, fg.displayNameSearchField = lower(s.name) + lower(f.name), fg.filter = f.name\n" +
+					"CREATE UNIQUE s<-[:DEPENDS]-fg<-[:IN {source:'MANUAL'}]-u " +
 					"RETURN fg.id as groupId ";
 			JsonObject p2 = new JsonObject()
 				.put("scope", scope)

--- a/feeder/src/test/java/org/entcore/feeder/test/integration/java/FeederTest.java
+++ b/feeder/src/test/java/org/entcore/feeder/test/integration/java/FeederTest.java
@@ -2,7 +2,6 @@ package org.entcore.feeder.test.integration.java;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
-import io.vertx.core.eventbus.DeliveryContext;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;
@@ -15,12 +14,14 @@ import org.entcore.feeder.Feeder;
 import org.entcore.feeder.ManualFeeder;
 import org.entcore.feeder.utils.TransactionHelper;
 import org.entcore.test.TestHelper;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.Neo4jContainer;
+
+import java.util.Arrays;
 
 @RunWith(VertxUnitRunner.class)
 public class FeederTest {
@@ -52,6 +53,11 @@ public class FeederTest {
         feeder.init(test.vertx(), context1);
         feeder.start();
         test.vertx().eventBus().consumer(Feeder.FEEDER_ADDRESS, feeder);
+    }
+
+    @After
+    public void cleanUp() {
+        test.database().executeNeo4j("MATCH (n) DETACH DELETE n", new JsonObject());
     }
 
     @Test
@@ -99,10 +105,12 @@ public class FeederTest {
      * This test aims at verifying that, when a user is manually added to a class :
      * - a relation between the user and the class profile group is created and marked with a MANUAL source
      * - no additional relation between the user and the structure profile group is created if one already exists
+     *
      * @param context test context to handle assertion in asynchronous environment
      */
     @Test
     public void testShouldAddUserToClass(final TestContext context) {
+        final Async async = context.async();
         final String prepareDatabaseQuery = "" +
                 "MERGE (u:User {id : {userId}})-[inStructureProfileGroup:IN {labelForCurrentTest : 'originalRelation'}]->(spg:ProfileGroup)-[:DEPENDS]->(s:Structure {id: {structureId}}) " +
                 "WITH spg, s " +
@@ -133,7 +141,113 @@ public class FeederTest {
                         context.assertEquals("class-id-1", verificationQueryResults.getJsonObject(0).getJsonObject("c").getJsonObject("data").getString("id"));
                         context.assertEquals("originalRelation", verificationQueryResults.getJsonObject(0).getJsonObject("inStructureProfileGroup").getJsonObject("data").getString("labelForCurrentTest"));
                     }));
-                    context.async().complete();
+                    async.complete();
+                });
+            });
+        }));
+    }
+
+    /**
+     * This test aims at verifying that local admin rights are given to a user for the specified structure and all the related sub-structures
+     *
+     * @param context test context to handle assertion in asynchronous environment
+     */
+    @Test
+    public void testShouldAddFunctionLocalAdmin(final TestContext context) {
+        final Async async = context.async();
+        final String prepareDatabaseQuery = "" +
+                "MERGE (u:User {id : {userId}}) " +
+                "MERGE (f:Function {externalId : {functionCode}}) " +
+                "MERGE (mainStructure:Structure {id : {mainStructureId}}) " +
+                "MERGE (subStructure1:Structure {id : {subStructureId1}})-[:HAS_ATTACHMENT]->(mainStructure) " +
+                "MERGE (subStructure2:Structure {id : {subStructureId2}})-[:HAS_ATTACHMENT]->(mainStructure) ";
+        final JsonObject params = new JsonObject()
+                .put("userId", "user-id-1")
+                .put("functionCode", "ADMIN_LOCAL")
+                .put("mainStructureId", "main-structure-id")
+                .put("subStructureId1", "sub-structure-id-1")
+                .put("subStructureId2", "sub-structure-id-2");
+        // prepare database
+        test.database().executeNeo4j(prepareDatabaseQuery, params).onComplete(context.asyncAssertSuccess(preparedDatabaseResult -> {
+            // execute method to be tested
+            test.vertx().eventBus().send(Feeder.FEEDER_ADDRESS, new JsonObject()
+                    .put("action", "manual-add-user-function")
+                    .put("userId", "user-id-1")
+                    .put("function", "ADMIN_LOCAL")
+                    .put("scope", new JsonArray(Arrays.asList("main-structure-id")))
+                    .put("inherit", "s"), (AsyncResult<Message<JsonObject>> feederResponse) -> {
+                context.assertEquals("ok", feederResponse.result().body().getString("status"));
+                context.assertEquals(3, feederResponse.result().body().getJsonArray("results").getJsonArray(1).size(), "Three ids of the newly created function group should be returned");
+                // wait for query to complete
+                test.vertx().setTimer(300, timerComplete -> {
+                    final String verificationQuery = "" +
+                            "MATCH (:User {id : {userId}})-[hasFunction:HAS_FUNCTION]->(:Function {externalId : {functionCode}}) RETURN hasFunction";
+                    test.database().executeNeo4j(verificationQuery, params).onComplete(context.asyncAssertSuccess(verificationQueryResults -> {
+                        // verify method execution
+                        context.assertEquals(1, verificationQueryResults.size());
+                        context.assertEquals(1, verificationQueryResults.getJsonObject(0).size());
+                        context.assertTrue(verificationQueryResults.getJsonObject(0).getJsonObject("hasFunction").getJsonObject("data").getJsonArray("scope").getList().containsAll(Arrays.asList("main-structure-id", "sub-structure-id-1", "sub-structure-id-2")));
+                    }));
+                    final String verificationQueryFunctionGroup = "" +
+                            "MATCH (:User {id : {userId}})-[:IN]->(functionGroup:FunctionGroup)-[:DEPENDS]->(:Structure) RETURN collect(functionGroup.externalId) as functionGroupIds";
+                    test.database().executeNeo4j(verificationQueryFunctionGroup, params).onComplete(context.asyncAssertSuccess(verificationQueryResults -> {
+                        // verify method execution
+                        context.assertEquals(1, verificationQueryResults.size());
+                        context.assertEquals(3, verificationQueryResults.getJsonObject(0).getJsonArray("functionGroupIds").size());
+                        context.assertTrue(verificationQueryResults.getJsonObject(0).getJsonArray("functionGroupIds").getList().containsAll(Arrays.asList("main-structure-id-ADMIN_LOCAL", "sub-structure-id-1-ADMIN_LOCAL", "sub-structure-id-2-ADMIN_LOCAL")));
+                    }));
+                    async.complete();
+                });
+            });
+        }));
+    }
+
+    /**
+     * This test aims at verifying that local admin rights of a user are removed for the specified structure and all the related sub-structures
+     *
+     * @param context test context to handle assertion in asynchronous environment
+     */
+    @Test
+    public void testShouldRemoveFunctionLocalAdmin(final TestContext context) {
+        final Async async = context.async();
+        final String prepareDatabaseQuery = "" +
+                "MERGE (u:User {id : {userId}})-[:HAS_FUNCTION]->(:Function { externalId : {functionCode}}) " +
+                "WITH u " +
+                "MERGE (u)-[:IN]->(:FunctionGroup { externalId : {mainStructureFunctionGroupId}}) " +
+                "MERGE (u)-[:IN]->(:FunctionGroup { externalId : {subStructureFunctionGroupId1}}) " +
+                "MERGE (u)-[:IN]->(:FunctionGroup { externalId : {subStructureFunctionGroupId2}}) " +
+                "MERGE (u)-[:COMMUNIQUE]->(:FunctionGroup { externalId : {subStructureFunctionGroupId2}}) " +
+                "MERGE (u)-[:COMMUNIQUE]->(:FunctionGroup { externalId : {subStructureFunctionGroupId2}}) " +
+                "MERGE (u)-[:COMMUNIQUE]->(:FunctionGroup { externalId : {subStructureFunctionGroupId2}}) ";
+        final JsonObject params = new JsonObject()
+                .put("userId", "user-id-1")
+                .put("functionCode", "ADMIN_LOCAL")
+                .put("mainStructureFunctionGroupId", "main-structure-ADMIN_LOCAL")
+                .put("subStructureFunctionGroupId1", "sub-structure-1-ADMIN_LOCAL")
+                .put("subStructureFunctionGroupId2", "sub-structure-2-ADMIN_LOCAL");
+        // prepare database
+        test.database().executeNeo4j(prepareDatabaseQuery, params).onComplete(context.asyncAssertSuccess(preparedDatabaseResult -> {
+            // execute method to be tested
+            test.vertx().eventBus().send(Feeder.FEEDER_ADDRESS, new JsonObject()
+                    .put("action", "manual-remove-user-function")
+                    .put("userId", "user-id-1")
+                    .put("function", "ADMIN_LOCAL"), (AsyncResult<Message<JsonObject>> feederResponse) -> {
+                context.assertEquals("ok", feederResponse.result().body().getString("status"));
+                // wait for query to complete
+                test.vertx().setTimer(300, timerComplete -> {
+                    final String verificationQuery = "" +
+                            "OPTIONAL MATCH (:User)-[hasFunction:HAS_FUNCTION]->(:Function) " +
+                            "OPTIONAL MATCH (:User)-[in:IN]->(:FunctionGroup) " +
+                            "OPTIONAL MATCH (:User)-[communique:COMMUNIQUE]->(:FunctionGroup) " +
+                            "RETURN count(hasFunction) as nbHasF, count(in) as nbIn, count(communique) as nbComm";
+                    test.database().executeNeo4j(verificationQuery, params).onComplete(context.asyncAssertSuccess(verificationQueryResults -> {
+                        // verify method execution
+                        context.assertEquals(1, verificationQueryResults.size());
+                        context.assertEquals(0, verificationQueryResults.getJsonObject(0).getInteger("nbHasF"));
+                        context.assertEquals(0, verificationQueryResults.getJsonObject(0).getInteger("nbIn"));
+                        context.assertEquals(0, verificationQueryResults.getJsonObject(0).getInteger("nbComm"));
+                    }));
+                    async.complete();
                 });
             });
         }));

--- a/feeder/src/test/java/org/entcore/feeder/test/integration/java/FeederTest.java
+++ b/feeder/src/test/java/org/entcore/feeder/test/integration/java/FeederTest.java
@@ -213,12 +213,13 @@ public class FeederTest {
         final String prepareDatabaseQuery = "" +
                 "MERGE (u:User {id : {userId}})-[:HAS_FUNCTION]->(:Function { externalId : {functionCode}}) " +
                 "WITH u " +
-                "MERGE (u)-[:IN]->(:FunctionGroup { externalId : {mainStructureFunctionGroupId}}) " +
-                "MERGE (u)-[:IN]->(:FunctionGroup { externalId : {subStructureFunctionGroupId1}}) " +
-                "MERGE (u)-[:IN]->(:FunctionGroup { externalId : {subStructureFunctionGroupId2}}) " +
-                "MERGE (u)-[:COMMUNIQUE]->(:FunctionGroup { externalId : {subStructureFunctionGroupId2}}) " +
-                "MERGE (u)-[:COMMUNIQUE]->(:FunctionGroup { externalId : {subStructureFunctionGroupId2}}) " +
-                "MERGE (u)-[:COMMUNIQUE]->(:FunctionGroup { externalId : {subStructureFunctionGroupId2}}) ";
+                "MERGE (u)-[:IN]->(fg:FunctionGroup { externalId : {mainStructureFunctionGroupId}}) " +
+                "MERGE (u)-[:IN]->(fg:FunctionGroup { externalId : {subStructureFunctionGroupId1}}) " +
+                "MERGE (u)-[:IN]->(fg:FunctionGroup { externalId : {subStructureFunctionGroupId2}}) " +
+                "WITH u, fg " +
+                "MERGE (u)-[:COMMUNIQUE]->(fg) " +
+                "MERGE (u)-[:COMMUNIQUE]->(fg) " +
+                "MERGE (u)-[:COMMUNIQUE]->(fg) ";
         final JsonObject params = new JsonObject()
                 .put("userId", "user-id-1")
                 .put("functionCode", "ADMIN_LOCAL")

--- a/tests/src/main/scala/org/entcore/test/scenarios/DirectoryScenario.scala
+++ b/tests/src/main/scala/org/entcore/test/scenarios/DirectoryScenario.scala
@@ -165,28 +165,11 @@ object DirectoryScenario {
       .check(status.is(201), jsonPath("$.id").find.saveAs("function-group-id-delete")))
 
     // add user function
-    .exec(http("User add function ")
-      .post("""/directory/user/function/${teacherId}""")
-      .header("Content-Type", "application/json")
-      .body(StringBody("""{"functionCode": "DELETE_${now}", "scope": ["${classId}"]}"""))
-      .check(status.is(200)))
 
     .exec(http("User add function ")
       .post("""/directory/user/function/${teacherId}""")
       .header("Content-Type", "application/json")
       .body(StringBody("""{"functionCode": "ADMIN_LOCAL_${now}", "scope": ["${schoolId}"]}"""))
-      .check(status.is(200)))
-
-    .exec(http("User add function ")
-      .post("""/directory/user/function/${teacherId}""")
-      .header("Content-Type", "application/json")
-      .body(StringBody("""{"functionCode": "DELETE_FS_${now}", "scope": ["${classId}"]}"""))
-      .check(status.is(200)))
-
-    .exec(http("User add function ")
-      .post("""/directory/user/function/${teacherId}""")
-      .header("Content-Type", "application/json")
-      .body(StringBody("""{"functionCode": "CLASS_ADMIN_FS_${now}", "scope": ["${classId}"]}"""))
       .check(status.is(200)))
 
     .exec(http("User add function ")


### PR DESCRIPTION
# Description

Optimisations des requêtes d'ajout et de retrait de droits ADML sur des structures chapeau.
L'optimisation consiste principalement à retirer les `collect` & `unwind`, inutiles et très coûteux.

Dans le cas de la méthode d'ajout de droits ADML, on ne considère plus le concept de Function**s** ni le fait de donner des droits d'admin sur une classe, car la méthode n'est pas appelée en pratique pour ces cas, à part dans des scénarios de tests  : https://github.com/opendigitaleducation/entcore/blob/70d01721b615765eaa4062ddf1083ee5d663e94a/tests/src/main/scala/org/entcore/test/scenarios/DirectoryScenario.scala#L168C14-L168C14


Des test "unitaires" ont également été ajoutés pour couvrir ces deux cas fonctioneles 

## Fixes

https://edifice-community.atlassian.net/browse/WB-1877

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [X] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

- Tests "unitaires" via TestContainer.
- Tests directs sur la preprod-saas sur le projet e-primo pour lequel il existe un grand nombre de sous-structures :
  - avec un compte admc, donner/retirer les droits ADML à un utilisateur (INVITÉ e-primo ou ESTUNENSEIGNANT Cécile)
  - constater qu'il n'y a pas de timeout côté front
  - les requêtes cypher n'apparaissent pas dans les logs neo4j de la plateforme (donc s'exécutent en moins d'une seconde)

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: