### PR TITLE
#COCO-5328 - Plages silencieuses #1

### DIFF
--- a/common/src/main/java/org/entcore/common/user/dto/Preference.java
+++ b/common/src/main/java/org/entcore/common/user/dto/Preference.java
@@ -1,5 +1,6 @@
 package org.entcore.common.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.vertx.core.json.Json;
 
 public interface Preference {
@@ -9,6 +10,7 @@ public interface Preference {
     }
 
     /** Returns true if the preference data is valid and can be persisted. */
+    @JsonIgnore
     default boolean validate() {
         return true;
     }

--- a/common/src/main/java/org/entcore/common/user/dto/Preference.java
+++ b/common/src/main/java/org/entcore/common/user/dto/Preference.java
@@ -7,4 +7,9 @@ public interface Preference {
     default String encode() {
         return Json.encode(this);
     }
+
+    /** Returns true if the preference data is valid and can be persisted. */
+    default boolean validate() {
+        return true;
+    }
 }

--- a/common/src/main/java/org/entcore/common/user/dto/QuietHoursPreference.java
+++ b/common/src/main/java/org/entcore/common/user/dto/QuietHoursPreference.java
@@ -5,10 +5,38 @@ import io.vertx.core.json.Json;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * Represents a user's quiet hours preference for notification deferral.
+ */
 public class QuietHoursPreference implements Preference {
 
+    /**
+     * Indicates who manages the quiet hours configuration.
+     */
+    public enum ManagedBy {
+        /** Set by the user themselves */
+        USER,
+        /** Set by the structure (school/organization) */
+        STRUCTURE
+    }
+
+    /**
+     * Weekly schedule of quiet hours.
+     * Array of 7 days (0=Monday, 6=Sunday), each containing the hours (0-23) that are quiet.
+     * Null means no schedule is defined.
+     */
     private int[][] schedule;
-    private boolean managed;
+
+    /**
+     * Indicates who manages this quiet hours configuration.
+     * See {@link ManagedBy} for possible values.
+     */
+    private ManagedBy managedBy;
+
+    /**
+     * Whether quiet hours filtering is active.
+     * When false, notifications are sent immediately regardless of the schedule.
+     */
     private boolean enabled;
 
     public int[][] getSchedule() {
@@ -19,12 +47,12 @@ public class QuietHoursPreference implements Preference {
         this.schedule = schedule;
     }
 
-    public boolean isManaged() {
-        return managed;
+    public ManagedBy getManagedBy() {
+        return managedBy;
     }
 
-    public void setManaged(boolean managed) {
-        this.managed = managed;
+    public void setManagedBy(ManagedBy managedBy) {
+        this.managedBy = managedBy;
     }
 
     public boolean isEnabled() {

--- a/common/src/main/java/org/entcore/common/user/dto/QuietHoursPreference.java
+++ b/common/src/main/java/org/entcore/common/user/dto/QuietHoursPreference.java
@@ -1,0 +1,57 @@
+package org.entcore.common.user.dto;
+
+import io.vertx.core.json.Json;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class QuietHoursPreference implements Preference {
+
+    private int[][] schedule;
+    private boolean managed;
+    private boolean enabled;
+
+    public int[][] getSchedule() {
+        return schedule;
+    }
+
+    public void setSchedule(int[][] schedule) {
+        this.schedule = schedule;
+    }
+
+    public boolean isManaged() {
+        return managed;
+    }
+
+    public void setManaged(boolean managed) {
+        this.managed = managed;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Override
+    public String encode() {
+        return Json.encode(this);
+    }
+
+    @Override
+    public boolean validate() {
+        if (schedule == null) return true;
+        if (schedule.length != 7) return false;
+        for (int[] day : schedule) {
+            if (day == null) return false;
+            Set<Integer> seen = new HashSet<>();
+            for (int hour : day) {
+                if (hour < 0 || hour > 23) return false;
+                if (!seen.add(hour)) return false; // duplicate
+            }
+        }
+        return true;
+    }
+}

--- a/common/src/main/java/org/entcore/common/user/dto/TimezonePreference.java
+++ b/common/src/main/java/org/entcore/common/user/dto/TimezonePreference.java
@@ -1,5 +1,7 @@
 package org.entcore.common.user.dto;
 
+import java.time.ZoneId;
+
 /**
  * User timezone preference.
  * Used to determine the user's local timezone independently of other preferences.
@@ -19,5 +21,16 @@ public class TimezonePreference implements Preference {
     @Override
     public String encode() {
         return timezone;
+    }
+
+    @Override
+    public boolean validate() {
+        if (timezone == null) return true;
+        try {
+            ZoneId.of(timezone);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/common/src/main/java/org/entcore/common/user/dto/TimezonePreference.java
+++ b/common/src/main/java/org/entcore/common/user/dto/TimezonePreference.java
@@ -1,0 +1,23 @@
+package org.entcore.common.user.dto;
+
+/**
+ * User timezone preference.
+ * Used to determine the user's local timezone independently of other preferences.
+ */
+public class TimezonePreference implements Preference {
+
+    private String timezone;
+
+    public String getTimezone() {
+        return timezone;
+    }
+
+    public void setTimezone(String timezone) {
+        this.timezone = timezone;
+    }
+
+    @Override
+    public String encode() {
+        return timezone;
+    }
+}

--- a/common/src/main/java/org/entcore/common/user/dto/UserPreferenceDto.java
+++ b/common/src/main/java/org/entcore/common/user/dto/UserPreferenceDto.java
@@ -13,6 +13,8 @@ public class UserPreferenceDto {
     private LanguagePreference language;
     private ApplicationPreference apps;
     private String lastDomain;
+    private TimezonePreference timezone;
+    private QuietHoursPreference quietHours;
 
     @JsonIgnore
     private JsonObject legacyPreferences;
@@ -86,12 +88,30 @@ public class UserPreferenceDto {
         return language.getLanguages().get(I18n.DEFAULT_DOMAIN);
     }
 
+    public TimezonePreference getTimezone() {
+        return timezone;
+    }
+
+    public void setTimezone(TimezonePreference timezone) {
+        this.timezone = timezone;
+    }
+
+    public QuietHoursPreference getQuietHours() {
+        return quietHours;
+    }
+
+    public void setQuietHours(QuietHoursPreference quietHours) {
+        this.quietHours = quietHours;
+    }
+
     public Preference getPreference(Application appName) {
         switch (appName) {
             case HOME_PAGE: return homePage;
             case THEME: return theme;
             case LANGUAGE: return language;
             case APPLICATION: return apps;
+            case TIMEZONE: return timezone;
+            case QUIET_HOURS: return quietHours;
         }
         return new Preference() {
             @Override
@@ -112,7 +132,9 @@ public class UserPreferenceDto {
         HOME_PAGE("homePage"),
         THEME("theme"),
         LANGUAGE("language"),
-        APPLICATION("apps");
+        APPLICATION("apps"),
+        TIMEZONE("timezone"),
+        QUIET_HOURS("quietHours");
 
         private String mappingName;
 

--- a/common/src/main/java/org/entcore/common/user/mapper/UserPreferenceDtoMapper.java
+++ b/common/src/main/java/org/entcore/common/user/mapper/UserPreferenceDtoMapper.java
@@ -44,8 +44,19 @@ public final class UserPreferenceDtoMapper {
         }
         if (pref.containsKey("lastDomain") && pref.getString("lastDomain") != null) {
             dto.setLastDomain(pref.getString("lastDomain"));
-        } else {
+        }
+       	else {
            dto.setLastDomain(I18n.DEFAULT_DOMAIN);
+        }
+        if (pref.containsKey(TIMEZONE.getMappingName())) {
+           dto.getPreferences().add(TIMEZONE);
+           dto.setTimezone(new TimezonePreference());
+           dto.getTimezone().setTimezone(pref.getString(TIMEZONE.getMappingName()));
+        }
+        if (pref.containsKey(QUIET_HOURS.getMappingName())) {
+           dto.getPreferences().add(QUIET_HOURS);
+           String encoded = pref.getString(QUIET_HOURS.getMappingName());
+           dto.setQuietHours(decodeSafely(encoded, QuietHoursPreference.class));
         }
         return dto;
     }

--- a/common/src/test/java/org/entcore/common/user/QuietHoursPreferenceTest.java
+++ b/common/src/test/java/org/entcore/common/user/QuietHoursPreferenceTest.java
@@ -1,6 +1,7 @@
 package org.entcore.common.user;
 
 import org.entcore.common.user.dto.QuietHoursPreference;
+import org.entcore.common.user.dto.QuietHoursPreference.ManagedBy;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -21,7 +22,6 @@ public class QuietHoursPreferenceTest {
     @Test
     public void testValidate_NullSchedule_Valid() {
         QuietHoursPreference pref = new QuietHoursPreference();
-        pref.setTimezone("Europe/Paris");
         assertTrue(pref.validate());
     }
 
@@ -85,7 +85,7 @@ public class QuietHoursPreferenceTest {
         assertTrue(pref.validate());
     }
 
-    // --- enabled / managed defaults ---
+    // --- enabled / managedBy defaults ---
 
     @Test
     public void testDefaults_EnabledIsFalse() {
@@ -95,10 +95,10 @@ public class QuietHoursPreferenceTest {
     }
 
     @Test
-    public void testDefaults_ManagedIsFalse() {
-        // primitive boolean -> default false
+    public void testDefaults_ManagedByIsNull() {
+        // enum reference -> default null
         QuietHoursPreference pref = new QuietHoursPreference();
-        assertFalse(pref.isManaged());
+        assertNull(pref.getManagedBy());
     }
 
     @Test
@@ -109,9 +109,16 @@ public class QuietHoursPreferenceTest {
     }
 
     @Test
-    public void testSetManaged_True() {
+    public void testSetManagedBy_Structure() {
         QuietHoursPreference pref = new QuietHoursPreference();
-        pref.setManaged(true);
-        assertTrue(pref.isManaged());
+        pref.setManagedBy(ManagedBy.STRUCTURE);
+        assertEquals(ManagedBy.STRUCTURE, pref.getManagedBy());
+    }
+
+    @Test
+    public void testSetManagedBy_User() {
+        QuietHoursPreference pref = new QuietHoursPreference();
+        pref.setManagedBy(ManagedBy.USER);
+        assertEquals(ManagedBy.USER, pref.getManagedBy());
     }
 }

--- a/common/src/test/java/org/entcore/common/user/QuietHoursPreferenceTest.java
+++ b/common/src/test/java/org/entcore/common/user/QuietHoursPreferenceTest.java
@@ -1,0 +1,117 @@
+package org.entcore.common.user;
+
+import org.entcore.common.user.dto.QuietHoursPreference;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class QuietHoursPreferenceTest {
+
+    private static int[][] validSchedule() {
+        int[][] s = new int[7][];
+        s[0] = new int[]{0, 1, 2, 3, 4, 5, 6, 7, 22, 23};
+        s[1] = new int[]{0, 1, 2, 3, 4, 5, 6, 7, 22, 23};
+        s[2] = new int[]{0, 1, 2, 3, 4, 5, 6, 7, 22, 23};
+        s[3] = new int[]{0, 1, 2, 3, 4, 5, 6, 7, 22, 23};
+        s[4] = new int[]{0, 1, 2, 3, 4, 5, 6, 7, 20, 21, 22, 23};
+        s[5] = new int[]{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23};
+        s[6] = new int[]{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23};
+        return s;
+    }
+
+    @Test
+    public void testValidate_NullSchedule_Valid() {
+        QuietHoursPreference pref = new QuietHoursPreference();
+        pref.setTimezone("Europe/Paris");
+        assertTrue(pref.validate());
+    }
+
+    @Test
+    public void testValidate_ValidSchedule() {
+        QuietHoursPreference pref = new QuietHoursPreference();
+        pref.setSchedule(validSchedule());
+        assertTrue(pref.validate());
+    }
+
+    @Test
+    public void testValidate_WrongNumberOfDays_Invalid() {
+        QuietHoursPreference pref = new QuietHoursPreference();
+        pref.setSchedule(new int[5][]);
+        assertFalse(pref.validate());
+    }
+
+    @Test
+    public void testValidate_HourOutOfRange_Invalid() {
+        QuietHoursPreference pref = new QuietHoursPreference();
+        int[][] s = validSchedule();
+        s[0] = new int[]{0, 1, 25}; // 25 is invalid
+        pref.setSchedule(s);
+        assertFalse(pref.validate());
+    }
+
+    @Test
+    public void testValidate_NegativeHour_Invalid() {
+        QuietHoursPreference pref = new QuietHoursPreference();
+        int[][] s = validSchedule();
+        s[0] = new int[]{-1, 0, 1};
+        pref.setSchedule(s);
+        assertFalse(pref.validate());
+    }
+
+    @Test
+    public void testValidate_DuplicateHour_Invalid() {
+        QuietHoursPreference pref = new QuietHoursPreference();
+        int[][] s = validSchedule();
+        s[0] = new int[]{0, 1, 1}; // duplicate 1
+        pref.setSchedule(s);
+        assertFalse(pref.validate());
+    }
+
+    @Test
+    public void testValidate_NullDayArray_Invalid() {
+        QuietHoursPreference pref = new QuietHoursPreference();
+        int[][] s = validSchedule();
+        s[3] = null; // null day
+        pref.setSchedule(s);
+        assertFalse(pref.validate());
+    }
+
+    @Test
+    public void testValidate_EmptyDayArray_Valid() {
+        // Empty array for a day is valid (no quiet hours that day)
+        QuietHoursPreference pref = new QuietHoursPreference();
+        int[][] s = validSchedule();
+        s[0] = new int[]{}; // no quiet hours Monday
+        pref.setSchedule(s);
+        assertTrue(pref.validate());
+    }
+
+    // --- enabled / managed defaults ---
+
+    @Test
+    public void testDefaults_EnabledIsFalse() {
+        // primitive boolean -> default false
+        QuietHoursPreference pref = new QuietHoursPreference();
+        assertFalse(pref.isEnabled());
+    }
+
+    @Test
+    public void testDefaults_ManagedIsFalse() {
+        // primitive boolean -> default false
+        QuietHoursPreference pref = new QuietHoursPreference();
+        assertFalse(pref.isManaged());
+    }
+
+    @Test
+    public void testSetEnabled_True() {
+        QuietHoursPreference pref = new QuietHoursPreference();
+        pref.setEnabled(true);
+        assertTrue(pref.isEnabled());
+    }
+
+    @Test
+    public void testSetManaged_True() {
+        QuietHoursPreference pref = new QuietHoursPreference();
+        pref.setManaged(true);
+        assertTrue(pref.isManaged());
+    }
+}

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultPreferenceService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultPreferenceService.java
@@ -36,11 +36,15 @@ public class DefaultPreferenceService implements PreferenceService {
         StringBuilder merge = new StringBuilder(" ON MATCH SET ");
 
         preference.getPreferences().forEach( ( appName ) -> {
+            if (!preference.getPreference(appName).validate()) {
+                promise.fail("invalid.preference." + appName.getMappingName());
+                return promise.future();
+            }
             String partialQuery = " uac."+ appName.getMappingName() +" = {"+ appName.getMappingName() +"},";
             create.append(partialQuery);
             merge.append(partialQuery);
             params.put(appName.getMappingName(), preference.getPreference(appName).encode());
-        });
+        }
 
         create.deleteCharAt(create.length() - 1);
         merge.deleteCharAt(merge.length() - 1);

--- a/timeline/src/main/java/org/entcore/timeline/controllers/helper/NotificationHelper.java
+++ b/timeline/src/main/java/org/entcore/timeline/controllers/helper/NotificationHelper.java
@@ -24,11 +24,13 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import org.entcore.common.utils.StringUtils;
+import org.entcore.common.user.dto.QuietHoursPreference;
+import org.entcore.common.user.dto.TimezonePreference;
 import org.entcore.timeline.services.TimelineConfigService;
 import org.entcore.timeline.services.TimelineMailerService;
 import org.entcore.timeline.services.TimelinePushNotifService;
@@ -38,8 +40,6 @@ import java.time.*;
 import java.util.List;
 
 import org.entcore.common.notification.NotificationUtils;
-
-import static java.lang.System.currentTimeMillis;
 
 
 public class NotificationHelper {
@@ -70,14 +70,31 @@ public class NotificationHelper {
                     }
                     final JsonObject notificationProperties = properties.right().getValue();
                     //Get users preferences (overrides notification properties)
-                    NotificationUtils.getUsersPreferences(eb, json.getJsonArray("recipientsIds"), "language: uac.language, displayName: u.displayName, tokens: uac.fcmTokens ", new Handler<JsonArray>() {
+                     NotificationUtils.getUsersPreferences(eb, json.getJsonArray("recipientsIds"),
+                             "language: uac.language, displayName: u.displayName, tokens: uac.fcmTokens, " +
+                             "uai: head([(u)-[:IN]->(:ProfileGroup)-[:DEPENDS]->(s:Structure) | s.UAI]), " +
+                             "quietHours: uac.quietHours, " +
+                             "timezone: uac.timezone ",
+                            new Handler<JsonArray>() {
                         public void handle(final JsonArray userList) {
                             if (userList == null) {
                                 log.error("[NotificationHelper] Issue while retrieving users preferences.");
                                 return;
                             }
+                            // Filter recipients currently in quiet hours based on their preference or structure's timezone
+                            final JsonArray activeUserList = new JsonArray();
+                            final Instant now = Instant.now();
+                             for (int i = 0; i < userList.size(); i++) {
+                                 JsonObject user = userList.getJsonObject(i);
+                                 QuietHoursPreference userPrefQuietHours = parseQuietHours(user);
+                                 TimezonePreference userPrefTimezone = parseTimezone(user);
+                                 String uai = user.getString("uai");
+                                 if (!isQuietHour(now, userPrefQuietHours, userPrefTimezone, uai)) {
+                                     activeUserList.add(user);
+                                 }
+                             }
                             if (disableMailNotification == null || !disableMailNotification.booleanValue()) {
-                                mailerService.sendImmediateMails(request, notificationName, notification, json.getJsonObject("params"), userList, notificationProperties);
+                                mailerService.sendImmediateMails(request, notificationName, notification, json.getJsonObject("params"), activeUserList, notificationProperties);
                             }
 
                             if (pushNotifServices != null && pushNotifServices.size() > 0
@@ -87,7 +104,7 @@ public class NotificationHelper {
                                     && !TimelineNotificationsLoader.Restrictions.INTERNAL.name().equals(notificationProperties.getString("restriction"))
                                     && !TimelineNotificationsLoader.Restrictions.HIDDEN.name().equals(notificationProperties.getString("restriction"))) {
                                 pushNotifServices.forEach(pushNotifService -> {
-                                    pushNotifService.sendImmediateNotifs(notificationName, json, userList, notificationProperties);
+                                    pushNotifService.sendImmediateNotifs(notificationName, json, activeUserList, notificationProperties);
                                 });
                             }
                         }
@@ -116,13 +133,125 @@ public class NotificationHelper {
         if(dateWrapper == null || dateWrapper.getString("$date") == null) {
             isImmediate = true;
         } else {
-            Instant now = LocalDateTime.now().toInstant(ZoneOffset.UTC);
+            Instant now = Instant.now();
             Instant publishDate = OffsetDateTime.parse(dateWrapper.getString("$date")).toInstant();
             isImmediate = publishDate.isBefore(now);
         }
         return isImmediate;
     }
 
+    /**
+     * Returns true if the current instant falls within the user's quiet hours.
+     * Returns false if no preference is set or no timezone can be resolved.
+     *
+     * @param now                current instant
+     * @param userPrefQuietHours parsed quiet hours preference, nullable
+     * @param userPrefTimezone   parsed timezone preference, nullable
+     * @param userPrefUai        UAI of the user's first structure, nullable
+     */
+    static boolean isQuietHour(Instant now, QuietHoursPreference userPrefQuietHours, TimezonePreference userPrefTimezone, String uai) {
+        if (userPrefQuietHours == null || !userPrefQuietHours.isEnabled() || userPrefQuietHours.getSchedule() == null) return false;
+        
+        ZoneId zone = resolveTimezone(userPrefTimezone, uai);
+        if (zone == null) return false;
+        
+        return isQuietHour(now.atZone(zone), userPrefQuietHours.getSchedule());
+    }
+
+    /**
+     * Returns true if the given datetime falls within the provided schedule.
+     * Returns false if schedule is null or the hour is not listed for that day.
+     * schedule[dayIndex] = array of quiet hours (0=Monday, 6=Sunday).
+     */
+    static boolean isQuietHour(ZonedDateTime now, int[][] quietHoursSchedule) {
+        if (quietHoursSchedule == null) return false;
+        
+        int dayIndex = now.getDayOfWeek().getValue() - 1; // 0=Monday, 6=Sunday
+        int hour = now.getHour();
+        
+        if (dayIndex >= quietHoursSchedule.length || quietHoursSchedule[dayIndex] == null) return false;
+        
+        for (int quietHour : quietHoursSchedule[dayIndex]) {
+            if (quietHour == hour) return true;
+        }
+        
+        return false;
+    }
+
+    /**
+     * Parses the quietHours preference from the user JSON object.
+     * Returns null if absent or malformed.
+     */
+    static QuietHoursPreference parseQuietHours(JsonObject user) {
+        String json = user.getString("quietHours");
+        if (json == null) return null;
+        
+        try {
+            return Json.decodeValue(json, QuietHoursPreference.class);
+        } catch (Exception e) {
+            log.warn("[NotificationHelper] Cannot parse quietHours preference: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Parses the timezone preference from the user JSON object.
+     * Returns null if absent or malformed.
+     */
+    static TimezonePreference parseTimezone(JsonObject user) {
+        String tz = user.getString("timezone");
+        if (tz == null) return null;
+        TimezonePreference pref = new TimezonePreference();
+        pref.setTimezone(tz);
+        return pref;
+    }
+
+    /**
+     * Resolves the ZoneId to use for quiet hours:
+     * 1. Explicit timezone from user preference
+     * 2. Fallback timezone (derived from UAI by the caller)
+     * 3. null if no fallback (foreign structure -> no quiet hours applied)
+     */
+    static ZoneId resolveTimezone(TimezonePreference userPrefTimezone, String uai) {
+        if (userPrefTimezone != null && userPrefTimezone.getTimezone() != null) {
+            try {
+                return ZoneId.of(userPrefTimezone.getTimezone());
+            } catch (Exception e) {
+                log.warn("[NotificationHelper] Invalid timezone in timezone preference: " + userPrefTimezone.getTimezone());
+            }
+        }
+        // Resolve from UAI only if no explicit preference timezone
+        return getTimezoneFromUai(uai);
+    }
+
+    /**
+     * Returns the ZoneId corresponding to the given UAI (French school code).
+     * Extracts the department from the first 2-3 characters to handle DOM-TOM.
+     * Falls back to Europe/Paris for metropolitan France, Corsica, or unknown UAI.
+     */
+    static ZoneId getTimezoneFromUai(String uai) {
+        if (uai == null) return null;
+        if (uai.length() < 3) return ZoneId.of("Europe/Paris");
+        try {
+            int dept = Integer.parseInt(uai.substring(0, 3));
+            switch (dept) {
+                case 971: return ZoneId.of("America/Guadeloupe");
+                case 972: return ZoneId.of("America/Martinique");
+                case 973: return ZoneId.of("America/Cayenne");
+                case 974: return ZoneId.of("Indian/Reunion");
+                case 975: return ZoneId.of("America/Miquelon");
+                case 976: return ZoneId.of("Indian/Mayotte");
+                case 977: return ZoneId.of("America/St_Barthelemy");
+                case 978: return ZoneId.of("America/Marigot");
+                case 986: return ZoneId.of("Pacific/Wallis");
+                case 987: return ZoneId.of("Pacific/Tahiti");
+                case 988: return ZoneId.of("Pacific/Noumea");
+                default:  return ZoneId.of("Europe/Paris");
+            }
+        } catch (NumberFormatException e) {
+            return ZoneId.of("Europe/Paris");
+        }
+    }
 
     public void setPushNotifServices(List<TimelinePushNotifService> pushNotifServices) {
         this.pushNotifServices = pushNotifServices;

--- a/timeline/src/main/java/org/entcore/timeline/controllers/helper/NotificationHelper.java
+++ b/timeline/src/main/java/org/entcore/timeline/controllers/helper/NotificationHelper.java
@@ -89,9 +89,9 @@ public class NotificationHelper {
                                  QuietHoursPreference userPrefQuietHours = parseQuietHours(user);
                                  TimezonePreference userPrefTimezone = parseTimezone(user);
                                  String uai = user.getString("uai");
-                                 if (!isQuietHour(now, userPrefQuietHours, userPrefTimezone, uai)) {
-                                     activeUserList.add(user);
-                                 }
+                                  if (!QuietHoursHelper.isQuietHour(now, userPrefQuietHours, userPrefTimezone, uai)) {
+                                      activeUserList.add(user);
+                                  }
                              }
                             if (disableMailNotification == null || !disableMailNotification.booleanValue()) {
                                 mailerService.sendImmediateMails(request, notificationName, notification, json.getJsonObject("params"), activeUserList, notificationProperties);
@@ -140,90 +140,7 @@ public class NotificationHelper {
         return isImmediate;
     }
 
-    /**
-     * Returns true if the current instant falls within the user's quiet hours.
-     * Returns false if no preference is set or no timezone can be resolved.
-     *
-     * @param now                current instant
-     * @param userPrefQuietHours parsed quiet hours preference, nullable
-     * @param userPrefTimezone   parsed timezone preference, nullable
-     * @param userPrefUai        UAI of the user's first structure, nullable
-     */
-    static boolean isQuietHour(Instant now, QuietHoursPreference userPrefQuietHours, TimezonePreference userPrefTimezone, String uai) {
-        if (userPrefQuietHours == null || !userPrefQuietHours.isEnabled() || userPrefQuietHours.getSchedule() == null) return false;
-        
-        ZoneId zone = resolveTimezone(userPrefTimezone, uai);
-        if (zone == null) return false;
-        
-        return isQuietHour(now.atZone(zone), userPrefQuietHours.getSchedule());
-    }
 
-    /**
-     * Returns true if the given datetime falls within the provided schedule.
-     * Returns false if schedule is null or the hour is not listed for that day.
-     * schedule[dayIndex] = array of quiet hours (0=Monday, 6=Sunday).
-     */
-    static boolean isQuietHour(ZonedDateTime now, int[][] quietHoursSchedule) {
-        if (quietHoursSchedule == null) return false;
-        
-        int dayIndex = now.getDayOfWeek().getValue() - 1; // 0=Monday, 6=Sunday
-        int hour = now.getHour();
-        
-        if (dayIndex >= quietHoursSchedule.length || quietHoursSchedule[dayIndex] == null) return false;
-        
-        for (int quietHour : quietHoursSchedule[dayIndex]) {
-            if (quietHour == hour) return true;
-        }
-        
-        return false;
-    }
-
-    /** Returns the next send instant based on quiet hours. Returns notificationTime if no preference is active. */
-    static Instant computeNextSendTime(Instant notificationTime, QuietHoursPreference userPrefQuietHours, TimezonePreference userPrefTimezone, String userPrefUai) {
-        if (userPrefQuietHours == null || !userPrefQuietHours.isEnabled() || userPrefQuietHours.getSchedule() == null) {
-            return notificationTime;
-        }
-        ZoneId zone = resolveTimezone(userPrefTimezone, userPrefUai);
-        return computeNextSendTime(notificationTime, userPrefQuietHours, zone);
-    }
-
-    /** Returns the next send instant using an already-resolved ZoneId. Returns notificationTime if zone is null. */
-    static Instant computeNextSendTime(Instant notificationTime, QuietHoursPreference userPrefQuietHours, ZoneId zone) {
-        if (zone == null) return notificationTime;
-        if (userPrefQuietHours == null || !userPrefQuietHours.isEnabled() || userPrefQuietHours.getSchedule() == null) {
-            return notificationTime;
-        }
-        return computeNextSendTime(notificationTime.atZone(zone), userPrefQuietHours.getSchedule());
-    }
-
-    /**
-     * Pure engine: returns the original instant if the current hour is not quiet.
-     * Otherwise advances hour by hour (max 168 slots) to find the first non-quiet hour.
-     * Returns null if no slot found (degenerate schedule). DST handled by ZonedDateTime.plusHours.
-     */
-    static Instant computeNextSendTime(ZonedDateTime localTime, int[][] schedule) {
-        if (schedule == null) return localTime.toInstant();
-        int currentDayIndex = localTime.getDayOfWeek().getValue() - 1;
-        int currentHour = localTime.getHour();
-        if (!isHourInSchedule(schedule, currentDayIndex, currentHour)) return localTime.toInstant();
-        ZonedDateTime cursor = localTime.truncatedTo(java.time.temporal.ChronoUnit.HOURS).plusHours(1);
-        for (int i = 0; i < 168; i++) {
-            if (!isHourInSchedule(schedule, cursor.getDayOfWeek().getValue() - 1, cursor.getHour())) {
-                return cursor.toInstant();
-            }
-            cursor = cursor.plusHours(1);
-        }
-        return null;
-    }
-
-    /** Returns true if the given hour is in the schedule for the given dayIndex. */
-    private static boolean isHourInSchedule(int[][] schedule, int dayIndex, int hour) {
-        if (dayIndex < 0 || dayIndex >= schedule.length || schedule[dayIndex] == null) return false;
-        for (int quietHour : schedule[dayIndex]) {
-            if (quietHour == hour) return true;
-        }
-        return false;
-    }
 
     /**
      * Parses the quietHours preference from the user JSON object.
@@ -253,52 +170,7 @@ public class NotificationHelper {
         return pref;
     }
 
-    /**
-     * Resolves the ZoneId to use for quiet hours:
-     * 1. Explicit timezone from user preference
-     * 2. Fallback timezone (derived from UAI by the caller)
-     * 3. null if no fallback (foreign structure -> no quiet hours applied)
-     */
-    static ZoneId resolveTimezone(TimezonePreference userPrefTimezone, String uai) {
-        if (userPrefTimezone != null && userPrefTimezone.getTimezone() != null) {
-            try {
-                return ZoneId.of(userPrefTimezone.getTimezone());
-            } catch (Exception e) {
-                log.warn("[NotificationHelper] Invalid timezone in timezone preference: " + userPrefTimezone.getTimezone());
-            }
-        }
-        // Resolve from UAI only if no explicit preference timezone
-        return getTimezoneFromUai(uai);
-    }
 
-    /**
-     * Returns the ZoneId corresponding to the given UAI (French school code).
-     * Extracts the department from the first 2-3 characters to handle DOM-TOM.
-     * Falls back to Europe/Paris for metropolitan France, Corsica, or unknown UAI.
-     */
-    static ZoneId getTimezoneFromUai(String uai) {
-        if (uai == null) return null;
-        if (uai.length() < 3) return ZoneId.of("Europe/Paris");
-        try {
-            int dept = Integer.parseInt(uai.substring(0, 3));
-            switch (dept) {
-                case 971: return ZoneId.of("America/Guadeloupe");
-                case 972: return ZoneId.of("America/Martinique");
-                case 973: return ZoneId.of("America/Cayenne");
-                case 974: return ZoneId.of("Indian/Reunion");
-                case 975: return ZoneId.of("America/Miquelon");
-                case 976: return ZoneId.of("Indian/Mayotte");
-                case 977: return ZoneId.of("America/St_Barthelemy");
-                case 978: return ZoneId.of("America/Marigot");
-                case 986: return ZoneId.of("Pacific/Wallis");
-                case 987: return ZoneId.of("Pacific/Tahiti");
-                case 988: return ZoneId.of("Pacific/Noumea");
-                default:  return ZoneId.of("Europe/Paris");
-            }
-        } catch (NumberFormatException e) {
-            return ZoneId.of("Europe/Paris");
-        }
-    }
 
     public void setPushNotifServices(List<TimelinePushNotifService> pushNotifServices) {
         this.pushNotifServices = pushNotifServices;

--- a/timeline/src/main/java/org/entcore/timeline/controllers/helper/NotificationHelper.java
+++ b/timeline/src/main/java/org/entcore/timeline/controllers/helper/NotificationHelper.java
@@ -178,6 +178,53 @@ public class NotificationHelper {
         return false;
     }
 
+    /** Returns the next send instant based on quiet hours. Returns notificationTime if no preference is active. */
+    static Instant computeNextSendTime(Instant notificationTime, QuietHoursPreference userPrefQuietHours, TimezonePreference userPrefTimezone, String userPrefUai) {
+        if (userPrefQuietHours == null || !userPrefQuietHours.isEnabled() || userPrefQuietHours.getSchedule() == null) {
+            return notificationTime;
+        }
+        ZoneId zone = resolveTimezone(userPrefTimezone, userPrefUai);
+        return computeNextSendTime(notificationTime, userPrefQuietHours, zone);
+    }
+
+    /** Returns the next send instant using an already-resolved ZoneId. Returns notificationTime if zone is null. */
+    static Instant computeNextSendTime(Instant notificationTime, QuietHoursPreference userPrefQuietHours, ZoneId zone) {
+        if (zone == null) return notificationTime;
+        if (userPrefQuietHours == null || !userPrefQuietHours.isEnabled() || userPrefQuietHours.getSchedule() == null) {
+            return notificationTime;
+        }
+        return computeNextSendTime(notificationTime.atZone(zone), userPrefQuietHours.getSchedule());
+    }
+
+    /**
+     * Pure engine: returns the original instant if the current hour is not quiet.
+     * Otherwise advances hour by hour (max 168 slots) to find the first non-quiet hour.
+     * Returns null if no slot found (degenerate schedule). DST handled by ZonedDateTime.plusHours.
+     */
+    static Instant computeNextSendTime(ZonedDateTime localTime, int[][] schedule) {
+        if (schedule == null) return localTime.toInstant();
+        int currentDayIndex = localTime.getDayOfWeek().getValue() - 1;
+        int currentHour = localTime.getHour();
+        if (!isHourInSchedule(schedule, currentDayIndex, currentHour)) return localTime.toInstant();
+        ZonedDateTime cursor = localTime.truncatedTo(java.time.temporal.ChronoUnit.HOURS).plusHours(1);
+        for (int i = 0; i < 168; i++) {
+            if (!isHourInSchedule(schedule, cursor.getDayOfWeek().getValue() - 1, cursor.getHour())) {
+                return cursor.toInstant();
+            }
+            cursor = cursor.plusHours(1);
+        }
+        return null;
+    }
+
+    /** Returns true if the given hour is in the schedule for the given dayIndex. */
+    private static boolean isHourInSchedule(int[][] schedule, int dayIndex, int hour) {
+        if (dayIndex < 0 || dayIndex >= schedule.length || schedule[dayIndex] == null) return false;
+        for (int quietHour : schedule[dayIndex]) {
+            if (quietHour == hour) return true;
+        }
+        return false;
+    }
+
     /**
      * Parses the quietHours preference from the user JSON object.
      * Returns null if absent or malformed.

--- a/timeline/src/main/java/org/entcore/timeline/controllers/helper/QuietHoursHelper.java
+++ b/timeline/src/main/java/org/entcore/timeline/controllers/helper/QuietHoursHelper.java
@@ -1,0 +1,136 @@
+package org.entcore.timeline.controllers.helper;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.entcore.common.user.dto.QuietHoursPreference;
+import org.entcore.common.user.dto.TimezonePreference;
+
+import java.time.*;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Utility class for quiet hours logic: schedule evaluation, timezone resolution, UAI mapping.
+ */
+public final class QuietHoursHelper {
+
+    private static final Logger log = LoggerFactory.getLogger(QuietHoursHelper.class);
+
+    private QuietHoursHelper() {}
+
+    /** Returns true if the current instant falls within the user's quiet hours. Returns false if no preference is active. */
+    static boolean isQuietHour(Instant now, QuietHoursPreference userPrefQuietHours, TimezonePreference userPrefTimezone, String userPrefUai) {
+        if (userPrefQuietHours == null || !userPrefQuietHours.isEnabled() || userPrefQuietHours.getSchedule() == null) return false;
+        ZoneId zone = resolveTimezone(userPrefTimezone, userPrefUai);
+        if (zone == null) return false;
+        return isQuietHour(now.atZone(zone), userPrefQuietHours.getSchedule());
+    }
+
+    /**
+     * Returns true if the given datetime falls within the provided schedule.
+     * Returns false if schedule is null or the hour is not listed for that day.
+     * schedule[dayIndex] = array of quiet hours (0=Monday, 6=Sunday).
+     */
+    static boolean isQuietHour(ZonedDateTime now, int[][] schedule) {
+        if (schedule == null) return false;
+        int dayIndex = now.getDayOfWeek().getValue() - 1;
+        int hour = now.getHour();
+        if (dayIndex >= schedule.length || schedule[dayIndex] == null) return false;
+        for (int quietHour : schedule[dayIndex]) {
+            if (quietHour == hour) return true;
+        }
+        return false;
+    }
+
+    /** Returns the next send instant based on quiet hours. Returns notificationTime if no preference is active. */
+    static Instant computeNextSendTime(Instant notificationTime, QuietHoursPreference userPrefQuietHours, TimezonePreference userPrefTimezone, String userPrefUai) {
+        if (userPrefQuietHours == null || !userPrefQuietHours.isEnabled() || userPrefQuietHours.getSchedule() == null) {
+            return notificationTime;
+        }
+        ZoneId zone = resolveTimezone(userPrefTimezone, userPrefUai);
+        return computeNextSendTime(notificationTime, userPrefQuietHours, zone);
+    }
+
+    /** Returns the next send instant using an already-resolved ZoneId. Returns notificationTime if zone is null. */
+    static Instant computeNextSendTime(Instant notificationTime, QuietHoursPreference userPrefQuietHours, ZoneId zone) {
+        if (zone == null) return notificationTime;
+        if (userPrefQuietHours == null || !userPrefQuietHours.isEnabled() || userPrefQuietHours.getSchedule() == null) {
+            return notificationTime;
+        }
+        return computeNextSendTime(notificationTime.atZone(zone), userPrefQuietHours.getSchedule());
+    }
+
+    /**
+     * Pure engine: returns the original instant if the current hour is not quiet.
+     * Otherwise advances hour by hour (max 168 slots) to find the first non-quiet hour.
+     * Returns null if no slot found (degenerate schedule). DST handled by ZonedDateTime.plusHours.
+     */
+    static Instant computeNextSendTime(ZonedDateTime localTime, int[][] schedule) {
+        if (schedule == null) return localTime.toInstant();
+        int currentDayIndex = localTime.getDayOfWeek().getValue() - 1;
+        int currentHour = localTime.getHour();
+        if (!isHourInSchedule(schedule, currentDayIndex, currentHour)) return localTime.toInstant();
+        ZonedDateTime cursor = localTime.truncatedTo(ChronoUnit.HOURS).plusHours(1);
+        for (int i = 0; i < 168; i++) {
+            if (!isHourInSchedule(schedule, cursor.getDayOfWeek().getValue() - 1, cursor.getHour())) {
+                return cursor.toInstant();
+            }
+            cursor = cursor.plusHours(1);
+        }
+        return null;
+    }
+
+    /** Returns true if the given hour is in the schedule for the given dayIndex. */
+    static boolean isHourInSchedule(int[][] schedule, int dayIndex, int hour) {
+        if (dayIndex < 0 || dayIndex >= schedule.length || schedule[dayIndex] == null) return false;
+        for (int quietHour : schedule[dayIndex]) {
+            if (quietHour == hour) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Resolves the ZoneId to use for quiet hours:
+     * 1. Explicit timezone from user preference
+     * 2. Fallback from UAI (structure code)
+     * 3. null if no fallback (foreign structure -> no quiet hours applied)
+     */
+    static ZoneId resolveTimezone(TimezonePreference userPrefTimezone, String userPrefUai) {
+        if (userPrefTimezone != null && userPrefTimezone.getTimezone() != null) {
+            try {
+                return ZoneId.of(userPrefTimezone.getTimezone());
+            } catch (Exception e) {
+                log.warn("[QuietHoursHelper] Invalid timezone in preference: " + userPrefTimezone.getTimezone());
+            }
+        }
+        return getTimezoneFromUai(userPrefUai);
+    }
+
+    /**
+     * Returns the ZoneId for a French school UAI code.
+     * Extracts the department from the first 2-3 characters to handle DOM-TOM.
+     * Falls back to Europe/Paris for metropolitan France or unknown UAI.
+     */
+    static ZoneId getTimezoneFromUai(String uai) {
+        if (uai == null) return null;
+        if (uai.length() < 3) return ZoneId.of("Europe/Paris");
+        try {
+            int dept = Integer.parseInt(uai.substring(0, 3));
+            switch (dept) {
+                case 971: return ZoneId.of("America/Guadeloupe");
+                case 972: return ZoneId.of("America/Martinique");
+                case 973: return ZoneId.of("America/Cayenne");
+                case 974: return ZoneId.of("Indian/Reunion");
+                case 975: return ZoneId.of("America/Miquelon");
+                case 976: return ZoneId.of("Indian/Mayotte");
+                case 977: return ZoneId.of("America/St_Barthelemy");
+                case 978: return ZoneId.of("America/Marigot");
+                case 986: return ZoneId.of("Pacific/Wallis");
+                case 987: return ZoneId.of("Pacific/Tahiti");
+                case 988: return ZoneId.of("Pacific/Noumea");
+                default:  return ZoneId.of("Europe/Paris");
+            }
+        } catch (NumberFormatException e) {
+            return ZoneId.of("Europe/Paris");
+        }
+    }
+}

--- a/timeline/src/test/java/org/entcore/timeline/controllers/helper/NotificationHelperTest.java
+++ b/timeline/src/test/java/org/entcore/timeline/controllers/helper/NotificationHelperTest.java
@@ -27,7 +27,7 @@ public class NotificationHelperTest {
         int[][] schedule = new int[7][];
         schedule[0] = new int[]{10, 11, 12};
         for (int i = 1; i < 7; i++) schedule[i] = new int[]{};
-        assertTrue(NotificationHelper.isQuietHour(dt(2026, 3, 30, 10, 0), schedule));
+        assertTrue(QuietHoursHelper.isQuietHour(dt(2026, 3, 30, 10, 0), schedule));
     }
 
     @Test
@@ -36,7 +36,7 @@ public class NotificationHelperTest {
         int[][] schedule = new int[7][];
         schedule[0] = new int[]{10, 11, 12};
         for (int i = 1; i < 7; i++) schedule[i] = new int[]{};
-        assertFalse(NotificationHelper.isQuietHour(dt(2026, 3, 30, 9, 0), schedule));
+        assertFalse(QuietHoursHelper.isQuietHour(dt(2026, 3, 30, 9, 0), schedule));
     }
 
     @Test
@@ -44,13 +44,13 @@ public class NotificationHelperTest {
         // Wednesday has empty array -> not quiet
         int[][] schedule = new int[7][];
         for (int i = 0; i < 7; i++) schedule[i] = new int[]{};
-        assertFalse(NotificationHelper.isQuietHour(dt(2026, 4, 1, 10, 0), schedule));
+        assertFalse(QuietHoursHelper.isQuietHour(dt(2026, 4, 1, 10, 0), schedule));
     }
 
     @Test
     public void testIsQuietHour_NullSchedule_NotQuiet() {
         // null schedule -> not quiet (no preference = no filtering)
-        assertFalse(NotificationHelper.isQuietHour(dt(2026, 4, 1, 3, 0), null));
+        assertFalse(QuietHoursHelper.isQuietHour(dt(2026, 4, 1, 3, 0), null));
     }
 
     @Test
@@ -58,7 +58,7 @@ public class NotificationHelperTest {
         // schedule has 3 days, Sunday (dayIndex=6) out of bounds -> not quiet
         int[][] schedule = new int[3][];
         for (int i = 0; i < 3; i++) schedule[i] = new int[]{};
-        assertFalse(NotificationHelper.isQuietHour(dt(2026, 3, 29, 12, 0), schedule));
+        assertFalse(QuietHoursHelper.isQuietHour(dt(2026, 3, 29, 12, 0), schedule));
     }
 
     // --- getTimezoneFromUai tests ---
@@ -66,90 +66,90 @@ public class NotificationHelperTest {
     @Test
     public void testGetTz_Null() {
         // null UAI (foreign structure) -> no timezone -> quiet hours do not apply
-        assertNull(NotificationHelper.getTimezoneFromUai(null));
+        assertNull(QuietHoursHelper.getTimezoneFromUai(null));
     }
 
     @Test
     public void testGetTz_TooShort() {
-        assertEquals(ZoneId.of("Europe/Paris"), NotificationHelper.getTimezoneFromUai("07"));
+        assertEquals(ZoneId.of("Europe/Paris"), QuietHoursHelper.getTimezoneFromUai("07"));
     }
 
     @Test
     public void testGetTz_CorseDuSud() {
         // Corse-du-Sud UAIs start with 620 -> default -> Europe/Paris
-        assertEquals(ZoneId.of("Europe/Paris"), NotificationHelper.getTimezoneFromUai("6200060W"));
+        assertEquals(ZoneId.of("Europe/Paris"), QuietHoursHelper.getTimezoneFromUai("6200060W"));
     }
 
     @Test
     public void testGetTz_HauteCorse() {
         // Haute-Corse UAIs start with 720 -> default -> Europe/Paris
-        assertEquals(ZoneId.of("Europe/Paris"), NotificationHelper.getTimezoneFromUai("7200062E"));
+        assertEquals(ZoneId.of("Europe/Paris"), QuietHoursHelper.getTimezoneFromUai("7200062E"));
     }
 
     @Test
     public void testGetTz_Metropole() {
-        assertEquals(ZoneId.of("Europe/Paris"), NotificationHelper.getTimezoneFromUai("0750010E"));
+        assertEquals(ZoneId.of("Europe/Paris"), QuietHoursHelper.getTimezoneFromUai("0750010E"));
     }
 
     @Test
     public void testGetTz_Guadeloupe() {
-        assertEquals(ZoneId.of("America/Guadeloupe"), NotificationHelper.getTimezoneFromUai("9710001A"));
+        assertEquals(ZoneId.of("America/Guadeloupe"), QuietHoursHelper.getTimezoneFromUai("9710001A"));
     }
 
     @Test
     public void testGetTz_Martinique() {
-        assertEquals(ZoneId.of("America/Martinique"), NotificationHelper.getTimezoneFromUai("9720001A"));
+        assertEquals(ZoneId.of("America/Martinique"), QuietHoursHelper.getTimezoneFromUai("9720001A"));
     }
 
     @Test
     public void testGetTz_Guyane() {
-        assertEquals(ZoneId.of("America/Cayenne"), NotificationHelper.getTimezoneFromUai("9730001A"));
+        assertEquals(ZoneId.of("America/Cayenne"), QuietHoursHelper.getTimezoneFromUai("9730001A"));
     }
 
     @Test
     public void testGetTz_Reunion() {
-        assertEquals(ZoneId.of("Indian/Reunion"), NotificationHelper.getTimezoneFromUai("9740001A"));
+        assertEquals(ZoneId.of("Indian/Reunion"), QuietHoursHelper.getTimezoneFromUai("9740001A"));
     }
 
     @Test
     public void testGetTz_Miquelon() {
-        assertEquals(ZoneId.of("America/Miquelon"), NotificationHelper.getTimezoneFromUai("9750001A"));
+        assertEquals(ZoneId.of("America/Miquelon"), QuietHoursHelper.getTimezoneFromUai("9750001A"));
     }
 
     @Test
     public void testGetTz_Mayotte() {
-        assertEquals(ZoneId.of("Indian/Mayotte"), NotificationHelper.getTimezoneFromUai("9760001A"));
+        assertEquals(ZoneId.of("Indian/Mayotte"), QuietHoursHelper.getTimezoneFromUai("9760001A"));
     }
 
     @Test
     public void testGetTz_SaintBarthelemy() {
-        assertEquals(ZoneId.of("America/St_Barthelemy"), NotificationHelper.getTimezoneFromUai("9770001A"));
+        assertEquals(ZoneId.of("America/St_Barthelemy"), QuietHoursHelper.getTimezoneFromUai("9770001A"));
     }
 
     @Test
     public void testGetTz_SaintMartin() {
-        assertEquals(ZoneId.of("America/Marigot"), NotificationHelper.getTimezoneFromUai("9780001A"));
+        assertEquals(ZoneId.of("America/Marigot"), QuietHoursHelper.getTimezoneFromUai("9780001A"));
     }
 
     @Test
     public void testGetTz_WallisFutuna() {
-        assertEquals(ZoneId.of("Pacific/Wallis"), NotificationHelper.getTimezoneFromUai("9860001A"));
+        assertEquals(ZoneId.of("Pacific/Wallis"), QuietHoursHelper.getTimezoneFromUai("9860001A"));
     }
 
     @Test
     public void testGetTz_Polynesie() {
-        assertEquals(ZoneId.of("Pacific/Tahiti"), NotificationHelper.getTimezoneFromUai("9870001A"));
+        assertEquals(ZoneId.of("Pacific/Tahiti"), QuietHoursHelper.getTimezoneFromUai("9870001A"));
     }
 
     @Test
     public void testGetTz_NouvelleCaledonie() {
-        assertEquals(ZoneId.of("Pacific/Noumea"), NotificationHelper.getTimezoneFromUai("9880001A"));
+        assertEquals(ZoneId.of("Pacific/Noumea"), QuietHoursHelper.getTimezoneFromUai("9880001A"));
     }
 
     @Test
     public void testGetTz_NonNumeric() {
         // Non-numeric UAI should fall back to Europe/Paris via NumberFormatException catch
-        assertEquals(ZoneId.of("Europe/Paris"), NotificationHelper.getTimezoneFromUai("ABCDEFG"));
+        assertEquals(ZoneId.of("Europe/Paris"), QuietHoursHelper.getTimezoneFromUai("ABCDEFG"));
     }
 
     // --- isQuietHour(Instant, QuietHoursPreference, String) ---
@@ -157,14 +157,14 @@ public class NotificationHelperTest {
     @Test
     public void testIsQuietHour_NoPreference_NoUai_NotQuiet() {
         // no preference, no UAI -> null zone -> not quiet (foreign structure)
-        assertFalse(NotificationHelper.isQuietHour(Instant.now(), null, null, null));
+        assertFalse(QuietHoursHelper.isQuietHour(Instant.now(), null, null, null));
     }
 
     @Test
     public void testIsQuietHour_NoPreference_WithUai_NotQuiet() {
         // no preference -> no schedule -> not quiet regardless of UAI or time
         ZonedDateTime wednesday10h = dt(2026, 4, 1, 10, 0);
-        assertFalse(NotificationHelper.isQuietHour(wednesday10h.toInstant(), null, null, "0750010E"));
+        assertFalse(QuietHoursHelper.isQuietHour(wednesday10h.toInstant(), null, null, "0750010E"));
     }
 
     @Test
@@ -177,7 +177,7 @@ public class NotificationHelperTest {
         userPrefQuietHours.setSchedule(schedule);
         // enabled stays false (primitive default)
         ZonedDateTime monday10h = dt(2026, 3, 30, 10, 0);
-        assertFalse(NotificationHelper.isQuietHour(monday10h.toInstant(), userPrefQuietHours, tz("Europe/Paris"), "0750010E"));
+        assertFalse(QuietHoursHelper.isQuietHour(monday10h.toInstant(), userPrefQuietHours, tz("Europe/Paris"), "0750010E"));
     }
 
     @Test
@@ -190,7 +190,7 @@ public class NotificationHelperTest {
         userPrefQuietHours.setEnabled(true);
         userPrefQuietHours.setSchedule(schedule);
         ZonedDateTime monday10h = dt(2026, 3, 30, 10, 0);
-        assertTrue(NotificationHelper.isQuietHour(monday10h.toInstant(), userPrefQuietHours, tz("Europe/Paris"), "0750010E"));
+        assertTrue(QuietHoursHelper.isQuietHour(monday10h.toInstant(), userPrefQuietHours, tz("Europe/Paris"), "0750010E"));
     }
 
     @Test
@@ -204,7 +204,7 @@ public class NotificationHelperTest {
         userPrefQuietHours.setEnabled(true);
         userPrefQuietHours.setSchedule(schedule);
         ZonedDateTime wednesday10hParis = dt(2026, 4, 1, 10, 0);
-        assertFalse(NotificationHelper.isQuietHour(wednesday10hParis.toInstant(), userPrefQuietHours, tz("Indian/Reunion"), "9710001A"));
+        assertFalse(QuietHoursHelper.isQuietHour(wednesday10hParis.toInstant(), userPrefQuietHours, tz("Indian/Reunion"), "9710001A"));
     }
 
     // --- resolveTimezone priority tests ---
@@ -214,31 +214,31 @@ public class NotificationHelperTest {
     @Test
     public void testResolveTimezone_PreferenceOverridesUai() {
         // explicit tz in preference wins -> UAI never resolved
-        assertEquals(ZoneId.of("Indian/Reunion"), NotificationHelper.resolveTimezone(tz("Indian/Reunion"), "9710001A"));
+        assertEquals(ZoneId.of("Indian/Reunion"), QuietHoursHelper.resolveTimezone(tz("Indian/Reunion"), "9710001A"));
     }
 
     @Test
     public void testResolveTimezone_FallsBackToUai_WhenNoPref() {
         // no preference -> resolves UAI
-        assertEquals(ZoneId.of("America/Guadeloupe"), NotificationHelper.resolveTimezone(null, "9710001A"));
+        assertEquals(ZoneId.of("America/Guadeloupe"), QuietHoursHelper.resolveTimezone(null, "9710001A"));
     }
 
     @Test
     public void testResolveTimezone_FallsBackToUai_WhenNoTzInPref() {
         // preference without timezone -> resolves UAI
-        assertEquals(ZoneId.of("Indian/Reunion"), NotificationHelper.resolveTimezone(new TimezonePreference(), "9740001A"));
+        assertEquals(ZoneId.of("Indian/Reunion"), QuietHoursHelper.resolveTimezone(new TimezonePreference(), "9740001A"));
     }
 
     @Test
     public void testResolveTimezone_NullUai_ReturnsNull() {
         // no preference, null UAI (foreign structure) -> null
-        assertNull(NotificationHelper.resolveTimezone(null, (String) null));
+        assertNull(QuietHoursHelper.resolveTimezone(null, (String) null));
     }
 
     @Test
     public void testResolveTimezone_InvalidTzInPref_FallsBackToUai() {
         // invalid tz string in preference -> falls back to UAI resolution
-        assertEquals(ZoneId.of("Europe/Paris"), NotificationHelper.resolveTimezone(tz("Invalid/Zone"), "0750010E"));
+        assertEquals(ZoneId.of("Europe/Paris"), QuietHoursHelper.resolveTimezone(tz("Invalid/Zone"), "0750010E"));
     }
 
     // --- computeNextSendTime (guards — point d'entrée) ---
@@ -259,7 +259,7 @@ public class NotificationHelperTest {
     @Test
     public void testComputeNextSendTime_NullPref_ReturnsOriginal() {
         Instant t = dt(2026, 3, 30, 22, 30).toInstant();
-        assertEquals(t, NotificationHelper.computeNextSendTime(t, null, (ZoneId) null));
+        assertEquals(t, QuietHoursHelper.computeNextSendTime(t, null, (ZoneId) null));
     }
 
     @Test
@@ -267,7 +267,7 @@ public class NotificationHelperTest {
         Instant t = dt(2026, 3, 30, 22, 30).toInstant();
         QuietHoursPreference pref = new QuietHoursPreference(); // enabled=false
         pref.setSchedule(fullSchedule(22, 23));
-        assertEquals(t, NotificationHelper.computeNextSendTime(t, pref, ZoneId.of("Europe/Paris")));
+        assertEquals(t, QuietHoursHelper.computeNextSendTime(t, pref, ZoneId.of("Europe/Paris")));
     }
 
     @Test
@@ -276,7 +276,7 @@ public class NotificationHelperTest {
         QuietHoursPreference pref = new QuietHoursPreference();
         pref.setEnabled(true);
         // schedule stays null
-        assertEquals(t, NotificationHelper.computeNextSendTime(t, pref, ZoneId.of("Europe/Paris")));
+        assertEquals(t, QuietHoursHelper.computeNextSendTime(t, pref, ZoneId.of("Europe/Paris")));
     }
 
     @Test
@@ -285,7 +285,7 @@ public class NotificationHelperTest {
         QuietHoursPreference pref = new QuietHoursPreference();
         pref.setEnabled(true);
         pref.setSchedule(fullSchedule(22, 23));
-        assertEquals(t, NotificationHelper.computeNextSendTime(t, pref, (ZoneId) null));
+        assertEquals(t, QuietHoursHelper.computeNextSendTime(t, pref, (ZoneId) null));
     }
 
     // --- computeNextSendTime (moteur pur ZonedDateTime, int[][]) ---
@@ -297,7 +297,7 @@ public class NotificationHelperTest {
         int[][] schedule = new int[7][];
         schedule[0] = new int[]{22, 23}; // Monday: only 22h-23h quiet
         for (int i = 1; i < 7; i++) schedule[i] = new int[]{};
-        Instant result = NotificationHelper.computeNextSendTime(localTime, schedule);
+        Instant result = QuietHoursHelper.computeNextSendTime(localTime, schedule);
         assertEquals(localTime.toInstant(), result);
     }
 
@@ -310,7 +310,7 @@ public class NotificationHelperTest {
         for (int i = 1; i < 7; i++) schedule[i] = new int[]{};
         // Expected: Tuesday 00:00 Europe/Paris
         ZonedDateTime expected = dt(2026, 3, 31, 0, 0);
-        assertEquals(expected.toInstant(), NotificationHelper.computeNextSendTime(localTime, schedule));
+        assertEquals(expected.toInstant(), QuietHoursHelper.computeNextSendTime(localTime, schedule));
     }
 
     @Test
@@ -322,7 +322,7 @@ public class NotificationHelperTest {
         schedule[5] = new int[]{0, 1, 2}; // Saturday
         for (int i = 0; i < 7; i++) if (schedule[i] == null) schedule[i] = new int[]{};
         ZonedDateTime expected = dt(2026, 3, 28, 3, 0); // Saturday 3h
-        assertEquals(expected.toInstant(), NotificationHelper.computeNextSendTime(localTime, schedule));
+        assertEquals(expected.toInstant(), QuietHoursHelper.computeNextSendTime(localTime, schedule));
     }
 
     @Test
@@ -333,7 +333,7 @@ public class NotificationHelperTest {
         schedule[0] = new int[]{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23}; // Monday full
         for (int i = 1; i < 7; i++) schedule[i] = new int[]{};
         ZonedDateTime expected = dt(2026, 3, 31, 0, 0); // Tuesday 00:00
-        assertEquals(expected.toInstant(), NotificationHelper.computeNextSendTime(localTime, schedule));
+        assertEquals(expected.toInstant(), QuietHoursHelper.computeNextSendTime(localTime, schedule));
     }
 
     @Test
@@ -343,7 +343,7 @@ public class NotificationHelperTest {
         int[] allHours = new int[]{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23};
         int[][] schedule = new int[7][];
         for (int i = 0; i < 7; i++) schedule[i] = allHours;
-        assertNull(NotificationHelper.computeNextSendTime(localTime, schedule));
+        assertNull(QuietHoursHelper.computeNextSendTime(localTime, schedule));
     }
 
     @Test
@@ -353,7 +353,7 @@ public class NotificationHelperTest {
         int[][] schedule = new int[7][];
         schedule[0] = new int[]{0, 1, 2, 3, 4, 5, 6, 7}; // 0h-7h quiet, 8h not
         for (int i = 1; i < 7; i++) schedule[i] = new int[]{};
-        assertEquals(localTime.toInstant(), NotificationHelper.computeNextSendTime(localTime, schedule));
+        assertEquals(localTime.toInstant(), QuietHoursHelper.computeNextSendTime(localTime, schedule));
     }
 
     @Test
@@ -364,7 +364,7 @@ public class NotificationHelperTest {
         schedule[0] = new int[]{0, 1, 2, 3, 4, 5, 6, 7}; // 0h-7h quiet
         for (int i = 1; i < 7; i++) schedule[i] = new int[]{};
         ZonedDateTime expected = dt(2026, 3, 30, 8, 0);
-        assertEquals(expected.toInstant(), NotificationHelper.computeNextSendTime(localTime, schedule));
+        assertEquals(expected.toInstant(), QuietHoursHelper.computeNextSendTime(localTime, schedule));
     }
 
     @Test
@@ -374,7 +374,7 @@ public class NotificationHelperTest {
         int[][] schedule = new int[7][];
         schedule[0] = null; // null treated as not quiet
         for (int i = 1; i < 7; i++) schedule[i] = new int[]{};
-        assertEquals(localTime.toInstant(), NotificationHelper.computeNextSendTime(localTime, schedule));
+        assertEquals(localTime.toInstant(), QuietHoursHelper.computeNextSendTime(localTime, schedule));
     }
 
     @Test
@@ -389,6 +389,6 @@ public class NotificationHelperTest {
         for (int i = 0; i < 6; i++) schedule[i] = new int[]{};
         // After DST, 2h doesn't exist: plusHours(1) from truncated 1h gives 3h directly
         ZonedDateTime expected = ZonedDateTime.of(2026, 3, 29, 3, 0, 0, 0, ZoneId.of("Europe/Paris"));
-        assertEquals(expected.toInstant(), NotificationHelper.computeNextSendTime(localTime, schedule));
+        assertEquals(expected.toInstant(), QuietHoursHelper.computeNextSendTime(localTime, schedule));
     }
 }

--- a/timeline/src/test/java/org/entcore/timeline/controllers/helper/NotificationHelperTest.java
+++ b/timeline/src/test/java/org/entcore/timeline/controllers/helper/NotificationHelperTest.java
@@ -1,0 +1,243 @@
+package org.entcore.timeline.controllers.helper;
+
+import io.vertx.core.json.JsonObject;
+import org.entcore.common.user.dto.QuietHoursPreference;
+import org.entcore.common.user.dto.TimezonePreference;
+import org.junit.Test;
+import java.time.*;
+import static org.junit.Assert.*;
+
+public class NotificationHelperTest {
+
+    private static ZonedDateTime dt(int year, int month, int day, int hour, int minute) {
+        return ZonedDateTime.of(year, month, day, hour, minute, 0, 0, ZoneId.of("Europe/Paris"));
+    }
+
+    private static TimezonePreference tz(String timezone) {
+        TimezonePreference pref = new TimezonePreference();
+        pref.setTimezone(timezone);
+        return pref;
+    }
+
+    // --- isQuietHour(ZonedDateTime, int[][]) ---
+
+    @Test
+    public void testIsQuietHour_HourInSchedule_Quiet() {
+        // Monday 10:00 is in schedule -> quiet
+        int[][] schedule = new int[7][];
+        schedule[0] = new int[]{10, 11, 12};
+        for (int i = 1; i < 7; i++) schedule[i] = new int[]{};
+        assertTrue(NotificationHelper.isQuietHour(dt(2026, 3, 30, 10, 0), schedule));
+    }
+
+    @Test
+    public void testIsQuietHour_HourNotInSchedule_NotQuiet() {
+        // Monday 09:00 not in schedule -> not quiet
+        int[][] schedule = new int[7][];
+        schedule[0] = new int[]{10, 11, 12};
+        for (int i = 1; i < 7; i++) schedule[i] = new int[]{};
+        assertFalse(NotificationHelper.isQuietHour(dt(2026, 3, 30, 9, 0), schedule));
+    }
+
+    @Test
+    public void testIsQuietHour_EmptyDayArray_NotQuiet() {
+        // Wednesday has empty array -> not quiet
+        int[][] schedule = new int[7][];
+        for (int i = 0; i < 7; i++) schedule[i] = new int[]{};
+        assertFalse(NotificationHelper.isQuietHour(dt(2026, 4, 1, 10, 0), schedule));
+    }
+
+    @Test
+    public void testIsQuietHour_NullSchedule_NotQuiet() {
+        // null schedule -> not quiet (no preference = no filtering)
+        assertFalse(NotificationHelper.isQuietHour(dt(2026, 4, 1, 3, 0), null));
+    }
+
+    @Test
+    public void testIsQuietHour_TooShortSchedule_NotQuiet() {
+        // schedule has 3 days, Sunday (dayIndex=6) out of bounds -> not quiet
+        int[][] schedule = new int[3][];
+        for (int i = 0; i < 3; i++) schedule[i] = new int[]{};
+        assertFalse(NotificationHelper.isQuietHour(dt(2026, 3, 29, 12, 0), schedule));
+    }
+
+    // --- getTimezoneFromUai tests ---
+
+    @Test
+    public void testGetTz_Null() {
+        // null UAI (foreign structure) -> no timezone -> quiet hours do not apply
+        assertNull(NotificationHelper.getTimezoneFromUai(null));
+    }
+
+    @Test
+    public void testGetTz_TooShort() {
+        assertEquals(ZoneId.of("Europe/Paris"), NotificationHelper.getTimezoneFromUai("07"));
+    }
+
+    @Test
+    public void testGetTz_CorseDuSud() {
+        // Corse-du-Sud UAIs start with 620 -> default -> Europe/Paris
+        assertEquals(ZoneId.of("Europe/Paris"), NotificationHelper.getTimezoneFromUai("6200060W"));
+    }
+
+    @Test
+    public void testGetTz_HauteCorse() {
+        // Haute-Corse UAIs start with 720 -> default -> Europe/Paris
+        assertEquals(ZoneId.of("Europe/Paris"), NotificationHelper.getTimezoneFromUai("7200062E"));
+    }
+
+    @Test
+    public void testGetTz_Metropole() {
+        assertEquals(ZoneId.of("Europe/Paris"), NotificationHelper.getTimezoneFromUai("0750010E"));
+    }
+
+    @Test
+    public void testGetTz_Guadeloupe() {
+        assertEquals(ZoneId.of("America/Guadeloupe"), NotificationHelper.getTimezoneFromUai("9710001A"));
+    }
+
+    @Test
+    public void testGetTz_Martinique() {
+        assertEquals(ZoneId.of("America/Martinique"), NotificationHelper.getTimezoneFromUai("9720001A"));
+    }
+
+    @Test
+    public void testGetTz_Guyane() {
+        assertEquals(ZoneId.of("America/Cayenne"), NotificationHelper.getTimezoneFromUai("9730001A"));
+    }
+
+    @Test
+    public void testGetTz_Reunion() {
+        assertEquals(ZoneId.of("Indian/Reunion"), NotificationHelper.getTimezoneFromUai("9740001A"));
+    }
+
+    @Test
+    public void testGetTz_Miquelon() {
+        assertEquals(ZoneId.of("America/Miquelon"), NotificationHelper.getTimezoneFromUai("9750001A"));
+    }
+
+    @Test
+    public void testGetTz_Mayotte() {
+        assertEquals(ZoneId.of("Indian/Mayotte"), NotificationHelper.getTimezoneFromUai("9760001A"));
+    }
+
+    @Test
+    public void testGetTz_SaintBarthelemy() {
+        assertEquals(ZoneId.of("America/St_Barthelemy"), NotificationHelper.getTimezoneFromUai("9770001A"));
+    }
+
+    @Test
+    public void testGetTz_SaintMartin() {
+        assertEquals(ZoneId.of("America/Marigot"), NotificationHelper.getTimezoneFromUai("9780001A"));
+    }
+
+    @Test
+    public void testGetTz_WallisFutuna() {
+        assertEquals(ZoneId.of("Pacific/Wallis"), NotificationHelper.getTimezoneFromUai("9860001A"));
+    }
+
+    @Test
+    public void testGetTz_Polynesie() {
+        assertEquals(ZoneId.of("Pacific/Tahiti"), NotificationHelper.getTimezoneFromUai("9870001A"));
+    }
+
+    @Test
+    public void testGetTz_NouvelleCaledonie() {
+        assertEquals(ZoneId.of("Pacific/Noumea"), NotificationHelper.getTimezoneFromUai("9880001A"));
+    }
+
+    @Test
+    public void testGetTz_NonNumeric() {
+        // Non-numeric UAI should fall back to Europe/Paris via NumberFormatException catch
+        assertEquals(ZoneId.of("Europe/Paris"), NotificationHelper.getTimezoneFromUai("ABCDEFG"));
+    }
+
+    // --- isQuietHour(Instant, QuietHoursPreference, String) ---
+
+    @Test
+    public void testIsQuietHour_NoPreference_NoUai_NotQuiet() {
+        // no preference, no UAI -> null zone -> not quiet (foreign structure)
+        assertFalse(NotificationHelper.isQuietHour(Instant.now(), null, null, null));
+    }
+
+    @Test
+    public void testIsQuietHour_NoPreference_WithUai_NotQuiet() {
+        // no preference -> no schedule -> not quiet regardless of UAI or time
+        ZonedDateTime wednesday10h = dt(2026, 4, 1, 10, 0);
+        assertFalse(NotificationHelper.isQuietHour(wednesday10h.toInstant(), null, null, "0750010E"));
+    }
+
+    @Test
+    public void testIsQuietHour_EnabledFalse_NotQuiet() {
+        // enabled = false (default) -> not quiet regardless of schedule
+        int[][] schedule = new int[7][];
+        schedule[0] = new int[]{10};
+        for (int i = 1; i < 7; i++) schedule[i] = new int[]{};
+        QuietHoursPreference userPrefQuietHours = new QuietHoursPreference();
+        userPrefQuietHours.setSchedule(schedule);
+        // enabled stays false (primitive default)
+        ZonedDateTime monday10h = dt(2026, 3, 30, 10, 0);
+        assertFalse(NotificationHelper.isQuietHour(monday10h.toInstant(), userPrefQuietHours, tz("Europe/Paris"), "0750010E"));
+    }
+
+    @Test
+    public void testIsQuietHour_WithSchedulePreference_UsesSchedule() {
+        // enabled = true + schedule with Monday 10h -> quiet
+        int[][] schedule = new int[7][];
+        schedule[0] = new int[]{10};
+        for (int i = 1; i < 7; i++) schedule[i] = new int[]{};
+        QuietHoursPreference userPrefQuietHours = new QuietHoursPreference();
+        userPrefQuietHours.setEnabled(true);
+        userPrefQuietHours.setSchedule(schedule);
+        ZonedDateTime monday10h = dt(2026, 3, 30, 10, 0);
+        assertTrue(NotificationHelper.isQuietHour(monday10h.toInstant(), userPrefQuietHours, tz("Europe/Paris"), "0750010E"));
+    }
+
+    @Test
+    public void testIsQuietHour_PreferenceTzOverridesUai() {
+        // enabled = true + preference tz (Reunion) overrides Guadeloupe UAI
+        // Wednesday 10:00 Paris = 14:00 Reunion -> 14h not in schedule -> not quiet
+        int[][] schedule = new int[7][];
+        schedule[2] = new int[]{22, 23, 0, 1}; // Wednesday quiet hours (not 14h)
+        for (int i = 0; i < 7; i++) if (schedule[i] == null) schedule[i] = new int[]{};
+        QuietHoursPreference userPrefQuietHours = new QuietHoursPreference();
+        userPrefQuietHours.setEnabled(true);
+        userPrefQuietHours.setSchedule(schedule);
+        ZonedDateTime wednesday10hParis = dt(2026, 4, 1, 10, 0);
+        assertFalse(NotificationHelper.isQuietHour(wednesday10hParis.toInstant(), userPrefQuietHours, tz("Indian/Reunion"), "9710001A"));
+    }
+
+    // --- resolveTimezone priority tests ---
+
+    // --- resolveTimezone(TimezonePreference, String) ---
+
+    @Test
+    public void testResolveTimezone_PreferenceOverridesUai() {
+        // explicit tz in preference wins -> UAI never resolved
+        assertEquals(ZoneId.of("Indian/Reunion"), NotificationHelper.resolveTimezone(tz("Indian/Reunion"), "9710001A"));
+    }
+
+    @Test
+    public void testResolveTimezone_FallsBackToUai_WhenNoPref() {
+        // no preference -> resolves UAI
+        assertEquals(ZoneId.of("America/Guadeloupe"), NotificationHelper.resolveTimezone(null, "9710001A"));
+    }
+
+    @Test
+    public void testResolveTimezone_FallsBackToUai_WhenNoTzInPref() {
+        // preference without timezone -> resolves UAI
+        assertEquals(ZoneId.of("Indian/Reunion"), NotificationHelper.resolveTimezone(new TimezonePreference(), "9740001A"));
+    }
+
+    @Test
+    public void testResolveTimezone_NullUai_ReturnsNull() {
+        // no preference, null UAI (foreign structure) -> null
+        assertNull(NotificationHelper.resolveTimezone(null, (String) null));
+    }
+
+    @Test
+    public void testResolveTimezone_InvalidTzInPref_FallsBackToUai() {
+        // invalid tz string in preference -> falls back to UAI resolution
+        assertEquals(ZoneId.of("Europe/Paris"), NotificationHelper.resolveTimezone(tz("Invalid/Zone"), "0750010E"));
+    }
+}

--- a/timeline/src/test/java/org/entcore/timeline/controllers/helper/NotificationHelperTest.java
+++ b/timeline/src/test/java/org/entcore/timeline/controllers/helper/NotificationHelperTest.java
@@ -240,4 +240,155 @@ public class NotificationHelperTest {
         // invalid tz string in preference -> falls back to UAI resolution
         assertEquals(ZoneId.of("Europe/Paris"), NotificationHelper.resolveTimezone(tz("Invalid/Zone"), "0750010E"));
     }
+
+    // --- computeNextSendTime (guards — point d'entrée) ---
+
+    private static QuietHoursPreference enabledPref(int[]... days) {
+        QuietHoursPreference pref = new QuietHoursPreference();
+        pref.setEnabled(true);
+        if (days.length == 7) pref.setSchedule(days);
+        return pref;
+    }
+
+    private static int[][] fullSchedule(int... hours) {
+        int[][] s = new int[7][];
+        for (int i = 0; i < 7; i++) s[i] = hours;
+        return s;
+    }
+
+    @Test
+    public void testComputeNextSendTime_NullPref_ReturnsOriginal() {
+        Instant t = dt(2026, 3, 30, 22, 30).toInstant();
+        assertEquals(t, NotificationHelper.computeNextSendTime(t, null, (ZoneId) null));
+    }
+
+    @Test
+    public void testComputeNextSendTime_NotEnabled_ReturnsOriginal() {
+        Instant t = dt(2026, 3, 30, 22, 30).toInstant();
+        QuietHoursPreference pref = new QuietHoursPreference(); // enabled=false
+        pref.setSchedule(fullSchedule(22, 23));
+        assertEquals(t, NotificationHelper.computeNextSendTime(t, pref, ZoneId.of("Europe/Paris")));
+    }
+
+    @Test
+    public void testComputeNextSendTime_NullSchedule_ReturnsOriginal() {
+        Instant t = dt(2026, 3, 30, 22, 30).toInstant();
+        QuietHoursPreference pref = new QuietHoursPreference();
+        pref.setEnabled(true);
+        // schedule stays null
+        assertEquals(t, NotificationHelper.computeNextSendTime(t, pref, ZoneId.of("Europe/Paris")));
+    }
+
+    @Test
+    public void testComputeNextSendTime_NullZone_ReturnsOriginal() {
+        Instant t = dt(2026, 3, 30, 22, 30).toInstant();
+        QuietHoursPreference pref = new QuietHoursPreference();
+        pref.setEnabled(true);
+        pref.setSchedule(fullSchedule(22, 23));
+        assertEquals(t, NotificationHelper.computeNextSendTime(t, pref, (ZoneId) null));
+    }
+
+    // --- computeNextSendTime (moteur pur ZonedDateTime, int[][]) ---
+
+    @Test
+    public void testComputeNextSendTime_HourNotQuiet_ReturnsOriginal() {
+        // Monday 10:37, hour 10 not in schedule -> original instant unchanged (not truncated)
+        ZonedDateTime localTime = dt(2026, 3, 30, 10, 37);
+        int[][] schedule = new int[7][];
+        schedule[0] = new int[]{22, 23}; // Monday: only 22h-23h quiet
+        for (int i = 1; i < 7; i++) schedule[i] = new int[]{};
+        Instant result = NotificationHelper.computeNextSendTime(localTime, schedule);
+        assertEquals(localTime.toInstant(), result);
+    }
+
+    @Test
+    public void testComputeNextSendTime_HourQuiet_ReturnsNextHour() {
+        // Monday 22:37 is quiet, 23h also quiet, next non-quiet = Tuesday 00:00 if not quiet
+        ZonedDateTime localTime = dt(2026, 3, 30, 22, 37);
+        int[][] schedule = new int[7][];
+        schedule[0] = new int[]{22, 23}; // Monday: 22h-23h quiet
+        for (int i = 1; i < 7; i++) schedule[i] = new int[]{};
+        // Expected: Tuesday 00:00 Europe/Paris
+        ZonedDateTime expected = dt(2026, 3, 31, 0, 0);
+        assertEquals(expected.toInstant(), NotificationHelper.computeNextSendTime(localTime, schedule));
+    }
+
+    @Test
+    public void testComputeNextSendTime_MidnightSpanning() {
+        // Friday 23:30, schedule [22,23,0,1,2] -> next non-quiet hour = 3h Saturday
+        ZonedDateTime localTime = dt(2026, 3, 27, 23, 30); // Friday
+        int[][] schedule = new int[7][];
+        schedule[4] = new int[]{22, 23}; // Friday
+        schedule[5] = new int[]{0, 1, 2}; // Saturday
+        for (int i = 0; i < 7; i++) if (schedule[i] == null) schedule[i] = new int[]{};
+        ZonedDateTime expected = dt(2026, 3, 28, 3, 0); // Saturday 3h
+        assertEquals(expected.toInstant(), NotificationHelper.computeNextSendTime(localTime, schedule));
+    }
+
+    @Test
+    public void testComputeNextSendTime_FullDayQuiet_SkipsToNextDay() {
+        // Monday entirely quiet -> first non-quiet hour is Tuesday 00:00
+        ZonedDateTime localTime = dt(2026, 3, 30, 14, 0);
+        int[][] schedule = new int[7][];
+        schedule[0] = new int[]{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23}; // Monday full
+        for (int i = 1; i < 7; i++) schedule[i] = new int[]{};
+        ZonedDateTime expected = dt(2026, 3, 31, 0, 0); // Tuesday 00:00
+        assertEquals(expected.toInstant(), NotificationHelper.computeNextSendTime(localTime, schedule));
+    }
+
+    @Test
+    public void testComputeNextSendTime_AllQuiet168Slots_ReturnsNull() {
+        // Every hour of every day is quiet -> no slot found -> null
+        ZonedDateTime localTime = dt(2026, 3, 30, 10, 0);
+        int[] allHours = new int[]{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23};
+        int[][] schedule = new int[7][];
+        for (int i = 0; i < 7; i++) schedule[i] = allHours;
+        assertNull(NotificationHelper.computeNextSendTime(localTime, schedule));
+    }
+
+    @Test
+    public void testComputeNextSendTime_ExactlyAtQuietBoundary_NotQuiet() {
+        // Monday 08:00 exactly, hour 8 not in schedule -> original instant unchanged
+        ZonedDateTime localTime = dt(2026, 3, 30, 8, 0);
+        int[][] schedule = new int[7][];
+        schedule[0] = new int[]{0, 1, 2, 3, 4, 5, 6, 7}; // 0h-7h quiet, 8h not
+        for (int i = 1; i < 7; i++) schedule[i] = new int[]{};
+        assertEquals(localTime.toInstant(), NotificationHelper.computeNextSendTime(localTime, schedule));
+    }
+
+    @Test
+    public void testComputeNextSendTime_ExactlyAtQuietHour_Reports() {
+        // Monday 07:59 is in quiet hour 7 -> report to 8h
+        ZonedDateTime localTime = dt(2026, 3, 30, 7, 59);
+        int[][] schedule = new int[7][];
+        schedule[0] = new int[]{0, 1, 2, 3, 4, 5, 6, 7}; // 0h-7h quiet
+        for (int i = 1; i < 7; i++) schedule[i] = new int[]{};
+        ZonedDateTime expected = dt(2026, 3, 30, 8, 0);
+        assertEquals(expected.toInstant(), NotificationHelper.computeNextSendTime(localTime, schedule));
+    }
+
+    @Test
+    public void testComputeNextSendTime_NullDayInSchedule_TreatedAsNotQuiet() {
+        // schedule[0] = null for Monday -> not quiet, return original
+        ZonedDateTime localTime = dt(2026, 3, 30, 10, 0);
+        int[][] schedule = new int[7][];
+        schedule[0] = null; // null treated as not quiet
+        for (int i = 1; i < 7; i++) schedule[i] = new int[]{};
+        assertEquals(localTime.toInstant(), NotificationHelper.computeNextSendTime(localTime, schedule));
+    }
+
+    @Test
+    public void testComputeNextSendTime_DST_SpringForward() {
+        // Europe/Paris: clocks go forward at 2h->3h on last Sunday of March
+        // Notif at 01:30 local, quiet hours [1,2], next non-quiet = 3h (but 2h doesn't exist that night)
+        // ZonedDateTime.plusHours(1) from 1h30 gives 3h30 (2h skipped by DST)
+        // schedule[6] = [1, 2] (Sunday) -> hour 1 is quiet, hour 2 doesn't exist (DST), cursor lands on 3h
+        ZonedDateTime localTime = ZonedDateTime.of(2026, 3, 29, 1, 30, 0, 0, ZoneId.of("Europe/Paris")); // Sunday
+        int[][] schedule = new int[7][];
+        schedule[6] = new int[]{1, 2}; // Sunday: quiet 1h and 2h
+        for (int i = 0; i < 6; i++) schedule[i] = new int[]{};
+        // After DST, 2h doesn't exist: plusHours(1) from truncated 1h gives 3h directly
+        ZonedDateTime expected = ZonedDateTime.of(2026, 3, 29, 3, 0, 0, 0, ZoneId.of("Europe/Paris"));
+        assertEquals(expected.toInstant(), NotificationHelper.computeNextSendTime(localTime, schedule));
+    }
 }


### PR DESCRIPTION
# Description

- Préférences utilisateur (tz, managed, enabled et schedule)
- Fallback TZ avec l'UAI
- Vérification de la plage silencieuse (drop pour le moment)

Le code de fallback de la TZ avec l'UAI est probablement à mettre ailleurs car il peut-être réutilisé, je suis preneur si vous avez des sugestions.

## Fixes

[#COCO-5325](https://edifice-community.atlassian.net/browse/COCO-5325)
[#COCO-5609](https://edifice-community.atlassian.net/browse/COCO-5609)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [x] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: