### PR TITLE
Feat: #WB-2247 Move LOOL aciton in Workspace to the title bar

### DIFF
--- a/workspace/src/main/resources/public/ts/delegates/lool.ts
+++ b/workspace/src/main/resources/public/ts/delegates/lool.ts
@@ -21,7 +21,7 @@ export function LoolDelegate($scope: LoolDelegateScope, $route) {
         Behaviours.load('lool').then(() => {
             Behaviours.applicationsBehaviours.lool.init(() => $scope.safeApply());
             Behaviours.applicationsBehaviours.lool.initPostMessage((event) => {
-               const data = JSON.parse(event.data);
+               const data = typeof event.data !== 'object' ? JSON.parse(event.data) : event.data;
                switch (data.id) {
                    case 'lool@getFolder': {
                        const response: any = {id: 'lool@getFolderResponse'};

--- a/workspace/src/main/resources/public/ts/delegates/lool.ts
+++ b/workspace/src/main/resources/public/ts/delegates/lool.ts
@@ -21,7 +21,7 @@ export function LoolDelegate($scope: LoolDelegateScope, $route) {
         Behaviours.load('lool').then(() => {
             Behaviours.applicationsBehaviours.lool.init(() => $scope.safeApply());
             Behaviours.applicationsBehaviours.lool.initPostMessage((event) => {
-               const data = typeof event.data !== 'object' ? JSON.parse(event.data) : event.data;
+               const data = JSON.parse(event.data);
                switch (data.id) {
                    case 'lool@getFolder': {
                        const response: any = {id: 'lool@getFolderResponse'};

--- a/workspace/src/main/resources/view-src/workspace.html
+++ b/workspace/src/main/resources/view-src/workspace.html
@@ -12,7 +12,7 @@
 	<script type="text/javascript" src="/assets/js/entcore/ng-app.js?v=@@VERSION" id="context"></script>
 	<script type="text/javascript" src="/workspace/public/dist/application.js?v=@@VERSION"></script>
 	<script type="text/javascript">
-		var ENABLE_LOOL= true;
+		var ENABLE_LOOL= {{enableLool}};
 		var ENABLE_SCRATCH= {{enableScratch}};
 		var ENABLE_GGB= {{enableGeogebra}};
 		var ENABLE_NEXTCLOUD= {{enableNextcloud}};

--- a/workspace/src/main/resources/view-src/workspace.html
+++ b/workspace/src/main/resources/view-src/workspace.html
@@ -12,7 +12,7 @@
 	<script type="text/javascript" src="/assets/js/entcore/ng-app.js?v=@@VERSION" id="context"></script>
 	<script type="text/javascript" src="/workspace/public/dist/application.js?v=@@VERSION"></script>
 	<script type="text/javascript">
-		var ENABLE_LOOL= {{enableLool}};
+		var ENABLE_LOOL= true;
 		var ENABLE_SCRATCH= {{enableScratch}};
 		var ENABLE_GGB= {{enableGeogebra}};
 		var ENABLE_NEXTCLOUD= {{enableNextcloud}};
@@ -84,19 +84,24 @@
 					<i class="storage"></i><i18n class="storage zero-mobile">workspace.headers</i18n>
 					<i class="storage"></i><i18n class="storage zero-desktop">workspace.headers.short</i18n>
 				</h1>
+				<div class="right-magnet zero-mobile  centered-bloc-text vertical-spacing-twice-1d" workflow="lool.createDocument" ng-if="canDropOnFolder() && !isSharedTree() && ENABLE_LOOL">
+					<button class="primary-button" ng-click="openLightbox()" ng-if="buttonType === ButtonType.PRIMARY">
+						<i18n>lool.sniplet.create-document.title</i18n>
+					</button>
+				</div>
+				<div class="right-magnet zero-mobile vertical-spacing-twice-1d  horizontal-spacing" ng-if="openedFolder.all.length || reloadingContent">
+					<div ng-repeat="button in currentTree.buttons">
+						<button ng-click="button.action()" ng-hide="canEmptyTrash()" ng-disabled="button.disabled()" workflow="[[button.workflow]]" class="primary-button">
+							 [[button.text]]
+						</button>
+					</div>
+				</div>
 			</app-title>
 		</div>
 		<div class="row rigid-grid">
 			<section class="four twelve-mobile cell">
 				<!--IMPORT DESKTOP-->
-				<div class="row zero-mobile" ng-if="openedFolder.all.length || reloadingContent">
-                    <div ng-repeat="button in currentTree.buttons">
-                        <button ng-click="button.action()" ng-hide="canEmptyTrash()" ng-disabled="button.disabled()" workflow="[[button.workflow]]">
-                             [[button.text]]
-                        </button>
-                    </div>
-				</div>
-				<nav class="vertical nav-droppable mobile-navigation top-spacing-twice-1d" side-nav>
+				<nav class="vertical nav-droppable mobile-navigation" side-nav>
 					<div data-ng-repeat="folder in wrapperTrees" data-ng-include="'folder-content'" class="folder-tree maxheight-minus350 maxheight-minus370-1d overflowx-hd maxheight-minus200-mobile minheight-100"></div>
 					<!-- nextcloud sniplet folder tree -->
 					<div ng-if="ENABLE_NEXTCLOUD">
@@ -106,9 +111,6 @@
 					<a ng-click="openNewFolderView()" ng-if="canCreateNewFolder()" class="classic-link centered-bloc-text vertical-spacing-twice-1d"><i18n>folder.new</i18n></a>
 					<a ng-click="openNewFolderView()" ng-if="canCreateNewFolderShared()" class="classic-link centered-bloc-text vertical-spacing-twice-1d"><i18n>folder.new.shared</i18n></a>
 					<a ng-click="confirmDelete()" ng-if="canEmptyTrash()" ng-hide="isTrashEmpty()" class="classic-link centered-bloc-text vertical-spacing-twice-1d"><i18n>workspace.empty.trash</i18n></a>
-                    <div class="classic-link centered-bloc-text vertical-spacing-twice-1d" workflow="lool.createDocument" ng-if="canDropOnFolder() && !isSharedTree() && ENABLE_LOOL">
-                        <sniplet application="lool" template="create" source="{type: 'secondary'}"></sniplet>
-                    </div>
 					<div class="row" ng-hide="canEmptyTrash() && isTrashEmpty()">
 						<h2>
 							<i18n>quota.title</i18n>
@@ -127,6 +129,11 @@
 						<div ng-if="openedFolder.all.length || reloadingContent" class="zero-desktop six-mobile" ng-repeat="button in currentTree.buttons">
 							<button ng-click="button.action(button.url)" ng-disabled="button.disabled()" workflow="[[button.workflow]]">
 								 [[translate(button.text)]]
+							</button>
+						</div>
+						<div class="zero-desktop  centered-bloc-text vertical-spacing-twice-1d" workflow="lool.createDocument" ng-if="canDropOnFolder() && !isSharedTree() && ENABLE_LOOL">
+							<button class="primary-button" ng-click="openLightbox()" ng-if="buttonType === ButtonType.PRIMARY">
+								<i18n>lool.sniplet.create-document.title</i18n>
 							</button>
 						</div>
 						<!--SEARCH DESKTOP-->


### PR DESCRIPTION
# Description

Move LOOL action (create document) from under the folder tree to the title bar with the import button

## Fixes

[WB-2247](https://edifice-community.atlassian.net/browse/WB-2247)

## Type of change

Please check options that are relevant.

- [x] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [x] workspace

## Tests

1. Go to workspace app and check the place of the button "Create document"

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley:

[WB-2247]: https://edifice-community.atlassian.net/browse/WB-2247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ