### PR TITLE
[EDIFICE] Add scm information to manifest files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,9 +55,44 @@ subprojects {
   sourceCompatibility = 1.8
   targetCompatibility = 1.8
 
+  task generateCommitId {
+    doLast {
+      def commitId = 'unknown'
+      def stdout = new ByteArrayOutputStream()
+      try {
+        def result = exec {
+          commandLine 'git', 'rev-parse', 'HEAD'
+          standardOutput = stdout
+        }
+        commitId = stdout.toString().trim()
+      } catch (Exception e) {
+        e.printStackTrace()
+        commitId = 'error'
+      }
+      project.ext.set('commitId', commitId)
+      def branch = 'unknown'
+      try {
+        def stdoutBranch = new ByteArrayOutputStream()
+        def resultBranch = exec {
+          commandLine 'git', 'rev-parse', '--abbrev-ref', 'HEAD'
+          standardOutput = stdoutBranch
+        }
+        branch = stdoutBranch.toString().trim()
+      } catch (Exception e) {
+        e.printStackTrace()
+        branch = 'error'
+      }
+      project.ext.set('branchName', branch)
+      def date = new Date()
+      def formattedDate = date.format('yyyyMMddHHmmss')
+      project.ext.set('buildTime', formattedDate)
+    }
+  }
+
   compileJava {
     sourceCompatibility = project.sourceCompatibility
     targetCompatibility = project.targetCompatibility
+    dependsOn generateCommitId
   }
 
   compileTestJava {
@@ -119,7 +154,10 @@ subprojects {
     sourceSets.main.resources.srcDirs += [ "deployment" ]
     manifest {
       attributes(
-          "Main-Verticle": "service:mod"
+          "Main-Verticle": "service:mod",
+          "SCM-Commit-Id": "${-> project.ext.commitId}",
+          "SCM-Branch": "${-> project.ext.branchName}",
+          "Build-Time": "${-> project.ext.buildTime}"
       )
     }
   }

--- a/infra/src/main/java/org/entcore/infra/controllers/MonitoringController.java
+++ b/infra/src/main/java/org/entcore/infra/controllers/MonitoringController.java
@@ -41,8 +41,6 @@ import io.vertx.core.eventbus.Message;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import org.vertx.java.core.http.RouteMatcher;
 
 import java.util.Map;
@@ -133,6 +131,18 @@ public class MonitoringController extends BaseController {
 		Renders.renderJson(request, versions);
 	}
 
+	@Get("/monitoring/detailedVersions")
+	@SecuredAction(value = "",  type = ActionType.RESOURCE)
+	@ResourceFilter(AdminFilter.class)
+	public void checkDetailedVersions(final HttpServerRequest request) {
+		final JsonArray versions = new fr.wseduc.webutils.collections.JsonArray();
+		LocalMap<String, JsonObject> versionMap = vertx.sharedData().getLocalMap("detailedVersions");
+		for (Map.Entry<String,JsonObject> entry : versionMap.entrySet()) {
+			versions.add(new JsonObject().put(entry.getKey(), entry.getValue()));
+		}
+		Renders.renderJson(request, versions);
+	}
+
 	private Handler<Message<JsonObject>> getResponseHandler(final String module, final long timerId,
 			final JsonObject result, final AtomicInteger count, final HttpServerRequest request, final AtomicBoolean closed) {
 		return new Handler<Message<JsonObject>>() {
@@ -160,7 +170,7 @@ public class MonitoringController extends BaseController {
 
 	/**
 	 * This endpoint receives CSP reports objects.
-	 * See https://www.w3.org/TR/CSP2/#violation-reports
+	 * See <a href="https://www.w3.org/TR/CSP2/#violation-reports">...</a>
 	 */
 	@Post("/monitoring/csp")
 	@SecuredAction(type = ActionType.AUTHENTICATED, value = "")


### PR DESCRIPTION
# Description

## build.gradle

Le but de cette PR est de mettre à disposition des différents verticles de l'ENT une map décrivant plus précisément les informations d'une module déployé. Ces informations sont pour l'instant :

le dernier commit du code déployé
la branche du module
l'horodatage du build
Ces informations sont lues depuis le fichier MANIFEST.MF du module déployé.

## Route

Ajout d'une nouvelle route ` /monitoring/detailedVersions` pour récupérer les metadata du manifest.mf.

## Fixes

WB-1923

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [x] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: