### PR TITLE
fix(admin): #WB-2089, fix ADML transversal search which was too long

### DIFF
--- a/admin/src/main/ts/src/app/groups/details/manage-users/input/group-input-users/group-input-users.component.ts
+++ b/admin/src/main/ts/src/app/groups/details/manage-users/input/group-input-users/group-input-users.component.ts
@@ -21,6 +21,7 @@ import {
 } from "../../../../../core/services/userlist.filters.service";
 import { SpinnerService } from "ngx-ode-ui";
 import { BundlesService } from "ngx-ode-sijil";
+import { SearchTypeEnum } from "src/app/core/enum/SearchTypeEnum";
 
 @Component({
   selector: "ode-group-input-users",
@@ -130,7 +131,7 @@ export class GroupInputUsersComponent
     this.userListService.inputFilter = this.searchTerm;
     this.spinner.perform(
       "portal-content",
-      this.usersService.search(this.userListService.inputFilter).then(data => {
+      this.usersService.search(this.userListService.inputFilter, SearchTypeEnum.DISPLAY_NAME).then(data => {
         this.model = data;
 
         this.refreshListCount(data);

--- a/directory/src/main/java/org/entcore/directory/controllers/UserController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/UserController.java
@@ -712,6 +712,7 @@ public class UserController extends BaseController {
 		/* Retro-compability : 
 		 * - if a "name" query parameter exists, its value must be used like a displayName.
 		 * - if a "lastName" or "firstName" query parameter exists, make an optimized search by fullname.
+		 * - if searchType is the string "undefined", consider it is "displayName" instead.
 		 * - otherwise, just apply the "searchTerm" and "searchType" query parameter, if any.
 		 */
 		if( nameFilter!=null && nameFilter.length()>0 && searchTerm==null && searchType==null) {
@@ -722,7 +723,7 @@ public class UserController extends BaseController {
 			final TransversalSearchType type = TransversalSearchType.fromCode(searchType);
 			if(TransversalSearchType.EMAIL.equals(type))
 				return TransversalSearchQuery.searchByMail(searchTerm);
-			if(TransversalSearchType.DISPLAY_NAME.equals(type))
+			if(TransversalSearchType.DISPLAY_NAME.equals(type) || "undefined".equals(searchType))
 				return TransversalSearchQuery.searchByDisplayName(searchTerm);
 		}
 		return TransversalSearchQuery.EMPTY;


### PR DESCRIPTION
# Description

This commit fixes the ADML transversal search of a user (in groups management), that was taking too much time by not applying the _searchTerm_ correctly.

## Fixes

WB-2089

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [X] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [X] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

* `./build.sh ngWatch`
* connect to localhost and reproduce the problem
* fix it
* ensure the correction works as expected, without any error message
* `./build.sh test`
* => 100% successful

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: