### PR TITLE
fix(directory): MOZO-77 hide private info from user info page

### DIFF
--- a/directory/src/main/resources/public/ts/controllers/directory.ts
+++ b/directory/src/main/resources/public/ts/controllers/directory.ts
@@ -531,6 +531,25 @@ export const directoryController = ng.controller('DirectoryController',['$scope'
 		template.close('details');
 	};
 
+	const privateInfosMapping = {
+		'SHOW_EMAIL': 'email',
+		// 'SHOW_MAIL': 'email', unused field at this time
+		'SHOW_PHONE': 'homePhone',
+		'SHOW_BIRTHDATE': 'birthdate',
+		'SHOW_HEALTH': 'health',
+		'SHOW_MOBILE': 'mobile',
+	}
+
+	$scope.removePrivateInfos = function() {
+		const infoToBeRemoved = {};
+		Object.entries(privateInfosMapping).forEach(([k, v]) => {
+			if (!$scope.currentUser.visibleInfos?.includes(k)) {
+				infoToBeRemoved[v] = undefined;
+			}
+		});
+		$scope.currentUser.updateData(infoToBeRemoved);
+	}
+
 	$scope.selectUser = async function(user){
 		if(!$scope.$$phase){
 			$scope.$apply('search');
@@ -557,6 +576,7 @@ export const directoryController = ng.controller('DirectoryController',['$scope'
 			if($scope.currentUser !== undefined){
 				$scope.scroolTop();
 			}
+			$scope.filterPrivateInfos(); // Tmp fix: MOZO-77 prevent display of private data on this screen until backend removes them from the response.
 			$scope.$apply('currentUser');
 		});
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ modowner=org.entcore
 modname=ent-core
 
 # Your module version
-version=4.11-b2school-SNAPSHOT
+version=4.11-develop-mozo-SNAPSHOT
 
 # The test timeout in seconds
 testtimeout=300


### PR DESCRIPTION
# Description

Add a filter onto the user info page to hide data that is private, even if the current user is an ADML/ADMC.

## Fixes

- https://edifice-community.atlassian.net/browse/MOZO-77

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Configure a non-admin account to hide some private info (mobile phone, email, etc)
2. Log in with an admin account and go to the non-admin user page. Private info mustn't show.
3. Go into the admin to see the non-admin user page. Private info must show.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: