### PR TITLE
[EDIFICE] Empêcher la création de doublon de noeud UserBook

### DIFF
--- a/common/src/main/java/org/entcore/common/service/impl/BasicQuotaService.java
+++ b/common/src/main/java/org/entcore/common/service/impl/BasicQuotaService.java
@@ -128,9 +128,8 @@ public class BasicQuotaService implements org.entcore.common.folders.QuotaServic
 	public void init(final String userId) {
 		String query = "MATCH (n:User {id : {userId}})-[:IN]->(:ProfileGroup)-[:HAS_PROFILE]->(p:Profile) "
 				+ "WITH n, sum(CASE WHEN has(p.defaultQuota) THEN p.defaultQuota ELSE 104857600 END) as quota "
-				+ "MERGE (m:UserBook { userid : {userId}}) "
-				+ "SET m.quota = quota, m.storage = 0, m.alertSize = false " + "WITH m, n "
-				+ "CREATE UNIQUE n-[:USERBOOK]->m";
+				+ "MERGE (n)-[:USERBOOK]->(m:UserBook) "
+				+ "SET m.userid = {userId}, m.quota = quota, m.storage = 0, m.alertSize = false ";
 		JsonObject params = new JsonObject().put("userId", userId);
 		neo4j.execute(query, params, new Handler<Message<JsonObject>>() {
 			@Override

--- a/common/src/test/java/org/entcore/common/service/impl/BasicQuotaServiceTest.java
+++ b/common/src/test/java/org/entcore/common/service/impl/BasicQuotaServiceTest.java
@@ -1,0 +1,134 @@
+package org.entcore.common.service.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import org.entcore.common.events.EventStoreFactory;
+import org.entcore.common.neo4j.Neo4j;
+import org.entcore.test.TestHelper;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.containers.Neo4jContainer;
+
+@RunWith(VertxUnitRunner.class)
+public class BasicQuotaServiceTest {
+    private static final TestHelper test = TestHelper.helper();
+    @ClassRule
+    public static Neo4jContainer<?> neo4jContainer = test.database().createNeo4jContainer();
+    private static Neo4j neo4j;
+    private static BasicQuotaService basicQuotaService;
+
+    @BeforeClass
+    public static void setUp(TestContext context) throws Exception {
+        EventStoreFactory.getFactory().setVertx(test.vertx());
+        basicQuotaService = new BasicQuotaService();
+        test.database().initNeo4j(context, neo4jContainer);
+        final String base = neo4jContainer.getHttpUrl() + "/db/data/";
+        final JsonObject neo4jConfig = new JsonObject()
+                .put("server-uri", base).put("poolSize", 1);
+        neo4j = Neo4j.getInstance();
+        neo4j.init(test.vertx(), neo4jConfig
+                .put("server-uri", base)
+                .put("ignore-empty-statements-error", false));
+    }
+
+    /**
+     * <h1>Goal</h1>
+     * <p>Test that if a user doesn't have any quota then a call to {@code init} will create
+     * <b><u>one and only one</u></b> userbook node.</p>
+     * @param testContext Test context
+     */
+    @Test
+    public void testInitQuotaOfUserWithoutUserBook(final TestContext testContext) {
+        final String userId = "userIdTestInitQuotaOfUserWithoutUserBook";
+        final Async async = testContext.async(3);
+        prepareData(userId, null).onComplete(testContext.asyncAssertSuccess(h -> {
+            basicQuotaService.init(userId);
+            test.vertx().setTimer(1000L, e -> assertUserHasOnlyOneUserBook(userId, testContext, async));
+        }));
+    }
+
+    /**
+     * <h1>Goal</h1>
+     * <p>Test that if a user is already linked to a UserBook node whose field userid is set to the actual id of the
+     * target user then a call to {@code init} will <b><u>NOT CREATE</u></b> a new userbook node. The user will still
+     * have <b><u>one and only one</u></b> UserBook node.</p>
+     * @param testContext Test context
+     */
+    @Test
+    public void testInitQuotaOfUserWithGoodUserBook(final TestContext testContext) {
+        final String userId = "userIdTestInitQuotaOfUserWithGoodUserBook";
+        final Async async = testContext.async(3);
+        prepareData(userId, userId).onComplete(testContext.asyncAssertSuccess(h -> {
+            basicQuotaService.init(userId);
+            test.vertx().setTimer(1000L, e -> assertUserHasOnlyOneUserBook(userId, testContext, async));
+        }));
+    }
+
+    /**
+     * <h1>Goal</h1>
+     * <p>Test that if a user is already linked to a UserBook node whose field userid is set to a value which is not
+     * the actual id of the target user's id then a call to {@code init} will <b><u>NOT CREATE</u></b> a new userbook
+     * node. The user will still have <b><u>one and only one</u></b> UserBook node.</p>
+     * @param testContext Test context
+     */
+    @Test
+    public void testInitQuotaOfUserWithBadUserBook(final TestContext testContext) {
+        final String userId = "userIdTestInitQuotaOfUserWithBadUserBook";
+        final Async async = testContext.async(3);
+        prepareData(userId, "badId").onComplete(testContext.asyncAssertSuccess(h -> {
+            basicQuotaService.init(userId);
+            test.vertx().setTimer(1000L, e -> assertUserHasOnlyOneUserBook(userId, testContext, async));
+        }));
+    }
+
+    private void assertUserHasOnlyOneUserBook(final String userId, final TestContext testContext, final Async async) {
+        neo4j.execute(
+                "MATCH (u:User{id:{userId}})-[r:USERBOOK]->(ub:UserBook) return ub.userid as ub_user_id ",
+                new JsonObject().put("userId", userId),
+                result -> {
+                    if ("ok".equals(result.body().getString("status"))) {
+                        final JsonArray ubs = result.body().getJsonArray("result");
+                        testContext.assertEquals(1, ubs.size(), "There should be only one created userbook");
+                        testContext.assertEquals(userId, ubs.getJsonObject(0).getString("ub_user_id"), "The created userbook's doesn't have the right user id");
+                        async.complete();
+                    } else {
+                        testContext.fail("Could not fetch userbooks");
+                    }
+                });
+    }
+
+    /**
+     * Creates a user and eventually a userbook linked to it.
+     * @param userId Id of the user to create
+     * @param ubUserId Value of the field {@code userid} to set for the UserBook node. If it is
+     * {@code null} then no UserBook node is created
+     * @return When this method ends
+     */
+    private Future<Void> prepareData(final String userId, final String ubUserId) {
+        final Promise<Void> promise = Promise.promise();
+        final String query;
+        final JsonObject params = new JsonObject().put("userId", userId);
+        if(isEmpty(ubUserId)) {
+            query = "create (u1:User{id: {userId}})-[:IN]->(:ProfileGroup)-[:HAS_PROFILE]->(p:Profile)";
+        } else {
+            query = "create (:UserBook{userid:{ubUserId}})<-[:USERBOOK]-(u1:User{id: {userId}})-[:IN]->(:ProfileGroup)-[:HAS_PROFILE]->(p:Profile)";
+            params.put("ubUserId", ubUserId);
+        }
+        neo4j.execute(query, params, e -> {
+            if ("ok".equals(e.body().getString("status"))) {
+                promise.complete();
+            } else {
+                promise.fail(e.body().encodePrettily());
+            }
+        });
+        return promise.future();
+    }
+}

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserBookService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserBookService.java
@@ -431,9 +431,9 @@ public class DefaultUserBookService implements UserBookService {
 			params.put("avatar", userBookData.getString("default-avatar"));
 			params.put("theme", userBookData.getString("default-theme", ""));
 			final StringBuilder query = new StringBuilder();
-			query.append("MERGE (m:UserBook { userid : {userId}}) ");
-			query.append("SET m.type = 'USERBOOK', m.picture = {avatar}, m.motto = '', m.health = '', m.mood = 'default', m.theme =  {theme} ");
-			query.append("WITH m MATCH (n:User {id : {userId}}) CREATE UNIQUE n-[:USERBOOK]->m");
+			query.append("MATCH (n:User {id : {userId}}) ");
+			query.append("MERGE (n)-[:USERBOOK]->(m:UserBook) ");
+			query.append("SET m.userid = {userId}, m.type = 'USERBOOK', m.picture = {avatar}, m.motto = '', m.health = '', m.mood = 'default', m.theme =  {theme} ");
 			queries.add(query.toString(), params);
 		}
 		final JsonArray listOfHobbies = userBookData.getJsonArray("hobbies", new JsonArray());

--- a/directory/src/test/java/org/entcore/directory/org/entcore/directory/services/impl/DefaultUserBookServiceTest.java
+++ b/directory/src/test/java/org/entcore/directory/org/entcore/directory/services/impl/DefaultUserBookServiceTest.java
@@ -1,0 +1,147 @@
+package org.entcore.directory.org.entcore.directory.services.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import org.entcore.common.events.EventStoreFactory;
+import org.entcore.common.neo4j.Neo4j;
+import org.entcore.directory.services.impl.DefaultUserBookService;
+import org.entcore.test.TestHelper;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.containers.Neo4jContainer;
+
+@RunWith(VertxUnitRunner.class)
+public class DefaultUserBookServiceTest {
+    private static final TestHelper test = TestHelper.helper();
+    @ClassRule
+    public static Neo4jContainer<?> neo4jContainer = test.database().createNeo4jContainer();
+    private static Neo4j neo4j;
+
+    private static DefaultUserBookService defaultUserBookService;
+
+    @BeforeClass
+    public static void setUp(TestContext context) throws Exception {
+        final Vertx vertx = test.vertx();
+        EventStoreFactory.getFactory().setVertx(vertx);
+        defaultUserBookService = new DefaultUserBookService(
+                vertx.eventBus(),
+                null,
+                null,
+                new JsonObject()
+                        .put("default-avatar", "avatar.png")
+                        .put("default-theme", "theme")
+                        .put("hobbies", new JsonArray().add("cinema").add("sport")));
+        test.database().initNeo4j(context, neo4jContainer);
+        final String base = neo4jContainer.getHttpUrl() + "/db/data/";
+        final JsonObject neo4jConfig = new JsonObject()
+                .put("server-uri", base).put("poolSize", 1);
+        neo4j = Neo4j.getInstance();
+        neo4j.init(test.vertx(), neo4jConfig
+                .put("server-uri", base)
+                .put("ignore-empty-statements-error", false));
+    }
+
+    /**
+     * <h1>Goal</h1>
+     * <p>Test that if a user is already linked to a UserBook node whose field userid is set to a value which is not
+     * the actual id of the target user's id then a call to {@code initUserbook} will <b><u>NOT CREATE</u></b> a new userbook
+     * node. The user will still have <b><u>one and only one</u></b> UserBook node.</p>
+     * @param testContext Test context
+     */
+    @Test
+    public void testInitUserWithBadUserBook(final TestContext testContext) {
+        final String userId = "userIdTestInitOfUserWithBadUserBook";
+        final Async async = testContext.async(3);
+        prepareData(userId, "badId").onComplete(testContext.asyncAssertSuccess(h -> {
+            defaultUserBookService.initUserbook(userId, "theme", new JsonObject());
+            test.vertx().setTimer(1000L, e -> assertUserHasOnlyOneUserBook(userId, testContext, async));
+        }));
+    }
+
+    /**
+     * <h1>Goal</h1>
+     * <p>Test that if a user doesn't have any quota then a call to {@code initUserbook} will create
+     * <b><u>one and only one</u></b> userbook node.</p>
+     * @param testContext Test context
+     */
+    @Test
+    public void testInitUserBookOfUserWithoutUserBook(final TestContext testContext) {
+        final String userId = "userIdTestInitUserBookOfUserWithoutUserBook";
+        final Async async = testContext.async(3);
+        prepareData(userId, null).onComplete(testContext.asyncAssertSuccess(h -> {
+            defaultUserBookService.initUserbook(userId, "theme", new JsonObject());
+            test.vertx().setTimer(1000L, e -> assertUserHasOnlyOneUserBook(userId, testContext, async));
+        }));
+    }
+
+    /**
+     * <h1>Goal</h1>
+     * <p>Test that if a user is already linked to a UserBook node whose field userid is set to the actual id of the
+     * target user then a call to {@code initUserbook} will <b><u>NOT CREATE</u></b> a new userbook node. The user will still
+     * have <b><u>one and only one</u></b> UserBook node.</p>
+     * @param testContext Test context
+     */
+    @Test
+    public void testInitUserBookOfUserWithGoodUserBook(final TestContext testContext) {
+        final String userId = "userIdTestInitUserBookOfUserWithGoodUserBook";
+        final Async async = testContext.async(3);
+        prepareData(userId, userId).onComplete(testContext.asyncAssertSuccess(h -> {
+            defaultUserBookService.initUserbook(userId, "theme", new JsonObject());
+            test.vertx().setTimer(1000L, e -> assertUserHasOnlyOneUserBook(userId, testContext, async));
+        }));
+    }
+
+
+    private void assertUserHasOnlyOneUserBook(final String userId, final TestContext testContext, final Async async) {
+        neo4j.execute(
+                "MATCH (u:User{id:{userId}})-[r:USERBOOK]->(ub:UserBook) return ub.userid as ub_user_id, ub as ub ",
+                new JsonObject().put("userId", userId),
+                result -> {
+                    if ("ok".equals(result.body().getString("status"))) {
+                        final JsonArray ubs = result.body().getJsonArray("result");
+                        testContext.assertEquals(1, ubs.size(), "There should be only one created userbook");
+                        testContext.assertEquals(userId, ubs.getJsonObject(0).getString("ub_user_id"), "The created userbook's doesn't have the right user id");
+                        async.complete();
+                    } else {
+                        testContext.fail("Could not fetch userbooks");
+                    }
+                });
+    }
+
+    /**
+     * Creates a user and eventually a userbook linked to it.
+     * @param userId Id of the user to create
+     * @param ubUserId Value of the field {@code userid} to set for the UserBook node. If it is
+     * {@code null} then no UserBook node is created
+     * @return When this method ends
+     */
+    private Future<Void> prepareData(final String userId, final String ubUserId) {
+        final Promise<Void> promise = Promise.promise();
+        final String query;
+        final JsonObject params = new JsonObject().put("userId", userId);
+        if(isEmpty(ubUserId)) {
+            query = "create (u1:User{id: {userId}})";
+        } else {
+            query = "create (:UserBook{userid:{ubUserId}})<-[:USERBOOK]-(u1:User{id: {userId}})";
+            params.put("ubUserId", ubUserId);
+        }
+        neo4j.execute(query, params, e -> {
+            if ("ok".equals(e.body().getString("status"))) {
+                promise.complete();
+            } else {
+                promise.fail(e.body().encodePrettily());
+            }
+        });
+        return promise.future();
+    }
+
+}

--- a/directory/src/test/java/org/entcore/directory/org/entcore/directory/services/impl/DefaultUserBookServiceTest.java
+++ b/directory/src/test/java/org/entcore/directory/org/entcore/directory/services/impl/DefaultUserBookServiceTest.java
@@ -93,7 +93,7 @@ public class DefaultUserBookServiceTest {
     @Test
     public void testInitUserBookOfUserWithGoodUserBook(final TestContext testContext) {
         final String userId = "userIdTestInitUserBookOfUserWithGoodUserBook";
-        final Async async = testContext.async(3);
+        final Async async = testContext.async(2);
         prepareData(userId, userId).onComplete(testContext.asyncAssertSuccess(h -> {
             defaultUserBookService.initUserbook(userId, "theme", new JsonObject());
             test.vertx().setTimer(1000L, e -> assertUserHasOnlyOneUserBook(userId, testContext, async));

--- a/feeder/src/main/java/org/entcore/feeder/dictionary/structures/DuplicateUsers.java
+++ b/feeder/src/main/java/org/entcore/feeder/dictionary/structures/DuplicateUsers.java
@@ -1057,14 +1057,15 @@ public class DuplicateUsers {
 				.put("id", principalUser.getString("id")).put("oldId", oldUser.getString("id"));
 		final String query1 =
 				"MATCH (old:User {id: {oldId}})-[r:USERBOOK]->(ub:UserBook), (u:User {id: {id}}) " +
-						"DELETE r " +
-						"WITH u, ub " +
+						"WITH u, ub, r " +
 						"OPTIONAL MATCH (u)-[:USERBOOK]->(prevUb:UserBook) " +
-						"WITH u, ub, prevUb " +
+						"WITH u, ub, prevUb, r " +
 						"WHERE prevUb IS NULL " +
 						"SET ub.theme = null " +
 						"CREATE UNIQUE (u)-[:USERBOOK]->(ub) " +
-						"SET ub.userid = {id}";
+						"SET ub.userid = {id} " +
+						"DELETE r"; // We only delete the relationship between the old user and the userbook if it was transfered to the new user
+									// So we will be able to delete unlinked UserBook nodes with query4
 		tx.add(query1, params);
 		final String query2 =
 				"MATCH (old:User {id: {oldId}})-[r:PREFERS]->(ub:UserAppConf), (u:User {id: {id}}) " +
@@ -1085,8 +1086,9 @@ public class DuplicateUsers {
 						"WHERE old.oldId IS NULL OR old.oldId <> {id} " +
 						"WITH old, old.id AS oldId, old.login AS oldLogin, old.password AS oldPassword, old.email AS oldEmail " +
 						"OPTIONAL MATCH (old)-[rb:HAS_RELATIONSHIPS]->(b:Backup) " +
+						"OPTIONAL MATCH (old)-[rUb:USERBOOK]->(ub:UserBook) " +
 						"OPTIONAL MATCH (old)-[r]-() " +
-						"DELETE r, rb, b, old " +
+						"DELETE r, rb, b, old, rUb, ub " +
 						"WITH oldId, oldLogin, oldPassword, oldEmail " +
 						"MATCH (u:User {login: {id}}) " +
 						"SET u.oldId = u.id, u.id = oldId, u.oldLogin = u.login, u.login = oldLogin, " +


### PR DESCRIPTION
# Description

Dans certaines circonstances (suite à une fusion par INE par exemple) il se peut qu'un noeud User se retrouve connecté à un nœud UserBook dont le champ userid ne reflète pas l'id de l'utilisateur cible.
Le but de cette PR est de palier ce genre d'incohérence de la base de données en remplaçant les occurrences de `MERGE (m:UserBook { userid : {userId}})` par des `MERGE (u:User{id:{userId}})-[:USERBOOK]->(m:UserBook)`

## Fixes

HDF-1267

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Les 2 nouvelles classes de TU introduites par cette PR.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: