### PR TITLE
fix: #PEDAGO-3100, add visible search mode to exclude family members from results

### DIFF
--- a/communication/src/main/java/org/entcore/communication/controllers/CommunicationController.java
+++ b/communication/src/main/java/org/entcore/communication/controllers/CommunicationController.java
@@ -943,7 +943,8 @@ public class CommunicationController extends BaseController {
 		UserUtils.getAuthenticatedUserInfos(eb, request)
 		.onSuccess(userInfos -> {
 			final String query = request.params().get("query");
-			communicationService.searchVisibles(userInfos, query, I18n.acceptLanguage(request))
+			final String mode = request.params().get("mode");
+			communicationService.searchVisibles(userInfos, query, mode, I18n.acceptLanguage(request))
 				.onSuccess(visibles -> renderJson(request, visibles))
 				.onFailure(th -> renderError(request, new JsonObject().put("error", th.getMessage())));
 		});

--- a/communication/src/main/java/org/entcore/communication/services/CommunicationService.java
+++ b/communication/src/main/java/org/entcore/communication/services/CommunicationService.java
@@ -177,7 +177,7 @@ public interface CommunicationService {
 	 * @param search Keyword to filter the search results
 	 * @param language User's language
 	 */
-	Future<JsonArray> searchVisibles(UserInfos user, String search, String language);
+	Future<JsonArray> searchVisibles(UserInfos user, String search, String mode, String language);
 
 }
 


### PR DESCRIPTION
# Description

The API `GET /communication/visible/search` returns search results with relatives and children but for some apps like Communities we do not want family members in the results so I added a query param mode to retrieve results without family

## Fixes

(Enter here Jira or Redmine ticket(s) links)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: