### PR TITLE
Fix coco 4308 fix id returned with path

### DIFF
--- a/common/src/main/java/org/entcore/common/s3/S3Client.java
+++ b/common/src/main/java/org/entcore/common/s3/S3Client.java
@@ -523,7 +523,7 @@ public class S3Client {
 			})
 			.onSuccess(response -> {
 				if (response.statusCode() == 200) {
-					handler.handle(new DefaultAsyncResult<>(id));
+					handler.handle(new DefaultAsyncResult<>(getUuid(id)));
 				} else {
 					handler.handle(new DefaultAsyncResult<>(new StorageException(response.statusMessage())));
 				}
@@ -876,7 +876,7 @@ public class S3Client {
 				List<String> matchingObjects = new ArrayList<>();
 				for(String objectId: results.result()) {
 					if (objectId.endsWith(endsWith)) {
-						matchingObjects.add(objectId);
+						matchingObjects.add(getUuid(objectId));
 					}
 				}
 
@@ -884,7 +884,6 @@ public class S3Client {
 			}
 			else {
 				handler.handle(results);
-				return;
 			}
 		});
 	}
@@ -919,6 +918,16 @@ public class S3Client {
 		}
 
 		return path;
+	}
+
+	public static String getUuid(final String path) {
+		final String separator = "/";
+		if (path.contains(separator)) {
+			return path.substring(path.lastIndexOf(separator));
+		}
+		else {
+			return path;
+		}
 	}
 
 }


### PR DESCRIPTION
# Description

The object ID is returned with a path prefix in the format xx/xx/uuid.
The path prefix is derived from the last 4 characters of the UUID.
In PostgreSQL, the corresponding field is sometimes stored as a VARCHAR(37).
Only the UUID portion should be returned in the response. If needed, the full path can be reconstructed from the UUID.

## Fixes

[#COCO-4308](https://edifice-community.atlassian.net/browse/COCO-4308) et [#COCO-4310](https://edifice-community.atlassian.net/browse/COCO-4310)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: