### PR TITLE
[EDIFICE] Réindexation des ressources par leur état d'ingestion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -252,6 +252,7 @@ project(':common') {
     compile "io.micrometer:micrometer-registry-prometheus:$micrometerPrometheusVersion"
     compile "com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:$owaspVersion"
     testCompile project(':test')
+    compile "org.apache.commons:commons-collections4:$commonsCollectionsVersion"
   }
 }
 

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPlugin.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPlugin.java
@@ -17,6 +17,9 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+
+import org.apache.commons.collections4.CollectionUtils;
 import org.entcore.common.explorer.ExplorerMessage;
 import org.entcore.common.explorer.ExplorerStream;
 import org.entcore.common.explorer.IExplorerFolderTree;
@@ -46,6 +49,7 @@ import java.util.stream.Collectors;
 public abstract class ExplorerPlugin implements IExplorerPlugin {
     public static final String RESOURCES_ADDRESS = "explorer.resources";
     public static final String FOLDERS_ADDRESS = "explorer.folders";
+    public static final String INGEST_JOB_STATE = "ingest_job_state";
     public enum ResourceActions{
         GetShares,
     }
@@ -267,7 +271,7 @@ public abstract class ExplorerPlugin implements IExplorerPlugin {
     protected void onReindexAction(final Message<JsonObject> message, final ExplorerReindexResourcesRequest request){
         final long now = currentTimeMillis();
         final Set<String> apps = request.getApps();
-        if(apps !=  null && !apps.isEmpty() && !apps.contains(getApplication())){
+        if(isNotEmpty(apps) && !(apps.contains(getApplication()) || apps.contains("all"))){
             log.info(String.format("Skip indexation for app=%s filter=%s", getApplication(), apps));
             reply(message, new ExplorerReindexResourcesResponse(0, 0, emptyMap()));
             return;

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPluginResourceSql.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPluginResourceSql.java
@@ -213,6 +213,7 @@ public abstract class ExplorerPluginResourceSql extends ExplorerPluginResource {
             );
         }).onFailure(e->{
             log.error("Failed to create sqlCursor resources "+getTableName()+ "for reindex : ", e);
+            stream.end();
         });
     }
 

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPluginResourceSql.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPluginResourceSql.java
@@ -5,7 +5,10 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.Tuple;
 import static java.lang.Long.parseLong;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+
 import io.vertx.core.CompositeFuture;
+import org.apache.commons.collections4.CollectionUtils;
 import org.entcore.common.explorer.ExplorerStream;
 import org.entcore.common.explorer.IExplorerPluginCommunication;
 import org.entcore.common.explorer.IngestJobState;
@@ -97,7 +100,7 @@ import java.util.stream.Collectors;
  */
 public abstract class ExplorerPluginResourceSql extends ExplorerPluginResource {
     protected final IPostgresClient pgPool;
-    protected List<String> defaultColumns = Arrays.asList("version", "ingest_job_state");
+    protected List<String> defaultColumns = Arrays.asList("version", INGEST_JOB_STATE);
 
     protected ExplorerPluginResourceSql(final IExplorerPluginCommunication communication,
                                         final IPostgresClient pool) {
@@ -183,8 +186,11 @@ public abstract class ExplorerPluginResourceSql extends ExplorerPluginResource {
             tuple.addValue(localTo);
             filters.add(String.format(" %s < $1 ",getCreatedAtColumn()));
         }
-        if(request.getIds() != null && !request.getIds().isEmpty()) {
+        if(isNotEmpty(request.getIds())) {
             filters.add("t." + getIdColumn() + " IN (" + String.join(",", request.getIds()) + ") ");
+        }
+        if(isNotEmpty(request.getStates())) {
+            filters.add("t." + INGEST_JOB_STATE + " IN (" + String.join(",", request.getStates()) + ") ");
         }
         if(!filters.isEmpty()) {
             query.append(" WHERE ");
@@ -216,7 +222,7 @@ public abstract class ExplorerPluginResourceSql extends ExplorerPluginResource {
         for(final JsonObject source : sources){
             setCreatorForModel(user, source);
             setCreatedAtForModel(user, source);
-            source.put("ingest_job_state", IngestJobState.TO_BE_SENT);
+            source.put(INGEST_JOB_STATE, IngestJobState.TO_BE_SENT);
         }
         final List<String> columnNames = new ArrayList<>(getColumns());
         columnNames.addAll(defaultColumns);

--- a/common/src/main/java/org/entcore/common/explorer/to/ExplorerReindexResourcesRequest.java
+++ b/common/src/main/java/org/entcore/common/explorer/to/ExplorerReindexResourcesRequest.java
@@ -22,6 +22,8 @@ public class ExplorerReindexResourcesRequest {
     private final boolean includeFolders;
     /** Ids of the resources to reindex.*/
     private final Set<String> ids;
+    /** Ingest state of resources to reindex.*/
+    private final Set<String> states;
 
 
     @JsonCreator
@@ -29,18 +31,20 @@ public class ExplorerReindexResourcesRequest {
                                            @JsonProperty("to") final Date to,
                                            @JsonProperty("apps") final Set<String> apps,
                                            @JsonProperty("includeFolders") final boolean includeFolders,
-                                           @JsonProperty("ids") final Set<String> ids) {
+                                           @JsonProperty("ids") final Set<String> ids,
+                                           @JsonProperty("states") final Set<String> states) {
         this.from = from;
         this.to = to;
         this.apps = apps;
         this.includeFolders = includeFolders;
         this.ids = ids;
+        this.states = states;
     }
     public ExplorerReindexResourcesRequest(final Set<String> ids) {
-        this(null, null, null, false, ids);
+        this(null, null, null, false, ids, null);
     }
     public ExplorerReindexResourcesRequest() {
-        this(null, null, null, false, null);
+        this(null, null, null, false, null, null);
     }
 
     public Date getFrom() {
@@ -63,14 +67,19 @@ public class ExplorerReindexResourcesRequest {
         return ids;
     }
 
+    public Set<String> getStates() {
+        return states;
+    }
+
     @Override
     public String toString() {
-        return "ExplorerReindexRequest{" +
-                "from=" + from +
-                ", to=" + to +
-                ", apps=" + apps +
-                ", includeFolders=" + includeFolders +
-                ", ids=" + ids +
-                '}';
+        return "ExplorerReindexResourcesRequest{" +
+            "from=" + from +
+            ", to=" + to +
+            ", apps=" + apps +
+            ", includeFolders=" + includeFolders +
+            ", ids=" + ids +
+            ", states=" + states +
+            '}';
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,3 +46,4 @@ modMongoVersion=3.2.0
 testContainerVersion=1.17.1
 micrometerMetricsVersion=3.9.5
 micrometerPrometheusVersion=1.1.0
+commonsCollectionsVersion=4.1


### PR DESCRIPTION
# Description

Permettre de réindexer les ressources par leur état d'ingestion.

## Fixes

wb-2243

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Create a blog
2. In mongo, set the `ingest_job_state` to KO and modify the field `description`
3. With an ADMC, go to http://localhost:8090/explorer/reindex/blog/blog?states=KO
4. Verify that the return of the call says that one message was concerned
5. Verify in mongo that `ingest_job_state` is set to OK
6. Verify in opensearch that the corresponding document has a `description` matching the one in the database

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: