### PR TITLE
fix:#COCO-5070-routing-and-vite-plugins-for-i18n

### DIFF
--- a/timeline/frontend/src/routes/index.tsx
+++ b/timeline/frontend/src/routes/index.tsx
@@ -8,7 +8,7 @@ import { manageRedirections } from './redirections';
 const routes = (_queryClient: QueryClient): RouteObject[] => [
   /* Main route */
   {
-    path: '/timeline',
+    path: '/',
     async lazy() {
       const { loader, Root: Component } = await import('~/routes/root');
       return {

--- a/timeline/frontend/src/routes/index.tsx
+++ b/timeline/frontend/src/routes/index.tsx
@@ -25,7 +25,7 @@ const routes = (_queryClient: QueryClient): RouteObject[] => [
   },
 ];
 
-export const basename = import.meta.env.PROD ? '/timeline' : '/';
+export const basename = import.meta.env.PROD ? '/timeline/timeline' : '/';
 
 export const router = (queryClient: QueryClient) => {
   const redirectPath = manageRedirections();

--- a/timeline/frontend/src/routes/redirections/index.tsx
+++ b/timeline/frontend/src/routes/redirections/index.tsx
@@ -3,7 +3,6 @@ export const manageRedirections = (): string | null => {
   const pathLocation = window.location.pathname;
 
   if (
-    pathLocation === '/' ||
     pathLocation === '/timeline' ||
     pathLocation === '/timeline/' ||
     pathLocation === '/timeline/timeline'

--- a/timeline/frontend/vite.config.ts
+++ b/timeline/frontend/vite.config.ts
@@ -1,44 +1,22 @@
 import react from '@vitejs/plugin-react';
 import { resolve } from 'node:path';
-import { loadEnv, ProxyOptions } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
+import { createDevProxyConfig } from './vite/plugins/devProxy';
 
 // https://vitejs.dev/config/
 export default ({ mode }: { mode: string }) => {
-  // Checking environment files
-  const envFile = loadEnv(mode, process.cwd());
-  const envs = { ...process.env, ...envFile };
-  const hasEnvFile = Object.keys(envFile).length;
-
-  // Proxy variables
-  const headers = hasEnvFile
-    ? {
-        'set-cookie': [
-          `oneSessionId=${envs.VITE_ONE_SESSION_ID}`,
-          `XSRF-TOKEN=${envs.VITE_XSRF_TOKEN}`,
-        ],
-        'Cache-Control': 'public, max-age=300',
-      }
-    : {};
-
-  const proxyObj: ProxyOptions = hasEnvFile
-    ? {
-        target: envs.VITE_RECETTE,
-        changeOrigin: true,
-        headers: {
-          cookie: `oneSessionId=${envs.VITE_ONE_SESSION_ID};authenticated=true; XSRF-TOKEN=${envs.VITE_XSRF_TOKEN}`,
-        },
-        configure: (proxy) => {
-          proxy.on('proxyReq', (proxyReq) => {
-            proxyReq.setHeader('X-XSRF-TOKEN', envs.VITE_XSRF_TOKEN || '');
-          });
-        },
-      }
-    : {
-        target: 'http://localhost:8090',
-        changeOrigin: false,
-      };
+  const { headers, proxy } = createDevProxyConfig({
+    mode,
+    routes: [
+      '/conf/public',
+      '^/(?=applications-list)',
+      '^/(?=assets)',
+      '^/(?=theme|locale|i18n|skin)',
+      '^/(?=auth|appregistry|cas|userbook|directory|communication|conversation|portal|session|timeline|workspace|infra)',
+      '^/calendar/(?!public/)',
+    ],
+  });
 
   return defineConfig({
     base: mode === 'production' ? '/timeline' : '',
@@ -55,27 +33,10 @@ export default ({ mode }: { mode: string }) => {
     },
 
     server: {
-      fs: {
-        /**
-         * Allow the server to access the node_modules folder (for the images)
-         * This is a solution to allow the server to access the images and fonts of the bootstrap package for 1D theme
-         */
-        allow: ['../../'],
-      },
-      proxy: {
-        '/applications-list': proxyObj,
-        '/conf/public': proxyObj,
-        '^/(?=help-1d|help-2d)': proxyObj,
-        '^/(?=assets)': proxyObj,
-        '^/(?=theme|locale|i18n|skin)': proxyObj,
-        '^/(?=auth|appregistry|cas|userbook|directory|communication|conversation|portal|session|timeline|workspace|infra)':
-          proxyObj,
-        '/explorer': proxyObj,
-        '/timeline': proxyObj,
-      },
       port: 4200,
-      headers,
       host: 'localhost',
+      headers,
+      proxy,
     },
 
     preview: {

--- a/timeline/frontend/vite/plugins/devProxy.ts
+++ b/timeline/frontend/vite/plugins/devProxy.ts
@@ -18,7 +18,7 @@ export type CreateDevProxyOptions = {
 };
 
 export type DevProxyConfig = {
-  headers: Record<string, string | string[]>;
+  headers: Record<string, string | string[] | undefined>;
   proxyObj: ProxyOptions;
   proxy: Record<string, ProxyOptions>;
 };

--- a/timeline/frontend/vite/plugins/devProxy.ts
+++ b/timeline/frontend/vite/plugins/devProxy.ts
@@ -1,0 +1,75 @@
+import { loadEnv, type ProxyOptions } from 'vite';
+
+type EnvValues = Record<string, string | undefined>;
+
+export type CreateDevProxyOptions = {
+  /**
+   * Paths/regex-like keys to proxy with the same proxy target/options.
+   */
+  routes: string[];
+  /**
+   * Vite mode used to load env files.
+   */
+  mode: string;
+  /**
+   * Fallback target when env file is missing.
+   */
+  defaultTarget?: string;
+};
+
+export type DevProxyConfig = {
+  headers: Record<string, string | string[]>;
+  proxyObj: ProxyOptions;
+  proxy: Record<string, ProxyOptions>;
+};
+
+/**
+ * Creates reusable dev proxy configuration for Entcore modules.
+ */
+export function createDevProxyConfig({
+  mode,
+  routes,
+  defaultTarget = 'http://localhost:8090',
+}: CreateDevProxyOptions): DevProxyConfig {
+  const envFile = loadEnv(mode, process.cwd());
+  const envs: EnvValues = { ...process.env, ...envFile };
+  const hasEnvFile = Object.keys(envFile).length > 0;
+
+  const setCookie = [
+    `oneSessionId=${envs.VITE_ONE_SESSION_ID ?? ''}`,
+    `XSRF-TOKEN=${envs.VITE_XSRF_TOKEN ?? ''}`,
+    'authenticated=true',
+  ];
+
+  const headers = hasEnvFile
+    ? {
+        'set-cookie': setCookie,
+        'Cache-Control': 'public, max-age=300',
+      }
+    : {};
+
+  const proxyObj: ProxyOptions = hasEnvFile
+    ? {
+        target: envs.VITE_RECETTE,
+        changeOrigin: true,
+        headers: {
+          cookie: `oneSessionId=${envs.VITE_ONE_SESSION_ID};authenticated=true; XSRF-TOKEN=${envs.VITE_XSRF_TOKEN}`,
+        },
+        configure: (proxy) => {
+          proxy.on('proxyReq', (proxyReq) => {
+            proxyReq.setHeader('X-XSRF-TOKEN', envs.VITE_XSRF_TOKEN || '');
+          });
+        },
+      }
+    : {
+        target: defaultTarget,
+        changeOrigin: false,
+      };
+
+  const proxy = routes.reduce<Record<string, ProxyOptions>>((acc, route) => {
+    acc[route] = proxyObj;
+    return acc;
+  }, {});
+
+  return { headers, proxyObj, proxy };
+}

--- a/timeline/frontend/vite/plugins/serveLocalI18n.ts
+++ b/timeline/frontend/vite/plugins/serveLocalI18n.ts
@@ -18,9 +18,15 @@ export const serveLocalI18nPlugin = ({
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
         if (req.url?.startsWith(routePath)) {
-          res.setHeader('Content-Type', 'application/json; charset=utf-8');
-          res.end(readFileSync(resolvedFilePath, 'utf-8'));
-          return;
+          try {
+            const fileContents = readFileSync(resolvedFilePath, 'utf-8');
+            res.setHeader('Content-Type', 'application/json; charset=utf-8');
+            res.end(fileContents);
+            return;
+          } catch (err) {
+            next(err);
+            return;
+          }
         }
         next();
       });

--- a/timeline/frontend/vite/plugins/serveLocalI18n.ts
+++ b/timeline/frontend/vite/plugins/serveLocalI18n.ts
@@ -11,11 +11,15 @@ type ServeLocalJsonPluginOptions = {
 export const serveLocalI18nPlugin = ({
   routePath,
   filePath,
+  rootDir,
 }: ServeLocalJsonPluginOptions): Plugin => {
-  const resolvedFilePath = resolve(process.cwd(), filePath);
   return {
     name: `serve-local-i18n`,
     configureServer(server) {
+      const resolvedFilePath = resolve(
+        rootDir ?? server.config.root ?? process.cwd(),
+        filePath,
+      );
       server.middlewares.use((req, res, next) => {
         if (req.url?.startsWith(routePath)) {
           try {

--- a/timeline/frontend/vite/plugins/serveLocalI18n.ts
+++ b/timeline/frontend/vite/plugins/serveLocalI18n.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { Plugin } from 'vite';
+
+type ServeLocalJsonPluginOptions = {
+  routePath: string;
+  filePath: string;
+  rootDir?: string;
+};
+
+export const serveLocalI18nPlugin = ({
+  routePath,
+  filePath,
+}: ServeLocalJsonPluginOptions): Plugin => {
+  const resolvedFilePath = resolve(process.cwd(), filePath);
+  return {
+    name: `serve-local-i18n`,
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.url?.startsWith(routePath)) {
+          res.setHeader('Content-Type', 'application/json; charset=utf-8');
+          res.end(readFileSync(resolvedFilePath, 'utf-8'));
+          return;
+        }
+        next();
+      });
+    },
+  };
+};


### PR DESCRIPTION
J'ai ajusté l’initialisation de l’app react.
il y avait un probleme de redirection qui nous emmenait sur /timeline (et provoquait une 404 au rafraichissement de la page)
 et j’en ai profité pour ajouter le plugin vite 
 - pour recuperé les traductions 
 - pour le proxy (qui fonctionnait mais été inclus dans le vite.config.ts) 


https://edifice-community.atlassian.net/browse/COCO-5070