### PR TITLE
Fix coco 4314 only some user are autolink in broadcastgroup

### DIFF
--- a/feeder/src/main/java/org/entcore/feeder/dictionary/structures/Group.java
+++ b/feeder/src/main/java/org/entcore/feeder/dictionary/structures/Group.java
@@ -198,33 +198,33 @@ public class Group {
 		log.info("tx groupLinkRules with groupId : " + groupId);
 		final StringBuilder linkQuery = new StringBuilder(
 				"MATCH (g:ManualGroup {id: {groupId}})-[:DEPENDS]->(:Structure)<-[:HAS_ATTACHMENT*0..]-(struct:Structure) " +
-						"WHERE EXISTS(g.autolinkUsersFromGroups) OR EXISTS(g.autolinkUsersFromPositions) "+
-						"WITH g, struct " +
-						"MATCH (u:User)-[:IN]->(target:Group)-[:DEPENDS]->(struct) " +
-						"OPTIONAL MATCH (u)-[:HAS_POSITION]->(position:UserPosition) " +
-						"WITH g, struct, u, target, position " +
-						"WHERE " +
-						// filter by type of auto link
-						" (" +
-						"    size(COALESCE(g.autolinkUsersFromPositions, [])) = 0 AND " +
-						"    (g.autolinkTargetAllStructs = true OR struct.id IN g.autolinkTargetStructs) AND " +
-						"    target.filter IN g.autolinkUsersFromGroups " +
-						"  )" +
-						"  OR " +
-						"  (" +
-						"    size(COALESCE(g.autolinkUsersFromPositions, [])) > 0 AND " +
-						"    position IS NOT NULL AND " +
-						"    position.name IN COALESCE(g.autolinkUsersFromPositions, []) " +
-						"  )" +
-						// update the timestamp to remove old user
-						"WITH g, u " );
+				"WHERE EXISTS(g.autolinkUsersFromGroups) OR EXISTS(g.autolinkUsersFromPositions) "+
+				"WITH g, struct " +
+				"MATCH (u:User)-[:IN]->(target:Group)-[:DEPENDS]->(struct) " +
+				"OPTIONAL MATCH (u)-[:HAS_POSITION]->(position:UserPosition) " +
+				"WITH g, struct, u, target, position " +
+				"WHERE " +
+				// filter by type of auto link
+				" (" +
+				"    size(COALESCE(g.autolinkUsersFromPositions, [])) = 0 AND " +
+				"    (g.autolinkTargetAllStructs = true OR struct.id IN g.autolinkTargetStructs) AND " +
+				"    target.filter IN g.autolinkUsersFromGroups " +
+				"  )" +
+				"  OR " +
+				"  (" +
+				"    size(COALESCE(g.autolinkUsersFromPositions, [])) > 0 AND " +
+				"    position IS NOT NULL AND " +
+				"    position.name IN COALESCE(g.autolinkUsersFromPositions, []) " +
+				"  )" +
+				// update the timestamp to remove old user
+				"WITH g, u " );
 		// Conditional filter on children or students level
 		if (autolinkUsersFromLevel != null && !autolinkUsersFromLevel.isEmpty()) {
 			if (autolinkUsersFromGroups.contains("Relative")) {
 				linkQuery.append(
 						"MATCH (u)<-[:RELATED]-(child:User) " +
-								"WHERE child.level IN COALESCE(g.autolinkUsersFromLevels,[]) " +
-								"WITH g, u ");
+						"WHERE child.level IN COALESCE(g.autolinkUsersFromLevels,[]) " +
+						"WITH g, u ");
 			} else if (autolinkUsersFromGroups.contains("Student")) {
 				linkQuery.append(
 						"WHERE u.level IN COALESCE(g.autolinkUsersFromLevels,[]) " +
@@ -233,14 +233,14 @@ public class Group {
 		}
 		linkQuery.append(
 				"MERGE (u)-[new:IN]->(g) " +
-						"ON CREATE SET new.source = 'AUTO' " +
-						"SET new.updated = {now} ");
+				"ON CREATE SET new.source = 'AUTO' " +
+				"SET new.updated = {now} ");
 
 		final String removeQuery =
 				"MATCH (g:ManualGroup {id: {groupId}})<-[old:IN]-(:User) " +
-						"WHERE (EXISTS(g.autolinkUsersFromGroups) OR EXISTS(g.autolinkUsersFromPositions))" +
-						" AND old.source = 'AUTO' AND (NOT EXISTS(old.updated) OR old.updated <> {now}) " +
-						"DELETE old ";
+				"WHERE (EXISTS(g.autolinkUsersFromGroups) OR EXISTS(g.autolinkUsersFromPositions))" +
+				" AND old.source = 'AUTO' AND (NOT EXISTS(old.updated) OR old.updated <> {now}) " +
+				"DELETE old ";
 
 
 		final JsonObject params = new JsonObject()


### PR DESCRIPTION
# Description

In production we have this issue: https://edifice-community.atlassian.net/browse/COCO-4314%7C*COCO-4314
Only a few users are autolink after AAF in their broadcast group. This is due to the query that select users for broadcast group that impose users to have a UserPosition (function)

## Fixes

https://edifice-community.atlassian.net/browse/COCO-4314%7C*COCO-4314

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [x] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

- Create a broadcastgroup on the teachers of all structure of a head structure
- Launch the import or the the broadcast group link process
- All teachers must be in the group


- Create a broadcastgroup on a Function (UserPositions) of all structure of a head structure
- Launch the import or the the broadcast group link process
- All users with this function must be in the broadcast group

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: