### PR TITLE
WB-1588 endpoint to check match between reset code and login

### DIFF
--- a/auth/src/main/java/org/entcore/auth/controllers/AuthController.java
+++ b/auth/src/main/java/org/entcore/auth/controllers/AuthController.java
@@ -1029,11 +1029,16 @@ public class AuthController extends BaseController {
 		});
 	}
 
+	/**
+	 * API endpoint to verify that a reset code matches with a login or an alias login
+	 * @param request the request with the reset code (password) and the login (or alias login)
+	 */
 	@Post("/reset/match")
 	public void resetPasswordMatch(final HttpServerRequest request) {
 		RequestUtils.bodyToJson(request, data -> {
 			if (data == null) {
 				badRequest(request);
+				log.warn("Request body with password and login is expected");
 				return;
 			}
 			final String login = data.getString("login");

--- a/auth/src/main/java/org/entcore/auth/controllers/AuthController.java
+++ b/auth/src/main/java/org/entcore/auth/controllers/AuthController.java
@@ -1029,6 +1029,27 @@ public class AuthController extends BaseController {
 		});
 	}
 
+	@Post("/reset/match")
+	public void resetPasswordMatch(final HttpServerRequest request) {
+		RequestUtils.bodyToJson(request, data -> {
+			if (data == null) {
+				badRequest(request);
+				return;
+			}
+			final String login = data.getString("login");
+			final String password = data.getString("password");
+			userAuthAccount.matchResetCode(login, password, matchReset -> {
+				if (matchReset) {
+					renderJson(request, new JsonObject().put("match", matchReset));
+				} else {
+					userAuthAccount.matchResetCodeByLoginAlias(login, password, matchResetAlias -> {
+						renderJson(request, new JsonObject().put("match", matchResetAlias));
+					});
+				}
+			});
+		});
+	}
+
 	@Post("/activation")
 	public void activeAccountSubmit(final HttpServerRequest request) {
 		activeAccountSubmit(request, true);


### PR DESCRIPTION
# Description

Provides Mobile team an API endpoint to verify that a reset code matches with the login or the alias login.

## Fixes

https://edifice-community.atlassian.net/browse/WB-1588

## Type of change

Please check options that are relevant.

- [x] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [x] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Manual dev tests of the API on local environment.
Additionally, both `userAuthAccount.matchResetCode` and `userAuthAccount.matchResetCodeByLoginAlias` methods called in the endpoint are already covered by unit tests.


# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: