### PR TITLE
[Edifice] Récupération de la configuration des métriques

### DIFF
--- a/feeder/src/main/java/org/entcore/feeder/dictionary/structures/User.java
+++ b/feeder/src/main/java/org/entcore/feeder/dictionary/structures/User.java
@@ -19,21 +19,15 @@
 
 package org.entcore.feeder.dictionary.structures;
 
+import com.mongodb.QueryBuilder;
 import fr.wseduc.mongodb.MongoDb;
-import fr.wseduc.webutils.Either;
+import fr.wseduc.mongodb.MongoQueryBuilder;
+import fr.wseduc.mongodb.MongoUpdateBuilder;
 import fr.wseduc.webutils.I18n;
 import fr.wseduc.webutils.Server;
 import fr.wseduc.webutils.email.EmailSender;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.eventbus.EventBus;
-import io.vertx.core.eventbus.Message;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import fr.wseduc.webutils.Either;
+
 import org.entcore.common.email.EmailFactory;
 import org.entcore.common.events.EventStore;
 import org.entcore.common.events.EventStoreFactory;
@@ -41,12 +35,22 @@ import org.entcore.common.http.request.JsonHttpServerRequest;
 import org.entcore.common.neo4j.Neo4j;
 import org.entcore.common.neo4j.Neo4jUtils;
 import org.entcore.common.notification.TimelineHelper;
-import org.entcore.common.user.UserDataSync;
 import org.entcore.common.user.UserInfos;
 import org.entcore.feeder.Feeder;
 import org.entcore.common.neo4j.TransactionHelper;
 import org.entcore.feeder.utils.TransactionManager;
+import io.vertx.core.Vertx;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import org.entcore.feeder.utils.Validator;
+import org.entcore.common.user.UserDataSync;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/infra/deployment/infra/conf.j2
+++ b/infra/deployment/infra/conf.j2
@@ -108,6 +108,18 @@
             "auth": "{{ nodePdfToken }}",
             "url" : "{{ nodePdfUrl }}"
         },
+        {% if contentTransformerUrl is defined %}
+        "content-transformer": {
+            "url": "{{ contentTransformerUrl }}",
+            "content-transformer-metrics": {
+                "enabled": {{ contentTransformerMetricsEnabled | default('true'}}
+                {% if contentTransformerMetricsSla is defined %}
+                ,
+                "sla": {{ contentTransformerMetricsSla }}
+                {% endif %}
+            }
+        },
+        {% endif %}
         {% if explorerEnabled is defined %}
         "explorerConfig": {
             "enabled": true,

--- a/infra/src/main/java/org/entcore/infra/Starter.java
+++ b/infra/src/main/java/org/entcore/infra/Starter.java
@@ -154,6 +154,10 @@ public class Starter extends BaseServer {
 			if(metricsOptions != null) {
 				serverMap.put("metricsOptions", metricsOptions.encode());
 			}
+			final JsonObject contentTransformer = config.getJsonObject("content-transformer");
+			if (contentTransformer != null) {
+				serverMap.put("content-transformer", contentTransformer.encode());
+			}
 			//initModulesHelpers(node);
 
 			/* sharedConf sub-object */


### PR DESCRIPTION
# Description

Récupération de la configuration des métriques (si elle existe) dans le module infra pour la mettre dans la configuration partagée.

## Fixes

WB-2009

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [x] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Démarrer le serveur sans la configuration
2. Constater qu'un warning est écrit dans les logs
3. Démarrer le serveur avec la configuration 
4. Créer un blog
5. Créer une publication
6. La publication contient bien en base un champ contentJson non null et correspondant au contenu

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: