### PR TITLE
WB-2008 providing plain text content to explorer for indexation

### DIFF
--- a/common/src/main/java/org/entcore/common/explorer/ExplorerMessage.java
+++ b/common/src/main/java/org/entcore/common/explorer/ExplorerMessage.java
@@ -218,7 +218,7 @@ public class ExplorerMessage {
         return this;
     }
 
-    public ExplorerMessage withSubResourceContent(final String id, final String content, final ExplorerContentType type) {
+    public ExplorerMessage withSubResourceContent(final String id, final String content, final ExplorerContentType type, final long version) {
         final JsonArray subResources = message.getJsonArray(SUBRESOURCES_KEY, new JsonArray());
         final Optional<JsonObject> subResourceOpt = subResources.stream().map(e -> (JsonObject)e).filter(e-> e.getString("id","").equals(id)).findFirst();
         final JsonObject subResource = subResourceOpt.orElse(new JsonObject().put("id", id));
@@ -235,6 +235,7 @@ public class ExplorerMessage {
                 break;
         }
         subResource.put("deleted", false);
+        subResource.put("version", version);
         subResources.add(subResource);
         message.put(SUBRESOURCES_KEY, subResources);
         return this;


### PR DESCRIPTION
# Description

Enrichissement de la méthode de création générique de sous-ressource avec la **version**.

## Fixes

Nécessaire pour implémenter : https://edifice-community.atlassian.net/browse/WB-2008

## Type of change

Please check options that are relevant.

- [x] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

- Tests dev manuels : création et mise à jour de billets de blog, vérification de l'existence des champs content & version dans la base elastic
- Mise à jour des tests unitaires côté Explorer : https://github.com/opendigitaleducation/explorer/pull/27

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: