### PR TITLE
[EDIFICE] #WB2-1273, Synchronisation de OpenSearch lors de la suppression d'un utilisateur

### DIFF
--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPlugin.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPlugin.java
@@ -275,7 +275,7 @@ public abstract class ExplorerPlugin implements IExplorerPlugin {
         log.info(String.format("Starting indexation for app=%s type=%s %s",getApplication(), getResourceType(), request));
         final JsonObject metrics = new JsonObject();
         // each missing id in DB should be deleted from opensearch
-        final Set<String> toDelete = request.getIds() == null? Collections.emptySet() : new HashSet<>();
+        final Set<String> toDelete = request.getIds() == null? Collections.emptySet() : new HashSet<>(request.getIds());
         final ExplorerStream<JsonObject> stream = new ExplorerStream<>(reindexBatchSize, bulk -> {
             // TODO JBE missing saving state and version here
             for (JsonObject entry : bulk) {
@@ -303,7 +303,9 @@ public abstract class ExplorerPlugin implements IExplorerPlugin {
         stream.getEndFuture().onComplete(root->{
             if(root.succeeded()){
                 // each id not in DB should be deleted from OpenSearch
-                log.warn(String.format("Cleaning %s id missing in DB for app=%s type=%s", toDelete.size(), getApplication(), getResourceType()));
+                if(!toDelete.isEmpty()){
+                    log.warn(String.format("Cleaning %s id missing in DB for app=%s type=%s", toDelete.size(), getApplication(), getResourceType()));
+                }
                 for(final String id : toDelete){
                     final UserInfos user = new UserInfos();
                     user.setUserId("explorer-plugin-cleaner");

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPlugin.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPlugin.java
@@ -275,7 +275,7 @@ public abstract class ExplorerPlugin implements IExplorerPlugin {
         log.info(String.format("Starting indexation for app=%s type=%s %s",getApplication(), getResourceType(), request));
         final JsonObject metrics = new JsonObject();
         // each missing id in DB should be deleted from opensearch
-        final Set<String> toDelete = request.getIds() == null? Collections.emptySet() : new HashSet<>(request.getIds());
+        final Set<String> toDelete = request.getIds() == null? new HashSet<>() : new HashSet<>(request.getIds());
         final ExplorerStream<JsonObject> stream = new ExplorerStream<>(reindexBatchSize, bulk -> {
             // TODO JBE missing saving state and version here
             for (JsonObject entry : bulk) {

--- a/common/src/main/java/org/entcore/common/service/impl/MongoDbRepositoryEvents.java
+++ b/common/src/main/java/org/entcore/common/service/impl/MongoDbRepositoryEvents.java
@@ -215,7 +215,9 @@ public class MongoDbRepositoryEvents extends AbstractRepositoryEvents {
 					} else {
 						log.error("[deleteUsers] Could not found updated resources:"+ eventFind.body());
 					}
-					// delete objects
+					// If the app as a manager right, we will delete objects that do not have
+					// - managers
+					// - owner
 					if (managerRight != null && !managerRight.trim().isEmpty()) {
 						removeObjects(collection, toDelete -> {
 							toDelete.forEach(toDel -> {
@@ -239,6 +241,15 @@ public class MongoDbRepositoryEvents extends AbstractRepositoryEvents {
 		this.removeObjects(collection, e -> {});
 	}
 
+	/**
+	 * Remove all the objects of the specified collection that :
+	 * <ul>
+	 *   <li>do not have managers</li>
+	 *   <li>do not have an owner</li>
+	 * </ul>
+	 * @param collection The name of the collection of the resources to delete
+	 * @param handler List of all the objects that were deleted
+	 */
 	protected void removeObjects(final String collection, final Handler<List<ResourceChanges>> handler) {
 		JsonObject matcher = MongoQueryBuilder.build(
 				QueryBuilder.start("shared." + managerRight).notEquals(true).put("owner.deleted").is(true));


### PR DESCRIPTION
# Description

Lors de la suppression du propriétaire la ressource associée n'était pas supprimé de l'EUR.
Ce fix vient corriger celà en notifiant l'EUR d'une suppression lorsque la ressource Mongo est supprimé de la BDD
Au passage, j'ai ajouté dans la méthode "reindex" des notifications de Delete si l'EUR demande à réindexer une ressource qui n'existe plus dans la BDD primaire

## Fixes

#WB2-1273

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [X ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Des tests ont été fait sur mindmap pour tester le RepositoryEventMongo associé à l'EUR:
- import d'un fichier => doit créer la ressource dans OpenSearch
- suppression d'un utilisateur en partage => doit mettre à jour les partages dans l'EUR
- suppression d'un groupe en partage => doit mettre à jour les partages dans l'EUR
- suppression du propriétaire => doit supprimer la ressource dans EUR

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ X] All done ! :smiley: