### PR TITLE
Fix: #WB-1829 Update error duplicate line in CSV translation

### DIFF
--- a/feeder/src/main/java/org/entcore/feeder/csv/CsvValidator.java
+++ b/feeder/src/main/java/org/entcore/feeder/csv/CsvValidator.java
@@ -433,7 +433,7 @@ public class CsvValidator extends CsvReport implements ImportValidator {
 			List<String> admlStructures, final Handler<JsonObject> handler) {
 		final List<String> columns = new ArrayList<>();
 		final AtomicInteger filterExternalId = new AtomicInteger(-1);
-		final Set<String> externalIds = new HashSet<>();
+		final Map<String, Integer> externalIds = new HashMap<String,Integer>();
 		CSVReader csvParser = null;
 		try {
 			csvParser = getCsvReader(path, charset);
@@ -470,9 +470,9 @@ public class CsvValidator extends CsvReport implements ImportValidator {
 					}
 				} else if (filterExternalId.get() >= 0 && !emptyLine(strings)) {
 					if (strings[filterExternalId.get()] != null && !strings[filterExternalId.get()].isEmpty()) {
-						if (!externalIds.add(strings[filterExternalId.get()])) {
+						if (externalIds.putIfAbsent(strings[filterExternalId.get()], (i + 1)) != null) {
 							addErrorByFile(profile, "duplicate.externalId.in.file",
-									"" + (i+1), strings[filterExternalId.get()]);
+									"" + (i+1), strings[columns.indexOf("firstName")] + ' ' +  strings[columns.indexOf("lastName")] + ", " + strings[filterExternalId.get()], "" + externalIds.get(strings[filterExternalId.get()]) );
 						}
 					} else if (findUsersEnabled) {
 						findUsersEnabled = false;
@@ -498,7 +498,7 @@ public class CsvValidator extends CsvReport implements ImportValidator {
 			}
 		}
 		if (filterExternalId.get() >= 0) {
-			filterExternalIdExists(admlStructures, profile, externalIds, ar -> {
+			filterExternalIdExists(admlStructures, profile, externalIds.keySet(), ar -> {
 				if (ar.succeeded()) {
 					final JsonArray externalIdsLogins = ar.result();
 					if (externalIdsLogins != null) {

--- a/feeder/src/main/resources/i18n/fr.json
+++ b/feeder/src/main/resources/i18n/fr.json
@@ -71,7 +71,7 @@
   "report.loadedFiles" : "Fichiers chargés",
   "validator.errorWithLine" : "Ligne {0} : {1}",
   "invalid.child.mapping" : "Ligne {0} : valeur(s) invalide(s) associée(s) au(x) champs {1} ",
-  "duplicate.externalId.in.file" : "Ligne {0} : identifiant {1} dupliqué dans le fichier.",
+  "duplicate.externalId.in.file" : "Ligne {0} : {1} est en double dans le fichier (en doublon avec la ligne {2}).",
   "externalId.used.in.aaf" : "L'import contient des identifiants AAF. Il n'est pas possible d'utiliser ces identifiants : {0}.",
   "externalId.used.in.not.adml.structure" : "L'import contient des identifiants externes déjà utilisés sur d'autres établissements. Il n'est pas possible d'utiliser ces identifiants : {0}."
 }


### PR DESCRIPTION
# Description

Update feeder module to change the error translation when importing CSV with duplicate lines

## Fixes

[JIRA Ticket](https://edifice-community.atlassian.net/browse/WB-1829)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [x] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Go to the admin console
2. Go to the import/export page ( `imports-exports/import-csv` )
3. Import a CSV with a duplicate line
4. on the step 4 you will see an error message this message will be updated according to the JIRA Ticket spec

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: