### PR TITLE
[EDIFICE] Désactivation de la vérification CSRF pour les appels mobile

### DIFF
--- a/directory/src/main/java/org/entcore/directory/security/UserbookCsrfFilter.java
+++ b/directory/src/main/java/org/entcore/directory/security/UserbookCsrfFilter.java
@@ -19,6 +19,7 @@
 
 package org.entcore.directory.security;
 
+import static fr.wseduc.webutils.Utils.isEmpty;
 import fr.wseduc.webutils.http.Binding;
 import fr.wseduc.webutils.security.SecureHttpServerRequest;
 import org.entcore.common.http.filter.CsrfFilter;
@@ -37,6 +38,7 @@ public class UserbookCsrfFilter extends CsrfFilter {
 	@Override
 	public void canAccess(final HttpServerRequest request, final Handler<Boolean> handler) {
 		if (request instanceof SecureHttpServerRequest && "GET".equals(request.method().name()) &&
+				isEmpty(((SecureHttpServerRequest) request).getAttribute("client_id")) &&
 				(request.uri().contains("/userbook/api/edit") || request.uri().contains("/userbook/api/set"))) {
 			compareToken(request, handler);
 		} else {

--- a/directory/src/test/java/org/entcore/directory/UserbookCsrfFilterTest.java
+++ b/directory/src/test/java/org/entcore/directory/UserbookCsrfFilterTest.java
@@ -1,0 +1,91 @@
+package org.entcore.directory;
+
+import fr.wseduc.webutils.security.SecureHttpServerRequest;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.entcore.directory.security.UserbookCsrfFilter;
+import org.entcore.test.TestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@RunWith(VertxUnitRunner.class)
+public class UserbookCsrfFilterTest {
+    private static final UserbookCsrfFilter filter = new UserbookCsrfFilter(
+            TestHelper.helper().vertx().eventBus(),
+            Collections.emptySet()
+    ) {
+        @Override
+        protected void compareToken(final HttpServerRequest request, final Handler<Boolean> handler) {
+            super.compareToken(request, handler);
+        }
+    };
+    /**
+     * Userbook requests coming from the mobile app should not be filtered.
+     */
+    @Test
+    public void testUserBookRequestFromMobileAppNotFiltered(final TestContext context) {
+        final Async async = context.async();
+        filter.canAccess(new DummySecuredRequest("test", "/userbook/api/edit", HttpMethod.GET),
+                e -> {
+            context.assertTrue(e, "Should have allowed a call with a client_id pass");
+            async.complete();
+        });
+    }
+    /**
+     * Userbook requests coming from the Web should be filtered.
+     */
+    @Test
+    public void testUserBookRequestFromWebShouldBeFiltered(final TestContext context) {
+        final Async async = context.async();
+        AtomicBoolean hasComparisonMethodBeenCalled = new AtomicBoolean(false);
+        final UserbookCsrfFilter filter = new UserbookCsrfFilter(
+                TestHelper.helper().vertx().eventBus(),
+                Collections.emptySet()
+        ) {
+            @Override
+            protected void compareToken(final HttpServerRequest request, final Handler<Boolean> handler) {
+                hasComparisonMethodBeenCalled.set(true);
+                handler.handle(false);
+            }
+        };
+        filter.canAccess(new DummySecuredRequest(null, "/userbook/api/edit", HttpMethod.GET),
+                e -> {
+                    context.assertTrue(hasComparisonMethodBeenCalled.get(), "Should have compare tokens");
+                    async.complete();
+                });
+    }
+
+    private static class DummySecuredRequest extends SecureHttpServerRequest {
+        private final String clientId;
+        private final String path;
+        private final HttpMethod method;
+        public DummySecuredRequest(final String clientId, final String path,
+                                   final HttpMethod method) {
+            super(null);
+            this.clientId = clientId;
+            this.path = path;
+            this.method = method;
+        }
+        public HttpMethod method() {return method;}
+
+        @Override
+        public String getAttribute(final String attr) {
+            if("client_id".equals(attr)) {
+                return clientId;
+            }
+            return null;
+        }
+
+        @Override
+        public String uri() {
+            return path;
+        }
+    }
+}


### PR DESCRIPTION
# Description

Les appels à Userbook sont filtrés (entre autre) par UserbookCsrfFilter qui impose une vérification pour le mobile (à l'inverser de CsrfFilter dont il dérive).
Cette PR vise à reporter dans UserbookCsrfFilter le test fait dans CsrfFilter afin de laisser passer les appels du mobile.

## Fixes

WB-2046

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

- unit tests
- test dans postman de l'appel à `{{URL}}/userbook/api/edit-user-info-visibility?info=health&state=public` en étant authentifié mobile

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: