### PR TITLE
feat: #WB-2247 Update LOOL actions display when emptyscreen

### DIFF
--- a/workspace/src/main/resources/view-src/workspace.html
+++ b/workspace/src/main/resources/view-src/workspace.html
@@ -84,12 +84,10 @@
 					<i class="storage"></i><i18n class="storage zero-mobile">workspace.headers</i18n>
 					<i class="storage"></i><i18n class="storage zero-desktop">workspace.headers.short</i18n>
 				</h1>
-				<div class="right-magnet zero-mobile  centered-bloc-text vertical-spacing-twice-1d" workflow="lool.createDocument" ng-if="canDropOnFolder() && !isSharedTree() && ENABLE_LOOL">
-					<button class="primary-button" ng-click="openLightbox()" ng-if="buttonType === ButtonType.PRIMARY">
-						<i18n>lool.sniplet.create-document.title</i18n>
-					</button>
-				</div>
 				<div class="right-magnet zero-mobile vertical-spacing-twice-1d  horizontal-spacing" ng-if="openedFolder.all.length || reloadingContent">
+					<div workflow="lool.createDocument" ng-if="canDropOnFolder() && !isSharedTree() && ENABLE_LOOL">
+						<sniplet application="lool" template="create" source="{type: 'primary'}"></sniplet>
+					</div>
 					<div ng-repeat="button in currentTree.buttons">
 						<button ng-click="button.action()" ng-hide="canEmptyTrash()" ng-disabled="button.disabled()" workflow="[[button.workflow]]" class="primary-button">
 							 [[button.text]]


### PR DESCRIPTION
# Description

Update LOOL actions display when empty screen (no action on the top bar)

## Fixes

[Ticket WB-2247](https://edifice-community.atlassian.net/browse/WB-2247)

## Type of change

Please check options that are relevant.

- [x] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [x] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: