### PR TITLE
feat: #pedago-3101, expose group labels to improve share ui modal

### DIFF
--- a/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
+++ b/common/src/main/java/org/entcore/common/share/impl/GenericShareService.java
@@ -57,8 +57,10 @@ import static org.entcore.common.validation.StringValidation.cleanId;
 public abstract class GenericShareService implements ShareService {
 
 	protected static final Logger log = LoggerFactory.getLogger(GenericShareService.class);
+	// Query to retrieve shared groups with their labels (including CommunityGroup labels)
 	private static final String GROUP_SHARED = "MATCH (g:Group) WHERE g.id in {groupIds} "
-			+ "RETURN distinct g.id as id, g.name as name, g.groupDisplayName as groupDisplayName, g.structureName as structureName "
+			+ "RETURN distinct g.id as id, g.name as name, g.groupDisplayName as groupDisplayName, g.structureName as structureName, "
+			+ "labels(g) as labels "
 			+ "ORDER BY name ";
 	private static final String USER_SHARED = "MATCH (u:User) WHERE u.id in {userIds} "
 			+ "RETURN distinct u.id as id, u.login as login, u.displayName as username, "
@@ -251,8 +253,11 @@ public abstract class GenericShareService implements ShareService {
 				}));
 			}));
 		} else {
+			// Complex query that combines visible profile groups and explicitly shared groups
+			// The UNION allows getting both types of groups with their labels for proper display
 			final String groupQuery = "RETURN distinct profileGroup.id as id, profileGroup.name as name, "
-					+ "profileGroup.groupDisplayName as groupDisplayName, profileGroup.structureName as structureName "
+					+ "profileGroup.groupDisplayName as groupDisplayName, profileGroup.structureName as structureName, "
+					+ "labels(profileGroup) as labels "
 					+ "ORDER BY name " + "UNION " + GROUP_SHARED;
 
 			final String userQuery = "RETURN distinct visibles.id as id, visibles.login as login, visibles.displayName as username, "


### PR DESCRIPTION
# Description
Cette évo expose les labels des groupes dans l'api de récupération des partages pour permettre à la modale de gérer le cas des groupes de communauté:
- dans un premier temps ils seront désactivé dans la modale
- dans un second temps ils auront leur propre onglet

## Fixes

#pedago-3101

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [X] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: