### PR TITLE
[EDIFICE] Ne plus retourner les personnes non rattachées dans la recherche transverse

### DIFF
--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
@@ -538,6 +538,8 @@ public class DefaultUserService implements UserService {
 			filterUser = "(n:Group {id : {groupId}})<-[:IN]-";
 			params.put("groupId", groupId);
 		} else {
+			// WB-2077, if we have no filter on the user we at least must only return users attached to structures
+			filterUser = "(s:Structure)<-[:DEPENDS]-(pg:ProfileGroup)<-[:IN]-";
 			restrictResultsToFunction = true;
 		}
 


### PR DESCRIPTION
# Description

Suite à un refacto de la méthode listAdmin, les utilisateurs non rattachés à une structure étaient remontés dans la recherche transverse.
Le but de cette PR est donc de remettre le filtre `(s:Structure)<-[:DEPENDS]-(pg:ProfileGroup)<-[:IN]-(u:User)` a minima.

## Fixes

WB-2077

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Avec un ADMC, pré-supprimer un utilisateur X
2. Aller dans la recherche transverse
3. Chercher X par nom et/ou par email
4. Vérifier que X ne remonte pas dans la liste des résultats
5. Chercher X dans les personnes non rattachées
6. Vérifier que X remonte dans la liste des résultats

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: