### PR TITLE
[EDIFICE] Ajouter des infos dans les events recoltés sur les SMS

### DIFF
--- a/auth/src/main/java/org/entcore/auth/services/impl/DefaultMfaService.java
+++ b/auth/src/main/java/org/entcore/auth/services/impl/DefaultMfaService.java
@@ -198,14 +198,16 @@ public class DefaultMfaService implements MfaService {
         }
 
         @Override
-        public Future<String> sendValidationMessage( final HttpServerRequest request, String target, JsonObject templateParams ) {
+        public Future<String> sendValidationMessage( final HttpServerRequest request, String target,
+                                                     final JsonObject templateParams,
+                                                     final String module) {
             if( StringUtils.isEmpty(target) ) {
                 logger.info("[2FA] Cannot send a code through sms or email, since target is empty !");
                 return Future.failedFuture("empty.target");
             }
 
             if( Mfa.withSms() ) {
-                return sms.sendUnique(request, target, "phone/mfaCode.txt", templateParams, "MFA");
+                return sms.sendUnique(request, target, "phone/mfaCode.txt", templateParams, module);
             }
             
             // if( Mfa.withEmail() ) {
@@ -274,7 +276,7 @@ public class DefaultMfaService implements MfaService {
                     .put("duration", Math.round(DataStateUtils.ttlToRemainingSeconds(expires) / 60f))
                     .put("code", DataStateUtils.getKey(mfaState));
 
-                    return mfaField.sendValidationMessage(request, fullState.getString("target"), templateParams)
+                    return mfaField.sendValidationMessage(request, fullState.getString("target"), templateParams, "MFA")
                     .onFailure( t -> {
                         // Code was not sent => consider it is outdated
                         logger.error(t);

--- a/common/src/main/java/org/entcore/common/datavalidation/DataValidationService.java
+++ b/common/src/main/java/org/entcore/common/datavalidation/DataValidationService.java
@@ -65,7 +65,8 @@ public interface DataValidationService {
 	 * @param request required to translate things...
 	 * @param target address where to send
 	 * @param templateParams for the "email/emailValidationCode.html" template
+	 * @param module name of the module which is sending a SMS for validation
 	 * @return the message ID
 	 */
-	Future<String> sendValidationMessage(HttpServerRequest request, String target, JsonObject templateParams);
+	Future<String> sendValidationMessage(HttpServerRequest request, String target, JsonObject templateParams, String module);
 }

--- a/common/src/main/java/org/entcore/common/datavalidation/impl/AbstractDataValidationService.java
+++ b/common/src/main/java/org/entcore/common/datavalidation/impl/AbstractDataValidationService.java
@@ -19,19 +19,10 @@
 
 package org.entcore.common.datavalidation.impl;
 
-import com.samskivert.mustache.Mustache;
-import com.samskivert.mustache.Template;
 import fr.wseduc.webutils.Either;
-import fr.wseduc.webutils.I18n;
-import fr.wseduc.webutils.http.Renders;
 import fr.wseduc.webutils.security.AES128CBC;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Promise;
-import io.vertx.core.eventbus.DeliveryOptions;
-import io.vertx.core.file.FileProps;
-import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonObject;
 import org.entcore.common.datavalidation.DataValidationService;
 import org.entcore.common.datavalidation.utils.DataStateUtils;
@@ -39,16 +30,6 @@ import org.entcore.common.http.renders.TemplatedEmailRenders;
 import org.entcore.common.neo4j.Neo4j;
 import org.entcore.common.utils.StringUtils;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.Writer;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static fr.wseduc.webutils.Utils.getOrElse;
-import static fr.wseduc.webutils.Utils.handlerToAsyncHandler;
 import static org.entcore.common.datavalidation.utils.DataStateUtils.*;
 import static org.entcore.common.neo4j.Neo4jResult.validEmpty;
 import static org.entcore.common.neo4j.Neo4jResult.validUniqueResult;

--- a/common/src/main/java/org/entcore/common/datavalidation/impl/DefaultUserValidationService.java
+++ b/common/src/main/java/org/entcore/common/datavalidation/impl/DefaultUserValidationService.java
@@ -55,9 +55,9 @@ public class DefaultUserValidationService implements UserValidationService {
         }
 
         @Override
-        public Future<String> sendValidationMessage( final HttpServerRequest request, String mobile, JsonObject templateParams ) {
+        public Future<String> sendValidationMessage( final HttpServerRequest request, String mobile, JsonObject templateParams, final String module ) {
             final SmsSender sms = SmsSenderFactory.getInstance().newInstance( this, eventStore );
-            return sms.sendUnique(request, mobile, "phone/mobileVerification.txt", templateParams);
+            return sms.sendUnique(request, mobile, "phone/mobileVerification.txt", templateParams, module);
         }
     }
 
@@ -73,7 +73,7 @@ public class DefaultUserValidationService implements UserValidationService {
         }
 
         @Override
-        public Future<String> sendValidationMessage( final HttpServerRequest request, String email, JsonObject templateParams ) {
+        public Future<String> sendValidationMessage( final HttpServerRequest request, String email, JsonObject templateParams, final String module) {
             Promise<String> promise = Promise.promise();
             if( emailSender == null ) {
                 promise.complete(null);
@@ -395,7 +395,7 @@ public class DefaultUserValidationService implements UserValidationService {
         .put("duration", Math.round(DataStateUtils.ttlToRemainingSeconds(expires) / 60f))
         .put("code", DataStateUtils.getKey(mobileState));
 
-        return mobileSvc.sendValidationMessage( request, DataStateUtils.getPending(mobileState), templateParams )
+        return mobileSvc.sendValidationMessage( request, DataStateUtils.getPending(mobileState), templateParams, "VALIDATION" )
         .map( id -> {
             // Code was sent => this is a metric to follow
             DataValidationMetricsFactory.getRecorder().onMobileCodeGenerated();
@@ -487,7 +487,7 @@ public class DefaultUserValidationService implements UserValidationService {
         .put("duration", Math.round(DataStateUtils.ttlToRemainingSeconds(expires) / 60f))
         .put("code", DataStateUtils.getKey(emailState));
 
-        return emailSvc.sendValidationMessage( request, DataStateUtils.getPending(emailState), templateParams )
+        return emailSvc.sendValidationMessage( request, DataStateUtils.getPending(emailState), templateParams, "VALIDATION")
         .map( id -> {
             // Code was sent => this is a metric to follow
             DataValidationMetricsFactory.getRecorder().onEmailCodeGenerated();

--- a/common/src/main/java/org/entcore/common/sms/SmsSender.java
+++ b/common/src/main/java/org/entcore/common/sms/SmsSender.java
@@ -8,6 +8,10 @@ import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.entcore.common.events.EventStore;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 /**
  *
  * Delegage class of {@link fr.wseduc.sms.Sms Sms} which stores new event for every successfully sent SMS.
@@ -57,7 +61,7 @@ public class SmsSender {
 
     public Future<SmsSendingReport> send(HttpServerRequest request, final String phone, String template, JsonObject params, final String module){
         return sms.send(request, phone, template, params, module)
-                .onSuccess(report -> storeEvent(report, request, module));
+                .onSuccess(report -> storeEvent(phone, report, request, module));
     }
 
     /**
@@ -66,13 +70,15 @@ public class SmsSender {
      * @param request HTTP request that triggered the SMS sending
      * @param module Name of the module which triggered the SMS
      */
-    private void storeEvent(final SmsSendingReport report,
+    private void storeEvent(final String phone,
+                            final SmsSendingReport report,
                            final HttpServerRequest request,
                            final String module){
         if(eventStore != null) {
             for (String sentSmdId : report.getIds()) {
                 final JsonObject customAttributes = new JsonObject()
-                        .put("sms_id", sentSmdId);
+                    .put("sms_id", sentSmdId)
+                    .put("phone", phone);
                 if (StringUtils.isNotBlank(module)) {
                     customAttributes.put("override-module", module);
                 }


### PR DESCRIPTION
# Description

- Ajout du numéro de téléphone aux événements d'envoi de SMS pour meilleur suivi
- Mise en place de de différentes valeurs de module pour les cas suivants :
   - MFA
   - validation du numéro de tel
   - réinitialisation du mdp

## Fixes

[WB-2329](https://edifice-community.atlassian.net/browse/WB-2329)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [x] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley:

[WB-2329]: https://edifice-community.atlassian.net/browse/WB-2329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ