### PR TITLE
fix(conversation): COCO-4223, move message to a newly created folder

### DIFF
--- a/conversation/frontend/src/routes/root/index.tsx
+++ b/conversation/frontend/src/routes/root/index.tsx
@@ -125,7 +125,9 @@ export function Component() {
           </div>
         )}
 
-        {openedModal === 'create' && <CreateFolderModal />}
+        {(openedModal === 'create' || openedModal === 'create-then-move') && (
+          <CreateFolderModal />
+        )}
         {openedModal === 'rename' && <RenameFolderModal />}
         {openedModal === 'trash' && <TrashFolderModal />}
         {openedModal === 'move-message' && <MoveMessageToFolderModal />}

--- a/conversation/frontend/src/store/actions.ts
+++ b/conversation/frontend/src/store/actions.ts
@@ -5,6 +5,7 @@ import { Folder } from '~/models';
 type OpenedModal =
   | undefined
   | 'create'
+  | 'create-then-move'
   | 'move'
   | 'rename'
   | 'trash'


### PR DESCRIPTION
# Description

Permet de déplacer un message dans un dossier nouvellement créé, via l'enchainement de 2 modales.
Avec auto-sélection du dossier nouvellement créé.

+ refacto de code pour respecter l'ordre des hooks préconisé (les useEffect en dernier, suivi des handlers...)

## Fixes

https://edifice-community.atlassian.net/browse/COCO-4223

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [X] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: