### PR TITLE
fix(common): #COCO-5693 add missing resource id in share notifications

### DIFF
--- a/common/src/main/java/org/entcore/common/controller/ControllerHelper.java
+++ b/common/src/main/java/org/entcore/common/controller/ControllerHelper.java
@@ -337,24 +337,21 @@ public abstract class ControllerHelper extends BaseController implements Shareab
 				.put("resourceUri", pathPrefix + "/" + resource);
 		}
 		final JsonObject params = p;
-		crudService.retrieve(resource, new Handler<Either<String, JsonObject>>() {
-			@Override
-			public void handle(Either<String, JsonObject> r) {
-				if (r.isRight()) {
-					String attr = (resourceNameAttribute != null && !resourceNameAttribute.trim().isEmpty()) ?
-							resourceNameAttribute : "name";
-					params.put("resourceName", r.right().getValue().getString(attr, ""));
-					final Object preview = params.remove("preview");
-					if (preview instanceof JsonObject) {
-						notification.notifyTimeline(request, notificationName, user, recipients, null, null, params, false, (JsonObject) preview);
-					} else {
-						notification.notifyTimeline(request, notificationName, user, recipients, params);
-					}
-				} else {
-					log.error("Unable to send timeline notification : missing name on resource " + resource);
-				}
-			}
-		});
+		crudService.retrieve(resource, r -> {
+            if (r.isRight()) {
+                String attr = (resourceNameAttribute != null && !resourceNameAttribute.trim().isEmpty()) ?
+                        resourceNameAttribute : "name";
+                params.put("resourceName", r.right().getValue().getString(attr, ""));
+                final Object preview = params.remove("preview");
+                if (preview instanceof JsonObject) {
+                    notification.notifyTimeline(request, notificationName, user, recipients, resource, null, params, false, (JsonObject) preview);
+                } else {
+                    notification.notifyTimeline(request, notificationName, user, recipients, resource, params );
+                }
+            } else {
+                log.error("Unable to send timeline notification : missing name on resource " + resource);
+            }
+        });
 	}
 
 	protected void shareResource(final HttpServerRequest request, final String notificationName,


### PR DESCRIPTION
# Description

Notification generate by shareService doesn't send the resouce id in the notification

## Fixes

[COCO-5693](https://edifice-community.atlassian.net/browse/COCO-5693)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley:

[COCO-5693]: https://edifice-community.atlassian.net/browse/COCO-5693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ