### PR TITLE
Wb 2008 explorer subresource content handles version

### DIFF
--- a/common/src/main/java/org/entcore/common/explorer/ExplorerMessage.java
+++ b/common/src/main/java/org/entcore/common/explorer/ExplorerMessage.java
@@ -218,7 +218,7 @@ public class ExplorerMessage {
         return this;
     }
 
-    public ExplorerMessage withSubResourceContent(final String id, final String content, final ExplorerContentType type) {
+    public ExplorerMessage withSubResourceContent(final String id, final String content, final ExplorerContentType type, final long version) {
         final JsonArray subResources = message.getJsonArray(SUBRESOURCES_KEY, new JsonArray());
         final Optional<JsonObject> subResourceOpt = subResources.stream().map(e -> (JsonObject)e).filter(e-> e.getString("id","").equals(id)).findFirst();
         final JsonObject subResource = subResourceOpt.orElse(new JsonObject().put("id", id));
@@ -235,6 +235,7 @@ public class ExplorerMessage {
                 break;
         }
         subResource.put("deleted", false);
+        subResource.put("version", version);
         subResources.add(subResource);
         message.put(SUBRESOURCES_KEY, subResources);
         return this;

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerSubResource.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerSubResource.java
@@ -190,7 +190,22 @@ public abstract class ExplorerSubResource implements IExplorerSubResource {
         return doToMessage(message, source);
     }
 
-    protected abstract Future<ExplorerMessage> doToMessage(final ExplorerMessage message, final JsonObject source);
+    /**
+     * Default implementation for doToMessage method
+     * @param message message to be sent
+     * @param source source from which to enrich the message
+     * @return message enriched with source data
+     */
+    protected Future<ExplorerMessage> doToMessage(final ExplorerMessage message, final JsonObject source) {
+        final String id = source.getString("_id");
+        message.withVersion(System.currentTimeMillis());
+        if (source.containsKey("contentPlain")) {
+            message.withSubResourceContent(id, source.getString("contentPlain"), ExplorerMessage.ExplorerContentType.Text, source.getLong("version", 0L));
+        } else {
+            message.withSubResourceContent(id, source.getString("content", ""), ExplorerMessage.ExplorerContentType.Html, source.getLong("version", 0L));
+        }
+        return Future.succeededFuture(message);
+    };
 
     protected abstract void doFetchForIndex(final ExplorerStream<JsonObject> stream, final ExplorerReindexSubResourcesRequest subResourcesRequest);
 


### PR DESCRIPTION
# Description

Implémentation par défaut pour la gestion des sous-ressources.

## Fixes

https://edifice-community.atlassian.net/browse/WB-2008

## Type of change

Please check options that are relevant.

- [x] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Unit tests and manual dev tests

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: