### PR TITLE
[EDIFICE]

### DIFF
--- a/auth/src/main/java/org/entcore/auth/controllers/AuthController.java
+++ b/auth/src/main/java/org/entcore/auth/controllers/AuthController.java
@@ -20,10 +20,7 @@
 package org.entcore.auth.controllers;
 
 import fr.wseduc.bus.BusAddress;
-import fr.wseduc.rs.Delete;
-import fr.wseduc.rs.Get;
-import fr.wseduc.rs.Post;
-import fr.wseduc.rs.Put;
+import fr.wseduc.rs.*;
 import fr.wseduc.security.ActionType;
 import fr.wseduc.security.SecuredAction;
 import fr.wseduc.webutils.Either;
@@ -101,6 +98,7 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 
 import static fr.wseduc.webutils.Utils.*;
+import static fr.wseduc.webutils.request.RequestUtils.getTokenHeader;
 import static org.entcore.auth.oauth.OAuthAuthorizationResponse.*;
 import static org.entcore.common.aggregation.MongoConstants.TRACE_TYPE_CONNECTOR;
 import static org.entcore.common.http.response.DefaultResponseHandler.defaultResponseHandler;
@@ -463,6 +461,33 @@ public class AuthController extends BaseController {
 					}
 
 				});
+			}
+		});
+	}
+
+	@Post("/oauth2/token-as-cookie")
+	@SecuredAction(value = "", type = ActionType.AUTHENTICATED)
+	@ApiDoc("Gives back a cookie to the user corresponding to its jwtToken")
+	public void tokenAsCookie(final HttpServerRequest request) {
+		UserUtils.getAuthenticatedUserInfos(eb, request).onSuccess(user -> {
+			final Optional<String> jwtToken = getTokenHeader(request);
+			if(jwtToken.isPresent()) {
+				final String oneSessionId = UUID.randomUUID().toString();
+				UserUtils.createSessionWithId(eb, user.getUserId(), oneSessionId, false)
+				.onSuccess(e -> {
+					log.debug("[AuthController@tokenAsCookie] Session created for user");
+					final long timeout = config.getLong("cookie_timeout", Long.MIN_VALUE);
+					CookieHelper.getInstance().setSigned("oneSessionId", oneSessionId, timeout, request);
+					CookieHelper.set("authenticated", "true", timeout, request);
+					Renders.render(request, new JsonObject().put("succces", true));
+				})
+				.onFailure(th -> {
+					log.warn("[AuthController@tokenAsCookie] Error while creating session", th);
+					Renders.renderError(request);
+				});
+			} else {
+				log.warn("[AuthController@tokenAsCookie] Called without a jwt token");
+				Renders.badRequest(request);
 			}
 		});
 	}


### PR DESCRIPTION
# Description

Création d'une route permettant de récupérer un `oneSessionId` à partir d'un token OAuth.

## Fixes

[WB-2238](https://edifice-community.atlassian.net/browse/WB-2238)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [x] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. S'authentifier sur le web
2. Réaliser un POST sur `/auth/oauth2/token-as-cookie`
3. Vérifier que l'on a une erreur 400
4. S'authentifier avec le mobile
5. Réaliser un POST sur `/auth/oauth2/token-as-cookie`
6. Vérifier que l'on a un code 200 ansi qu'un objet json contenant  la valeur d'un cookie
7. Réaliser l'appel suivant `curl http://localhost:8090/timeline/timeline -H "Cookie: oneSessionId=<LE_COOKIE_OBTENU>" -v`
8. Vérifier que l'on a un code 200 et la page HTML de la timeline

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley:

[WB-2238]: https://edifice-community.atlassian.net/browse/WB-2238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ