### PR TITLE
[EDIFICE] set shared when restoring subfolder

### DIFF
--- a/common/src/main/java/org/entcore/common/folders/impl/InheritShareComputer.java
+++ b/common/src/main/java/org/entcore/common/folders/impl/InheritShareComputer.java
@@ -10,7 +10,7 @@ import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
-class InheritShareComputer {
+public class InheritShareComputer {
 	static class InheritShareResult {
 		public final Optional<JsonObject> parentRoot;
 		public final JsonObject root;
@@ -44,7 +44,6 @@ class InheritShareComputer {
 					if(userId != null){
 						final JsonObject currentShare = byUser.computeIfAbsent(userId, e -> {
 							final JsonObject newShare = new JsonObject().mergeIn(shareJson);
-							byUser.put(userId, newShare);
 							merged.add(newShare);
 							return newShare;
 						});
@@ -52,7 +51,6 @@ class InheritShareComputer {
 					}else if(groupId != null){
 						final JsonObject currentShare = byGroup.computeIfAbsent(groupId, e -> {
 							final JsonObject newShare = new JsonObject().mergeIn(shareJson);
-							byGroup.put(groupId, newShare);
 							merged.add(newShare);
 							return newShare;
 						});

--- a/common/src/main/java/org/entcore/common/folders/impl/QueryHelper.java
+++ b/common/src/main/java/org/entcore/common/folders/impl/QueryHelper.java
@@ -1072,7 +1072,9 @@ class QueryHelper {
 				String id = DocumentHelper.getId(doc);
 				String parent = DocumentHelper.getParent(doc);
 				String oldParent = DocumentHelper.getParentOld(doc);
+				final JsonArray shared = doc.getJsonArray("shared", new JsonArray());
 				final JsonArray inheritedShares = doc.getJsonArray("inheritedShares", new JsonArray());
+				final JsonArray mergedShares = InheritShareComputer.concatShares(inheritedShares, shared);
 				// if oldparent is not in my virtual tree=> remove parent
 				if (oldParent != null) {
 					if (parentIdsOk.contains(oldParent) || treeIds.contains(oldParent)) {
@@ -1081,7 +1083,7 @@ class QueryHelper {
 						idsToRemoveParent.add(id);
 						// doc is moved to root => shared = inheritedshares
 						if(inheritedShares.size() > 0){
-							futures.add(update(id, new MongoUpdateBuilder().set("shared", inheritedShares)));
+							futures.add(update(id, new MongoUpdateBuilder().set("shared", mergedShares)));
 						}
 					}
 				} else if(parent != null){
@@ -1091,7 +1093,7 @@ class QueryHelper {
 						idsToRemoveParent.add(id);
 						// doc is moved to root => shared = inheritedshares
 						if(inheritedShares.size() > 0){
-							futures.add(update(id, new MongoUpdateBuilder().set("shared", inheritedShares)));
+							futures.add(update(id, new MongoUpdateBuilder().set("shared", mergedShares)));
 						}
 					}
 				}//else do nothing

--- a/workspace/src/test/java/org/entcore/workspace/FolderTest.java
+++ b/workspace/src/test/java/org/entcore/workspace/FolderTest.java
@@ -95,15 +95,6 @@ public class FolderTest {
     private JsonObject folder(String name) {
         return new JsonObject().put("name", name);
     }
-    private JsonObject folder(String name, final String id) {
-        return new JsonObject().put("name", name).put("_id", id);
-    }
-
-    private ElementShareOperations readOnly(UserInfos user, final String userid) {
-        return ElementShareOperations.addShareObject(WorkspaceController.SHARED_ACTION, user,
-                new JsonObject().put("groups", new JsonObject()).put("users", new JsonObject().put(userid,
-                        new JsonArray().add("org-entcore-workspace-controllers-WorkspaceController|renameFolder"))));
-    }
 
     private JsonObject folder(String name, final String id) {
         return new JsonObject().put("name", name).put("_id", id);
@@ -347,7 +338,7 @@ public class FolderTest {
         final UserInfos user = test.directory().generateUser("user13");
         // create reader
         test.directory().createActiveUser("reader", "password", "email").onComplete(context.asyncAssertSuccess(reader -> {
-            // create reader
+            // create writer
             test.directory().createActiveUser("writter", "password", "email").onComplete(context.asyncAssertSuccess(writter -> {
                 // create folder tree
                 workspaceService.createFolder(folder("folder1", "folder1"), user, context.asyncAssertSuccess(onCreateFolder1 -> {

--- a/workspace/src/test/java/org/entcore/workspace/FolderTest.java
+++ b/workspace/src/test/java/org/entcore/workspace/FolderTest.java
@@ -74,7 +74,7 @@ public class FolderTest {
                 DocumentDao.DOCUMENTS_COLLECTION);
         final Storage storage = new StorageFactory(test.vertx(), new JsonObject(),
                 new MongoDBApplicationStorage(DocumentDao.DOCUMENTS_COLLECTION, Workspace.class.getSimpleName()))
-                        .getStorage();
+                .getStorage();
         final String imageResizerAddress = "wse.image.resizer";
         final FolderManager folderManager = FolderManager.mongoManager(DocumentDao.DOCUMENTS_COLLECTION, storage,
                 test.vertx(), shareService, imageResizerAddress, false);
@@ -103,6 +103,23 @@ public class FolderTest {
         return ElementShareOperations.addShareObject(WorkspaceController.SHARED_ACTION, user,
                 new JsonObject().put("groups", new JsonObject()).put("users", new JsonObject().put(userid,
                         new JsonArray().add("org-entcore-workspace-controllers-WorkspaceController|renameFolder"))));
+    }
+
+    private JsonObject folder(String name, final String id) {
+        return new JsonObject().put("name", name).put("_id", id);
+    }
+
+    private ElementShareOperations readOnly(UserInfos user, final String userid) {
+        return ElementShareOperations.addShareObject(WorkspaceController.SHARED_ACTION, user,
+                new JsonObject().put("groups", new JsonObject()).put("users", new JsonObject().put(userid,
+                        new JsonArray().add("org-entcore-workspace-controllers-WorkspaceController|renameFolder"))));
+    }
+
+    private ElementShareOperations readWrite(UserInfos user, final String userid) {
+        return ElementShareOperations.addShareObject(WorkspaceController.SHARED_ACTION, user,
+                new JsonObject().put("groups", new JsonObject()).put("users", new JsonObject().put(userid,
+                        new JsonArray().add("org-entcore-workspace-controllers-WorkspaceController|renameFolder")
+                                .add("org-entcore-workspace-controllers-WorkspaceController|updateDocument"))));
     }
 
     @Test
@@ -304,19 +321,23 @@ public class FolderTest {
      *
      * <u>STEPS</u> :
      * <ol>
+     *     <li>Create user "reader" and "writter"</li>
      *     <li>Create folder1 for user13</li>
      *     <li>Create folder2 for user13 (child of folder1)</li>
      *     <li>Verify that folder1 is child of folder2</li>
      *     <li>Share folder1 to reader</li>
+     *     <li>Share folder2 to writer</li>
      *     <li>Verify that folder1 has share to reader</li>
-     *     <li>Verify that folder2 has inherited share to reader</li>
+     *     <li>Verify that folder2 has shared share to writer</li>
+     *     <li>Verify that folder2 has inherited share to reader and writer</li>
      *     <li>Delete folder1</li>
      *     <li>Verify that folder1 and folder2 has been deleted</li>
      *     <li>Restore folder2</li>
      *     <li>Verify that folder2 has no more parent and is not trashed</li>
-     *     <li>Verify that folder2 has direct shared to reader</li>
+     *     <li>Verify that folder2 has direct shared to reader and writer</li>
      *     <li>Verify that folder2 has inherited shared to reader</li>
      * </ol>
+     *
      * @param context
      * @throws Exception
      */
@@ -326,55 +347,60 @@ public class FolderTest {
         final UserInfos user = test.directory().generateUser("user13");
         // create reader
         test.directory().createActiveUser("reader", "password", "email").onComplete(context.asyncAssertSuccess(reader -> {
-            // create folder tree
-            workspaceService.createFolder(folder("folder1","folder1"), user, context.asyncAssertSuccess(onCreateFolder1 -> {
-                workspaceService.createFolder("folder1", user, folder("folder2","folder2"), context.asyncAssertSuccess(onCreateFolder2 -> {
-                    // share folder tree
-                    workspaceService.share("folder1", readOnly(user, reader), context.asyncAssertSuccess(onShare->{
-                        workspaceService.findByQuery(new ElementQuery(true),user, context.asyncAssertSuccess(folders -> {
-                            // check folder tree
-                            context.assertEquals(2, folders.size());
-                            final JsonObject folder1 = folders.getJsonObject(0);
-                            final JsonObject folder2 = folders.getJsonObject(1);
-                            context.assertEquals("folder1", DocumentHelper.getName(folder1));
-                            context.assertEquals("folder2", DocumentHelper.getName(folder2));
-                            context.assertNull(DocumentHelper.getParent(folder1));
-                            context.assertEquals("folder1", DocumentHelper.getParent(folder2));
-                            context.assertEquals(1, folder1.getJsonArray("shared").size());
-                            context.assertEquals(1, folder1.getJsonArray("inheritedShares").size());
-                            context.assertEquals(0, folder2.getJsonArray("shared").size());
-                            context.assertEquals(1, folder2.getJsonArray("inheritedShares").size());
-                            // trash folder tree
-                            workspaceService.trash("folder1", user, context.asyncAssertSuccess(onDelete -> {
-                                final ElementQuery queryTrashed = new ElementQuery(true);
-                                queryTrashed.setTrash(true);
-                                queryTrashed.setHierarchical(true);
-                                workspaceService.findByQuery(queryTrashed, user, context.asyncAssertSuccess(deletedFolders -> {
-                                    // check trash
-                                    context.assertEquals(2, deletedFolders.size());
-                                    final JsonObject delFolder1 = deletedFolders.getJsonObject(0);
-                                    final JsonObject delFolder2 = deletedFolders.getJsonObject(1);
-                                    context.assertEquals(true, delFolder1.getBoolean("deleted"));
-                                    context.assertEquals(1, delFolder1.getJsonArray("shared").size());
-                                    context.assertEquals(1, delFolder1.getJsonArray("inheritedShares").size());
-                                    context.assertEquals(true, delFolder2.getBoolean("deleted"));
-                                    context.assertEquals(0, delFolder2.getJsonArray("shared").size());
-                                    context.assertEquals(1, delFolder2.getJsonArray("inheritedShares").size());
-                                    // restore folder2
-                                    workspaceService.restore("folder2", user, context.asyncAssertSuccess(onRestore -> {
-                                        final ElementQuery queryRestored = new ElementQuery(true);
-                                        queryRestored.setTrash(false);
-                                        queryRestored.setHierarchical(true);
-                                        workspaceService.findByQuery(queryRestored, user, context.asyncAssertSuccess(restoredFolders -> {
-                                            // check restore
-                                            context.assertEquals(1, restoredFolders.size());
-                                            final JsonObject restoredFolder1 = restoredFolders.getJsonObject(0);
-                                            context.assertNull(DocumentHelper.getParent(restoredFolder1));
-                                            context.assertEquals(false, restoredFolder1.getBoolean("deleted"));
-                                            // should have direct shares to reader1
-                                            context.assertEquals(1, restoredFolder1.getJsonArray("shared").size());
-                                            context.assertEquals(1, restoredFolder1.getJsonArray("inheritedShares").size());
-                                            async.complete();
+            // create reader
+            test.directory().createActiveUser("writter", "password", "email").onComplete(context.asyncAssertSuccess(writter -> {
+                // create folder tree
+                workspaceService.createFolder(folder("folder1", "folder1"), user, context.asyncAssertSuccess(onCreateFolder1 -> {
+                    workspaceService.createFolder("folder1", user, folder("folder2", "folder2"), context.asyncAssertSuccess(onCreateFolder2 -> {
+                        // share folder tree
+                        workspaceService.share("folder1", readOnly(user, reader), context.asyncAssertSuccess(onShare -> {
+                            workspaceService.share("folder2", readWrite(user, writter), context.asyncAssertSuccess(onShareWriter -> {
+                                workspaceService.findByQuery(new ElementQuery(true), user, context.asyncAssertSuccess(folders -> {
+                                    // check folder tree
+                                    context.assertEquals(2, folders.size());
+                                    final JsonObject folder1 = folders.getJsonObject(0);
+                                    final JsonObject folder2 = folders.getJsonObject(1);
+                                    context.assertEquals("folder1", DocumentHelper.getName(folder1));
+                                    context.assertEquals("folder2", DocumentHelper.getName(folder2));
+                                    context.assertNull(DocumentHelper.getParent(folder1));
+                                    context.assertEquals("folder1", DocumentHelper.getParent(folder2));
+                                    context.assertEquals(1, folder1.getJsonArray("shared").size());
+                                    context.assertEquals(1, folder1.getJsonArray("inheritedShares").size());
+                                    context.assertEquals(1, folder2.getJsonArray("shared").size());
+                                    context.assertEquals(2, folder2.getJsonArray("inheritedShares").size());
+                                    // trash folder tree
+                                    workspaceService.trash("folder1", user, context.asyncAssertSuccess(onDelete -> {
+                                        final ElementQuery queryTrashed = new ElementQuery(true);
+                                        queryTrashed.setTrash(true);
+                                        queryTrashed.setHierarchical(true);
+                                        workspaceService.findByQuery(queryTrashed, user, context.asyncAssertSuccess(deletedFolders -> {
+                                            // check trash
+                                            context.assertEquals(2, deletedFolders.size());
+                                            final JsonObject delFolder1 = deletedFolders.getJsonObject(0);
+                                            final JsonObject delFolder2 = deletedFolders.getJsonObject(1);
+                                            context.assertEquals(true, delFolder1.getBoolean("deleted"));
+                                            context.assertEquals(1, delFolder1.getJsonArray("shared").size());
+                                            context.assertEquals(1, delFolder1.getJsonArray("inheritedShares").size());
+                                            context.assertEquals(true, delFolder2.getBoolean("deleted"));
+                                            context.assertEquals(1, delFolder2.getJsonArray("shared").size());
+                                            context.assertEquals(2, delFolder2.getJsonArray("inheritedShares").size());
+                                            // restore folder2
+                                            workspaceService.restore("folder2", user, context.asyncAssertSuccess(onRestore -> {
+                                                final ElementQuery queryRestored = new ElementQuery(true);
+                                                queryRestored.setTrash(false);
+                                                queryRestored.setHierarchical(true);
+                                                workspaceService.findByQuery(queryRestored, user, context.asyncAssertSuccess(restoredFolders -> {
+                                                    // check restore
+                                                    context.assertEquals(1, restoredFolders.size());
+                                                    final JsonObject restoredFolder1 = restoredFolders.getJsonObject(0);
+                                                    context.assertNull(DocumentHelper.getParent(restoredFolder1));
+                                                    context.assertEquals(false, restoredFolder1.getBoolean("deleted"));
+                                                    // should have direct shares to reader1
+                                                    context.assertEquals(2, restoredFolder1.getJsonArray("shared").size());
+                                                    context.assertEquals(2, restoredFolder1.getJsonArray("inheritedShares").size());
+                                                    async.complete();
+                                                }));
+                                            }));
                                         }));
                                     }));
                                 }));

--- a/workspace/src/test/java/org/entcore/workspace/ShareComputerTest.java
+++ b/workspace/src/test/java/org/entcore/workspace/ShareComputerTest.java
@@ -1,0 +1,100 @@
+package org.entcore.workspace;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.entcore.common.folders.impl.InheritShareComputer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class ShareComputerTest {
+    private JsonObject userRead(final String userId) {
+        return new JsonObject().put("userId", userId).put("read", true);
+    }
+
+    private JsonObject userContrib(final String userId) {
+        return new JsonObject().put("userId", userId).put("read", true).put("contrib", true);
+    }
+
+    private JsonObject userManage(final String userId) {
+        return new JsonObject().put("userId", userId).put("read", true).put("contrib", true).put("manage", true);
+    }
+
+    private JsonObject groupRead(final String groupId) {
+        return new JsonObject().put("groupId", groupId).put("read", true);
+    }
+
+    private JsonObject groupContrib(final String groupId) {
+        return new JsonObject().put("groupId", groupId).put("read", true).put("contrib", true);
+    }
+
+    private JsonObject groupManage(final String groupId) {
+        return new JsonObject().put("groupId", groupId).put("read", true).put("contrib", true).put("manage", true);
+    }
+
+    /**
+     * <u>GOAL</u> : Ensure that concatShare merge shares without duplicate
+     * <ol>
+     *     <li>Create share with 2 different users</li>
+     *     <li>Verify that concat generate 2 entries</li>
+     *     <li>Create share with 2 different entries (read, manage) but one user</li>
+     *     <li>Verify that concat generate 1 entry with manage rights</li>
+     *     <li>Create share with 2 same entries (read) and one user</li>
+     *     <li>Verify that concat generate 1 entry with 1 read rights</li>
+     *     <li>Create share with 2 different groups</li>
+     *     <li>Verify that concat generate 2 entries</li>
+     *     <li>Create share with 2 different entries (read,manage) but one group</li>
+     *     <li>Verify that concat generate 1 entry with manage rights</li>
+     *     <li>Create share with 2 same entries (read) and one group</li>
+     *     <li>Verify that concat generate 1 entry with 1 read rights</li>
+     *     <li>Create share with 4 same entries (user1 read + group1 read)</li>
+     *     <li>Verify that concat generate 2 entry with 1 read rights for user1 and group1</li>
+     * </ol>
+     */
+    @Test
+    public void shouldConcatShare(TestContext context) {
+        // 2 users and 2 entries
+        JsonArray result = InheritShareComputer.concatShares(new JsonArray().add(userRead("user1")).add(userContrib("user2")));
+        context.assertEquals(2, result.size());
+        context.assertEquals(2, result.getJsonObject(0).fieldNames().size());
+        context.assertEquals("user1", result.getJsonObject(0).getString("userId"));
+        context.assertEquals(3, result.getJsonObject(1).fieldNames().size());
+        context.assertEquals("user2", result.getJsonObject(1).getString("userId"));
+        // 1 user and 1 entry with manage rights
+        result = InheritShareComputer.concatShares(new JsonArray().add(userRead("user1")).add(userManage("user1")));
+        context.assertEquals(1, result.size());
+        context.assertEquals(4, result.getJsonObject(0).fieldNames().size());
+        context.assertEquals("user1", result.getJsonObject(0).getString("userId"));
+        // 1 user and 1 entry with read rights
+        result = InheritShareComputer.concatShares(new JsonArray().add(userRead("user1")).add(userRead("user1")));
+        context.assertEquals(1, result.size());
+        context.assertEquals(2, result.getJsonObject(0).fieldNames().size());
+        context.assertEquals("user1", result.getJsonObject(0).getString("userId"));
+        // 2 groups and 2 entries
+        result = InheritShareComputer.concatShares(new JsonArray().add(groupRead("group1")).add(groupContrib("group2")));
+        context.assertEquals(2, result.size());
+        context.assertEquals(2, result.getJsonObject(0).fieldNames().size());
+        context.assertEquals("group1", result.getJsonObject(0).getString("groupId"));
+        context.assertEquals(3, result.getJsonObject(1).fieldNames().size());
+        context.assertEquals("group2", result.getJsonObject(1).getString("groupId"));
+        // 1 group and 1 entry with manage rights
+        result = InheritShareComputer.concatShares(new JsonArray().add(groupRead("group1")).add(groupManage("group1")));
+        context.assertEquals(1, result.size());
+        context.assertEquals(4, result.getJsonObject(0).fieldNames().size());
+        context.assertEquals("group1", result.getJsonObject(0).getString("groupId"));
+        // 1 group and 1 entry with read rights
+        result = InheritShareComputer.concatShares(new JsonArray().add(groupRead("group1")).add(groupRead("group1")));
+        context.assertEquals(1, result.size());
+        context.assertEquals(2, result.getJsonObject(0).fieldNames().size());
+        context.assertEquals("group1", result.getJsonObject(0).getString("groupId"));
+        // 2 entry with group1 and user1 with read rights
+        result = InheritShareComputer.concatShares(new JsonArray().add(userRead("user1")).add(userRead("user1")).add(groupRead("group1")).add(groupRead("group1")));
+        context.assertEquals(2, result.size());
+        context.assertEquals(2, result.getJsonObject(0).fieldNames().size());
+        context.assertEquals("user1", result.getJsonObject(0).getString("userId"));
+        context.assertEquals(2, result.getJsonObject(1).fieldNames().size());
+        context.assertEquals("group1", result.getJsonObject(1).getString("groupId"));
+    }
+}


### PR DESCRIPTION
# Description

Ce fix corrige le cas suivant:
- je crée un dossier A1 et un sous dossier A2
- je supprime A1
- je restaure A2
- A2 devient un dossier racine il conserve ses partages hérités

Le problème c'est que si A2 est un dossier racine il ne peut pas hérités de partage (puisqu'il n'a plus de parent) alors ses partages hérités deviennent des partages direct.
L'objectif du fix est de corriger ce cas suivant en settant shared=inheritedShared

## Fixes

WB2-741

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [X ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [X ] workspace

## Tests

J'ai ajouté un test dans FolderTest qui simule le scénario précèdent en s'assurant que le dossier A2 (devenu racine) a bien des partages directs une fois restauré

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X ] All done ! :smiley: