### PR TITLE
[EDIFICE] #Wb2-1367: ajout d'un retry pour reindexer les ressources après import

### DIFF
--- a/common/src/main/java/org/entcore/common/explorer/IExplorerPluginClient.java
+++ b/common/src/main/java/org/entcore/common/explorer/IExplorerPluginClient.java
@@ -35,6 +35,16 @@ public interface IExplorerPluginClient {
         return reindex(null, request);
     }
 
+    /**
+     * Try reindexing resources multiple times until it succeed
+     * @param user User requesting the reindexation
+     * @param request Filter for the resources to reindex
+     * @param times Number of times we should try
+     * @param delay Delay (in ms) between each tentatives
+     * @return A swift report of the indexation process
+     */
+    Future<IndexResponse> tryReindex(UserInfos user, ExplorerReindexResourcesRequest request, int times, int delay);
+
     Future<List<String>> createAll(UserInfos user, List<JsonObject> json, boolean isCopy);
 
     Future<DeleteResponse> deleteById(UserInfos user, Set<String> ids);

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPluginClient.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPluginClient.java
@@ -1,7 +1,10 @@
 package org.entcore.common.explorer.impl;
 
+import fr.wseduc.webutils.DefaultAsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
@@ -19,12 +22,49 @@ import java.util.stream.Collectors;
 
 public abstract class ExplorerPluginClient implements IExplorerPluginClient {
     static final Logger log = LoggerFactory.getLogger(ExplorerPluginClient.class);
+    private final Vertx vert;
+
+    public ExplorerPluginClient(final Vertx vert) {
+        this.vert = vert;
+    }
+
+    private void tryReindexRecursively(final Promise<IndexResponse> promise, final UserInfos userInfos, final ExplorerReindexResourcesRequest request, final int times, final int delay) {
+        // trigger reindex
+        this.reindex(userInfos, request).onComplete((reindexResponse) -> {
+            // if reindex failed or reindex does not found any messsage (replication lag) => retry later
+            if (reindexResponse.failed() || reindexResponse.succeeded() && reindexResponse.result().nbMessage == 0) {
+                // decrease counter
+                final int newTimes = times - 1;
+                // check wether we reached limit of retry
+                if (newTimes <= 0) {
+                    // finished
+                    promise.handle(reindexResponse);
+                    return;
+                }else{
+                    // retry later
+                    this.vert.setTimer(delay, (time) -> {
+                        this.tryReindexRecursively(promise, userInfos, request, newTimes, delay);
+                    });
+                }
+            } else {
+                // if reindex succeed => trigger response
+                promise.handle(reindexResponse);
+            }
+        });
+    }
 
     @Override
-    public Future<IndexResponse> reindex(final UserInfos user, final ExplorerReindexResourcesRequest request){
+    public Future<IndexResponse> tryReindex(final UserInfos user, final ExplorerReindexResourcesRequest request, final int times, final int delay) {
+        final Promise<IndexResponse> promise = Promise.promise();
+        this.tryReindexRecursively(promise, user, request, times, delay);
+        return promise.future();
+    }
+
+    @Override
+    public Future<IndexResponse> reindex(final UserInfos user, final ExplorerReindexResourcesRequest request) {
         final MultiMap headers = MultiMap.caseInsensitiveMultiMap();
         headers.add("action", ExplorerPlugin.ExplorerRemoteAction.QueryReindex.name());
-        if(user != null) {
+        if (user != null) {
             if (user.getUserId() != null) {
                 headers.add("userId", user.getUserId());
             }
@@ -34,19 +74,19 @@ public abstract class ExplorerPluginClient implements IExplorerPluginClient {
         }
         final Future<JsonObject> future = send(headers, JsonObject.mapFrom(request), Duration.ofDays(100));
         log.info("Trigger indexation " + request);
-        return future.map(res->{
+        return future.map(res -> {
             log.info(String.format("End trigger indexation " + res));
             final ExplorerReindexResourcesResponse response = res.mapTo(ExplorerReindexResourcesResponse.class);
             final int nb_message = response.getNbMessages();
             final int nb_batch = response.getNbBatch();
             return new IndexResponse(nb_batch, nb_message);
-        }).onFailure(e->{
-            log.error("Trigger indexation failed. request="+request.toString(), e);
+        }).onFailure(e -> {
+            log.error("Trigger indexation failed. request=" + request.toString(), e);
         });
     }
 
     @Override
-    public Future<List<String>> createAll(final UserInfos user, final List<JsonObject> json, final boolean isCopy){
+    public Future<List<String>> createAll(final UserInfos user, final List<JsonObject> json, final boolean isCopy) {
         final MultiMap headers = MultiMap.caseInsensitiveMultiMap();
         headers.add("action", ExplorerPlugin.ExplorerRemoteAction.QueryCreate.name());
         headers.add("userId", user.getUserId());
@@ -55,13 +95,13 @@ public abstract class ExplorerPluginClient implements IExplorerPluginClient {
         payload.put("resources", json);
         payload.put("copy", isCopy);
         final Future<JsonArray> future = send(headers, payload, Duration.ofMinutes(10));
-        return future.map(jsonarray->{
-            return jsonarray.stream().map(id-> (String)id).collect(Collectors.toList());
+        return future.map(jsonarray -> {
+            return jsonarray.stream().map(id -> (String) id).collect(Collectors.toList());
         });
     }
 
     @Override
-    public Future<DeleteResponse> deleteById(final UserInfos user, final Set<String> ids){
+    public Future<DeleteResponse> deleteById(final UserInfos user, final Set<String> ids) {
         final MultiMap headers = MultiMap.caseInsensitiveMultiMap();
         headers.add("action", ExplorerPlugin.ExplorerRemoteAction.QueryDelete.name());
         headers.add("userId", user.getUserId());
@@ -70,9 +110,9 @@ public abstract class ExplorerPluginClient implements IExplorerPluginClient {
         payload.put("resources", new JsonArray(new ArrayList(ids)));
         final Future<JsonObject> future = send(headers, payload, Duration.ofMinutes(5));
         //deleted, failed
-        return future.map(res->{
-            final List<String> deleted = res.getJsonArray("deleted").stream().map(id-> (String)id).collect(Collectors.toList());
-            final List<String> failed = res.getJsonArray("failed").stream().map(id-> (String)id).collect(Collectors.toList());
+        return future.map(res -> {
+            final List<String> deleted = res.getJsonArray("deleted").stream().map(id -> (String) id).collect(Collectors.toList());
+            final List<String> failed = res.getJsonArray("failed").stream().map(id -> (String) id).collect(Collectors.toList());
             final DeleteResponse delRes = new DeleteResponse();
             delRes.deleted.addAll(deleted);
             delRes.notDeleted.addAll(failed);
@@ -81,7 +121,7 @@ public abstract class ExplorerPluginClient implements IExplorerPluginClient {
     }
 
     @Override
-    public Future<ShareResponse> shareByIds(final UserInfos user, final Set<String> ids, final JsonObject shares){
+    public Future<ShareResponse> shareByIds(final UserInfos user, final Set<String> ids, final JsonObject shares) {
         final MultiMap headers = MultiMap.caseInsensitiveMultiMap();
         headers.add("action", ExplorerPlugin.ExplorerRemoteAction.QueryShare.name());
         headers.add("userId", user.getUserId());
@@ -90,7 +130,7 @@ public abstract class ExplorerPluginClient implements IExplorerPluginClient {
         payload.put("resources", new JsonArray(new ArrayList(ids)));
         payload.put("shares", shares);
         final Future<JsonObject> future = send(headers, payload, Duration.ofMinutes(5));
-        return future.map(res->{
+        return future.map(res -> {
             final int nbShared = res.getInteger("nbShared", 0);
             final JsonObject notifyTimelineMap = res.getJsonObject("notifyTimelineMap", new JsonObject());
             final ShareResponse sres = new ShareResponse(nbShared, notifyTimelineMap);
@@ -99,7 +139,7 @@ public abstract class ExplorerPluginClient implements IExplorerPluginClient {
     }
 
     @Override
-    public Future<JsonObject> getMetrics(final UserInfos user){
+    public Future<JsonObject> getMetrics(final UserInfos user) {
         final MultiMap headers = MultiMap.caseInsensitiveMultiMap();
         headers.add("action", ExplorerPlugin.ExplorerRemoteAction.QueryMetrics.name());
         headers.add("userId", user.getUserId());
@@ -109,6 +149,7 @@ public abstract class ExplorerPluginClient implements IExplorerPluginClient {
     }
 
     abstract protected <T> Future<T> send(final MultiMap headers, final JsonObject payload, final Duration timeout);
+
     abstract protected <T> Future<T> send(final MultiMap headers, final Object payload, Class<T> responseType, final Duration timeout);
 
 

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPluginClientDefault.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerPluginClientDefault.java
@@ -18,12 +18,14 @@ public class ExplorerPluginClientDefault extends ExplorerPluginClient {
     private final Optional<String> resourceType;
 
     public ExplorerPluginClientDefault(final Vertx vertx, final String application) {
+        super(vertx);
         this.vertx = vertx;
         this.application = application;
         this.resourceType = Optional.empty();
     }
 
     public ExplorerPluginClientDefault(final Vertx vertx, final String application, final String resourceType) {
+        super(vertx);
         this.vertx = vertx;
         this.application = application;
         this.resourceType = Optional.ofNullable(resourceType);

--- a/common/src/main/java/org/entcore/common/explorer/impl/ExplorerRepositoryEvents.java
+++ b/common/src/main/java/org/entcore/common/explorer/impl/ExplorerRepositoryEvents.java
@@ -22,6 +22,7 @@ import fr.wseduc.webutils.DefaultAsyncResult;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
@@ -39,7 +40,8 @@ import java.util.stream.Collectors;
  * Any app using BaseServer.setRepositoryEvents() and the explorer feature should use it.
  */
 public class ExplorerRepositoryEvents implements RepositoryEvents {
-
+    private static final int RETRY_TIMES = 5;
+    private static final int RETRY_DELAY = 1000;
     private static final Logger log = LoggerFactory.getLogger(ExplorerRepositoryEvents.class);
 
     /**
@@ -171,7 +173,7 @@ public class ExplorerRepositoryEvents implements RepositoryEvents {
                         userInfos.setUserId(userId);
                         userInfos.setLogin(userLogin);
                         userInfos.setFirstName(userName);
-                        pluginClient.reindex(userInfos, new ExplorerReindexResourcesRequest(idsToReindex)).onComplete(this.onReindex);
+                        pluginClient.tryReindex(userInfos, new ExplorerReindexResourcesRequest(idsToReindex), RETRY_TIMES, RETRY_DELAY).onComplete(this.onReindex);
                     }
                 });
             } else {


### PR DESCRIPTION
# Description

Lorsque le temps de latence sur les replica mongodb est non négligeable, la réindexation après import échoue
Cette petite évo ajoute un mécanisme de retentative de la réindexation tant que celle ci échoue

## Fixes

#Wb2-1367:

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ X] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Testé sur une plateforme HA:
- import sur blog
- import sur mindmap

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ X] All done ! :smiley: