### PR TITLE
[EDIFICE] authorize null values for updated users' fields

### DIFF
--- a/directory/src/main/resources/jsonschema/updateUser.json
+++ b/directory/src/main/resources/jsonschema/updateUser.json
@@ -13,31 +13,31 @@
       "type": "string"
     },
     "birthDate": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "address": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "zipCode": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "city": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "loginAlias": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "email": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "homePhone": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "mobile": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "childrenIds": {
-      "type": "string"
+      "type": ["string", "null"]
     }
   }
 }


### PR DESCRIPTION
# Description

Supporter la valeur `nulle` pour les champs de la route `[PUT]/directory/users/u:userId`

## Fixes

WB-2154

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Le test du ticket

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: