### PR TITLE
feat(stats): #STAT-156 add access event for Jupyter connector

### DIFF
--- a/cas/src/main/java/org/entcore/cas/services/JupyterRegisteredService.java
+++ b/cas/src/main/java/org/entcore/cas/services/JupyterRegisteredService.java
@@ -1,0 +1,29 @@
+package org.entcore.cas.services;
+
+import fr.wseduc.cas.entities.User;
+import io.vertx.core.json.JsonObject;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import java.util.List;
+
+
+public class JupyterRegisteredService extends AbstractCas20ExtensionRegisteredService {
+
+    protected static final String UID = "uid";
+
+    @Override
+    protected void prepareUserCas20(User user, String userId, String service, JsonObject data, Document doc, List<Element> additionnalAttributes) {
+        user.setUser(data.getString(principalAttributeName));
+
+        try {
+            if (data.containsKey("externalId")) {
+                additionnalAttributes.add(createTextElement(UID, data.getString("externalId"), doc));
+            }
+        } catch (Exception e) {
+            log.error("JupyterConnector@Failed to transform User for JupyterRegistered service" + e.getMessage());
+        }
+    }
+
+
+}


### PR DESCRIPTION
# Description

added an access event for the Jupyter connector. The aim is to be able to report Jupyter connector access statistics in the "Statistics" module.

data example :

```
db.getCollection('events').find({'event-type': 'ACCESS', 'connector-type': 'Cas'})

...
 "connector-type" : "Cas",
 "event-type" : "ACCESS",
 "module" : "JupyterRegisteredService",
 "date" : NumberLong(1702636429991),
 "userId" : "uuid",
 "profil" : "Personnel",
```

## Fixes

[STAT-156](https://jira.support-ent.fr/browse/STAT-156)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [x] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests
[DOC](https://confluence.support-ent.fr/pages/viewpage.action?pageId=54724067#FonctionTransverse:R%C3%A9ponseCAS-Enlocal)

Create a Connector with a simple url like https://google.com or https://github.com

In "Champs spécifiques CAS" click on the green "+" and in "Type" enter the name of your CAS response

Then in Postman you can test the requests by following the documentation.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: