### PR TITLE
fix: #WB2-1173, make archive purge more reliable

### DIFF
--- a/archive/src/main/java/org/entcore/archive/Archive.java
+++ b/archive/src/main/java/org/entcore/archive/Archive.java
@@ -87,7 +87,10 @@ public class Archive extends BaseServer {
 								new StorageFactory(vertx, config).getStorage(),
 								config.getInteger("deleteDelay", 24),
 								exportPath,
-								importService
+								importService,
+								importPath,
+								config.getBoolean("enablePurgeByFileAge", true),
+								config.getInteger("maxFileAge", 24)
 						));
 			} catch (ParseException e) {
 				log.error("Invalid cron expression.", e);

--- a/archive/src/main/java/org/entcore/archive/services/impl/DeleteOldArchives.java
+++ b/archive/src/main/java/org/entcore/archive/services/impl/DeleteOldArchives.java
@@ -21,99 +21,141 @@ package org.entcore.archive.services.impl;
 
 
 import fr.wseduc.mongodb.MongoDb;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Vertx;
+import io.vertx.core.*;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.entcore.archive.Archive;
 import org.entcore.archive.services.ImportService;
 import org.entcore.common.storage.Storage;
-import io.vertx.core.Handler;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.entcore.common.utils.StringUtils;
 
 import java.io.File;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 
 public class DeleteOldArchives implements Handler<Long> {
 
-	private final MongoDb mongo = MongoDb.getInstance();
-	private final Vertx vertx;
-	private final Storage storage;
-	private final int delay;
-	private ImportService importService;
-	private String exportPath;
+    private final MongoDb mongo = MongoDb.getInstance();
+    private final Vertx vertx;
+    private final Storage storage;
+    private final int delay;
+    private ImportService importService;
+    private String exportPath;
+    private final String importPath;
+    private final int maxFileAge;
+    private final boolean enablePurgeByFileAge;
 
-	private static final Logger log = LoggerFactory.getLogger(DeleteOldArchives.class);
+    private static final Logger log = LoggerFactory.getLogger(DeleteOldArchives.class);
 
 
-	public DeleteOldArchives(Vertx vertx, Storage storage, int delay, String exportPath, ImportService importService) {
-		this.storage = storage;
-		this.vertx = vertx;
-		this.delay = delay;
-		this.importService = importService;
-		this.exportPath = exportPath;
-	}
+    public DeleteOldArchives(Vertx vertx, Storage storage, int delay, String exportPath, ImportService importService, final String importPath, final boolean enablePurgeByFileAge, final int maxFileAge) {
+        this.storage = storage;
+        this.vertx = vertx;
+        this.delay = delay;
+        this.importService = importService;
+        this.exportPath = exportPath;
+        this.importPath = importPath;
+        this.maxFileAge = maxFileAge;
+        this.enablePurgeByFileAge = enablePurgeByFileAge;
+    }
 
-	@Override
-	public void handle(Long event) {
-		Calendar c = Calendar.getInstance();
-		c.setTime(new Date());
-		c.add(Calendar.HOUR, - delay);
-		final JsonObject query = new JsonObject()
-				.put("date", new JsonObject()
-						.put("$lt", new JsonObject()
-								.put("$date", c.getTime().getTime())));
-		mongo.find(Archive.ARCHIVES, query, new Handler<Message<JsonObject>>() {
-			@Override
-			public void handle(Message<JsonObject> event) {
-				JsonArray res = event.body().getJsonArray("results");
-				if ("ok".equals(event.body().getString("status")) && res != null && res.size() > 0) {
-					JsonArray ids = new fr.wseduc.webutils.collections.JsonArray();
-					for (Object object: res) {
-						if (!(object instanceof JsonObject)) continue;
-						JsonObject jo = (JsonObject) object;
-						if (jo.containsKey("file_id")) {
-							final String exportId = jo.getString("file_id");
-							ids.add(exportId);
-							if (!StringUtils.isEmpty(exportId) && !StringUtils.isEmpty(exportPath) &&
-									exportId.matches("[0-9]+_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")) {
-								final String path = exportPath + File.separator + exportId;
-								vertx.fileSystem().deleteRecursive(path, true, new Handler<AsyncResult<Void>>() {
-									@Override
-									public void handle(AsyncResult<Void> event) {
-										if (event.failed()) {
-											log.error("Error deleting directory : " + path, event.cause());
-										}
-									}
-								});
-								final String zipPath = path + ".zip";
-								vertx.fileSystem().delete(zipPath, new Handler<AsyncResult<Void>>() {
-									@Override
-									public void handle(AsyncResult<Void> event) {
-										if (event.failed()) {
-											log.error("Error deleting temp zip export " + zipPath, event.cause());
-										}
-									}
-								});
-							}
+    @Override
+    public void handle(Long event) {
+        log.info("[cron][purge] Starting...");
+        this.purgeArchive().onComplete(e -> {
+            if (this.enablePurgeByFileAge) {
+                CompositeFuture.all(this.purgeFileByAge(this.importPath), this.purgeFileByAge(this.exportPath)).onComplete(onFinish -> {
+                    log.info("[cron][purge] Finished");
+                });
+            } else {
+                log.info("[cron][purge] Purge by file age is disabled");
+            }
+        });
+    }
 
-						} else if (jo.containsKey("import_id")) {
-							importService.deleteArchive(jo.getString("import_id"));
-						}
-					}
-					storage.removeFiles(ids, new Handler<JsonObject>() {
-						@Override
-						public void handle(JsonObject event) {
-							mongo.delete(Archive.ARCHIVES, query);
-						}
-					});
-				}
-			}
-		});
-	}
+    public Future<Void> purgeArchive() {
+        final Promise promise = Promise.promise();
+        Calendar c = Calendar.getInstance();
+        c.setTime(new Date());
+        c.add(Calendar.HOUR, -delay);
+        final JsonObject query = new JsonObject()
+                .put("date", new JsonObject()
+                        .put("$lt", new JsonObject()
+                                .put("$date", c.getTime().getTime())));
+        mongo.find(Archive.ARCHIVES, query, event -> {
+            JsonArray res = event.body().getJsonArray("results");
+            if ("ok".equals(event.body().getString("status"))) {
+                if (res != null && res.size() > 0) {
+                    JsonArray ids = new fr.wseduc.webutils.collections.JsonArray();
+                    for (Object object : res) {
+                        if (!(object instanceof JsonObject)) continue;
+                        JsonObject jo = (JsonObject) object;
+                        if (jo.containsKey("file_id")) {
+                            final String exportId = jo.getString("file_id");
+                            ids.add(exportId);
+                            if (!StringUtils.isEmpty(exportId) && !StringUtils.isEmpty(exportPath) &&
+                                    exportId.matches("[0-9]+_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")) {
+                                final String path = exportPath + File.separator + exportId;
+                                vertx.fileSystem().deleteRecursive(path, true, delEvent -> {
+                                    if (delEvent.failed()) {
+                                        log.error("Error deleting directory : " + path, delEvent.cause());
+                                    }
+                                });
+                                final String zipPath = path + ".zip";
+                                vertx.fileSystem().delete(zipPath, delEvent -> {
+                                    if (delEvent.failed()) {
+                                        log.error("Error deleting temp zip export " + zipPath, delEvent.cause());
+                                    }
+
+                                });
+                            }
+
+                        } else if (jo.containsKey("import_id")) {
+                            importService.deleteArchive(jo.getString("import_id"));
+                        }
+                    }
+                    log.info("[cron][purge] Removing files. numberOfFiles=" + ids.size());
+                    storage.removeFiles(ids, removeEvent -> {
+                        mongo.delete(Archive.ARCHIVES, query);
+                        promise.complete();
+                    });
+                } else {
+                    log.info("[cron][purge] Nothing to delete.");
+                    promise.complete();
+                }
+            } else {
+                final String error = event.body().getString("message");
+                log.info("[cron][purge] Failed to fetch: " + error);
+                promise.fail(error);
+            }
+        });
+        return promise.future();
+    }
+
+    private Future<Void> purgeFileByAge(final String path) {
+        log.info("[cron][purge] Starting deleting file from path=" + path + " having age (hours) >" + this.delay);
+        final Date minDate = Date.from(Instant.now().minus(this.maxFileAge, ChronoUnit.HOURS));
+        return this.storage.deleteByFilter(path, (info) -> {
+            final boolean shouldDelete = info.props.lastModifiedTime() < minDate.getTime();
+            if (shouldDelete) {
+                log.info("[cron][purge] deleting file=" + info.path);
+            }
+            return shouldDelete;
+        }).onComplete(e -> {
+            if (e.succeeded()) {
+                final long numberDelete = e.result().stream().filter(file -> file.deleted).count();
+                final long numberChecked = e.result().size();
+                log.info("[cron][purge] Finished purge on path=" + path + " numberOfFileDeleted=" + numberDelete + " numberOfFileChecked=" + numberChecked);
+            } else {
+                log.error("[cron][purge] Failed with error on path=" + path, e.cause());
+            }
+        }).mapEmpty();
+    }
 
 }

--- a/common/src/main/java/org/entcore/common/storage/Storage.java
+++ b/common/src/main/java/org/entcore/common/storage/Storage.java
@@ -23,12 +23,16 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.file.FileProps;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.streams.ReadStream;
 import org.entcore.common.messaging.to.UploadedFileMessage;
 import org.entcore.common.validation.FileValidator;
+
+import java.util.List;
+import java.util.function.Function;
 
 public interface Storage {
 
@@ -125,4 +129,26 @@ public interface Storage {
 	 * @return The raw content of the file
 	 */
     Future<byte[]> readFileToMemory(UploadedFileMessage uploadedFileMessage);
+
+	/**
+	 * Delete all children matching filter
+	 * @param parent directory
+	 * @param filter returning true if child should be deleted
+	 * @return list of deleted file
+	 */
+	default Future<List<FileInfo>> deleteByFilter(final String parent, final Function<FileInfo, Boolean> filter) {
+		throw new UnsupportedOperationException("Not supported yet");
+	}
+
+	class FileInfo{
+		public final String path;
+		public final FileProps props;
+		public final boolean deleted;
+
+		public FileInfo(String path, FileProps props, boolean deleted) {
+			this.path = path;
+			this.props = props;
+			this.deleted = deleted;
+		}
+	}
 }


### PR DESCRIPTION
# Description

Ce fix vient renforcer la purge existante sur le module archive en ajoutant une tâche qui vient supprimer tout les fichiers et dossiers dans l'âge de modification dépasse X heures.
Pour cela une config a été ajouté:
- enablePurgeByFileAge (true par défaut) qui active ou non cette nouvelle tâche
- maxFileAge (défaut à 24) le nombre d'heure max de durée d'un fichier ou dossier

## Fixes

#WB2-1173

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [X ] archive
- [ ] auth
- [ ] cas
- [X ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Testé sur une plateforme de recette en
- créant un fichier avec une fausse date de modif dépassant l'age => il est supprimé
- créant un fichier avec une fausse date de modif ne dépassant pas l'age => il est conservé

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ X] All done ! :smiley: