### PR TITLE
fix: #PEDAGO-3292, manage i18n overrides

### DIFF
--- a/portal/backend/src/main/java/org/entcore/portal/Portal.java
+++ b/portal/backend/src/main/java/org/entcore/portal/Portal.java
@@ -20,6 +20,7 @@
 package org.entcore.portal;
 
 import io.vertx.core.Promise;
+import java.io.File;
 import org.entcore.broker.api.utils.AddressParameter;
 import org.entcore.broker.api.utils.BrokerProxyUtils;
 import org.entcore.common.cache.CacheService;
@@ -33,7 +34,7 @@ public class Portal extends BaseServer {
 	@Override
 	public void start(final Promise<Void> startPromise) throws Exception {
 		super.start(startPromise);
-		final String assetPath = config.getString("assets-path", "../..");
+		final String assetPath = config.getString("assets-path", "../..")+ File.separator + "assets";
 		final AddressParameter parameter = new AddressParameter("application", "portal");
 		final CacheService cacheService = CacheService.create(vertx);
 		BrokerProxyUtils.addBrokerProxy(new I18nBrokerListenerImpl(vertx, assetPath, cacheService), vertx, parameter);


### PR DESCRIPTION
# Description

Ce fix permet de corriger la gestion des overrides i18n provenant de thèmes et du module traduction (phrase)

## Fixes

#PEDAGO-3292

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [X] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: