### PR TITLE
[EDIFICE] fix(admin v2): #WB-2077, transversal search CSS

### DIFF
--- a/admin/src/main/ts/src/assets/admin.scss
+++ b/admin/src/main/ts/src/assets/admin.scss
@@ -1547,105 +1547,105 @@ ode-list {
   }
 }
 
-ode-user-list,
-ode-admc-search-transverse,
-ode-tree-user-list,
-ode-group-users-list,
-ode-group-input-users,
-ode-group-output-users {
-  ode-list {
-    li {
-      position: relative;
-      display: flex;
-      gap: 12px;
-      justify-content: center;
-      align-items: center;
-      .display-name {
-        font-size: 14px;
-        flex: 1;
+ode-user-list ode-list,
+ode-admc-search-transverse admc-user-search-list,
+ode-tree-user-list ode-list,
+ode-group-users-list ode-list,
+ode-group-input-users ode-list,
+ode-group-output-users ode-list {
+  li {
+    position: relative;
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+    align-items: center;
+    .display-name {
+      font-size: 14px;
+      flex: 1;
+      padding-right: 5px;
+    }
+    i {
+      &.profile {
+        color: $grey-dark;
+        border: 1px solid $shadow-light;
+        background-color: $white-transparent;
+        font-size: 12px;
+        font-style: normal;
+        border-radius: 30px;
+        padding: 5px 15px;
+        text-align: center;
+        &::before {
+          content: " ";
+          display: inline-block;
+          width: 10px;
+          height: 10px;
+          border-radius: 50%;
+          margin-right: 5px;
+        }
+      }
+      &.Student.profile::before {
+        background-color: $orange;
+      }
+      &.Teacher.profile::before {
+        background-color: $green;
+      }
+      &.Relative.profile::before {
+        background-color: $cyan;
+      }
+      &.Personnel.profile::before {
+        background-color: $purple;
+      }
+      &.Guest.profile::before {
+        background-color: $pink;
+      }
+      &.fa {
+        font-size: 1.3em;
         padding-right: 5px;
-      }
-      i {
-        &.profile {
-          color: $grey-dark;
-          border: 1px solid $shadow-light;
-          background-color: $white-transparent;
-          font-size: 12px;
-          font-style: normal;
-          border-radius: 30px;
-          padding: 5px 15px;
-          text-align: center;
-          &::before {
-            content: " ";
-            display: inline-block;
-            width: 10px;
-            height: 10px;
-            border-radius: 50%;
-            margin-right: 5px;
-          }
+        &.fa-lock {
+          color: #aaa;
         }
-        &.Student.profile::before {
-          background-color: $orange;
-        }
-        &.Teacher.profile::before {
-          background-color: $green;
-        }
-        &.Relative.profile::before {
-          background-color: $cyan;
-        }
-        &.Personnel.profile::before {
-          background-color: $purple;
-        }
-        &.Guest.profile::before {
-          background-color: $pink;
-        }
-        &.fa {
-          font-size: 1.3em;
-          padding-right: 5px;
-          &.fa-lock {
-            color: #aaa;
-          }
-          &.fa-times-circle,
-          &.fa-ban {
-            color: $contrast;
-          }
-        }
-        &.duplicates {
-          padding-right: 5px;
-          font-size: 1.8em;
-          color: $accent;
-          &::before {
-            content: "\e7fb";
-          }
-        }
-        &.waiting-predelete {
-          padding-right: 5px;
-          font-size: 1.5em;
+        &.fa-times-circle,
+        &.fa-ban {
           color: $contrast;
-          &::before {
-            content: "\e936";
-          }
-        }
-        &.check,
-        &.check-empty {
-          margin-left: 12px;
         }
       }
-      &.selected {
-        i.duplicates {
-          color: $accent-light;
+      &.duplicates {
+        padding-right: 5px;
+        font-size: 1.8em;
+        color: $accent;
+        &::before {
+          content: "\e7fb";
         }
+      }
+      &.waiting-predelete {
+        padding-right: 5px;
+        font-size: 1.5em;
+        color: $contrast;
+        &::before {
+          content: "\e936";
+        }
+      }
+      &.check,
+      &.check-empty {
+        margin-left: 12px;
+      }
+    }
+    &.selected {
+      i.duplicates {
+        color: $accent-light;
       }
     }
   }
 }
 
-ode-tree-user-list,
-ode-admc-search-transverse {
-  ode-list {
-    li {
-      display: block;
-    }
+ode-tree-user-list ode-list li {
+  display: block;
+}
+
+ode-admc-search-transverse admc-user-search-list li {
+  display: block;
+  &>span {
+    gap: 12px;
   }
 }
 


### PR DESCRIPTION
# Description

This completes the first fix for the WB-2077 ticket.
An &lt;ode-list&gt; component had been specialized by a new &lt;admc-user-search-list&gt; component during WB-1368, but CSS was missing. Corrected here.

## Fixes

WB-2077

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [X] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Used `./build.sh ngWatch` to reproduce and correct the UI.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] I thought about it all very hard