### PR TITLE
fix-(conversation,bookmark): #COCO-3996 add alert when using a bookmark that contain not visible users

### DIFF
--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultShareBookmarkService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultShareBookmarkService.java
@@ -29,12 +29,8 @@ import io.vertx.core.logging.LoggerFactory;
 import org.entcore.common.neo4j.Neo4j;
 import org.entcore.directory.services.ShareBookmarkService;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
-import java.util.UUID;
 
 import static fr.wseduc.webutils.Utils.getOrElse;
 
@@ -142,10 +138,13 @@ public class DefaultShareBookmarkService implements ShareBookmarkService {
 					.map(jo -> jo.getString("id"))
 					.collect(Collectors.toList());
 				// Keep only visible users, in the *membersMap*
+				//eliminate himself from the memebers to check
+				int initialCount = membersMapIds.size() - (membersMapIds.contains(userId) ? 1 : 0);
 				membersMapIds.retainAll(visibleIds);
 				// Update members array
 				members.clear();
 				membersMap.values().stream().forEach( member -> members.add(member) );
+				res.put("notVisibleCount", initialCount - members.size());
 			})
 			.onComplete( ar -> {
 				// Filtered or not, handle the results anyway.


### PR DESCRIPTION
# Description

Ajout sur le endpoint de récupération d'un favori (/conversation/bookmark/:ID) d'un champ en réponse donnant le nombre d'utilisateur/groupe plus vsible dans le favori afin de prevenir l'utilisateur.

## Fixes

https://edifice-community.atlassian.net/browse/COCO-3996

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [x] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: