### PR TITLE
fix(timeline): #COCO-5724 performance issue on sendImmediateMail

### DIFF
--- a/timeline/src/main/java/org/entcore/timeline/controllers/TimelineLambda.java
+++ b/timeline/src/main/java/org/entcore/timeline/controllers/TimelineLambda.java
@@ -115,9 +115,31 @@ public final class TimelineLambda {
 		return timelineI18n;
 	}
 
-	public static String translate(String language,  String key, HttpServerRequest request,
+	public static String translate( String language,  String key, String domain,
 									   final Map<String, String> eventsI18n,
 									   final Map<String, JsonObject> lazyEventsI18n) {
+		JsonObject timelineI18n;
+		if (!lazyEventsI18n.containsKey(language)) {
+			timelineI18n = computeTimeLineI18n(language, eventsI18n, lazyEventsI18n);
+		} else {
+			String eventI18n = eventsI18n.get(language.split(",")[0].split("-")[0]);
+			if( eventI18n != null && (!i18nEventsHash.containsKey(language) || eventI18n.hashCode() != i18nEventsHash.get(language))) {
+				computeTimeLineI18n(language, eventsI18n, lazyEventsI18n);
+			}
+			timelineI18n = lazyEventsI18n.get(language);
+		}
+		timelineI18n = lazyEventsI18n.get(language);
+		// #46383, translations from the theme takes precedence over those from the domain
+		String translatedContents = I18n.getInstance().translate(key, domain, null, I18n.getLocale(language));
+		if (translatedContents.equals(key)) {
+			translatedContents = timelineI18n.getString(key, key);
+		}
+		return translatedContents;
+	}
+
+	public static String translate(String language,  String key, HttpServerRequest request,
+								   final Map<String, String> eventsI18n,
+								   final Map<String, JsonObject> lazyEventsI18n) {
 		JsonObject timelineI18n;
 		if (!lazyEventsI18n.containsKey(language)) {
 			timelineI18n = computeTimeLineI18n(language, eventsI18n, lazyEventsI18n);

--- a/timeline/src/main/java/org/entcore/timeline/services/TimelineMailerService.java
+++ b/timeline/src/main/java/org/entcore/timeline/services/TimelineMailerService.java
@@ -54,16 +54,6 @@ public interface TimelineMailerService {
 							final JsonObject templateParameters, final JsonArray recipientIds);
 
 	/**
-	 * Translates a key using the usual i18n keys + the timeline folders keys (from all apps).
-	 *
-	 * @param i18nKeys : Keys to translate
-	 * @param domain : Domain of the i18n files
-	 * @param language : Language preference of the receiver
-	 * @param handler : Handles a JsonArray containing translated Strings.
-	 */
-	void translateTimeline(JsonArray i18nKeys, String language, String domain, Handler<JsonArray> handler);
-
-	/**
 	 * Processes a mustache template using lambdas defined in the Timeline module.
 	 *
 	 * @param parameters : Template parameters

--- a/timeline/src/main/java/org/entcore/timeline/services/impl/DefaultTimelineMailerService.java
+++ b/timeline/src/main/java/org/entcore/timeline/services/impl/DefaultTimelineMailerService.java
@@ -117,7 +117,7 @@ public class DefaultTimelineMailerService extends Renders implements TimelineMai
 		final Map<String, Map<String, Map<String,String>>> processedTemplates = new HashMap<>();
 		templateParameters.put("innerTemplate", notification.getString("template", ""));
 
-		final Map<String, Map<String, Map<String,String>>> toByDomainLang = new HashMap<>();
+		final Map<String, Map<String, Map<String, String>>> toByDomainLang = new HashMap<>();
 
 		final AtomicInteger userCount = new AtomicInteger(userList.size());
 		final Handler<Void> templatesHandler = new Handler<Void>(){
@@ -242,20 +242,11 @@ public class DefaultTimelineMailerService extends Renders implements TimelineMai
 		});
 	}
 
-	@Override
 	public void translateTimeline(JsonArray i18nKeys, String domain, String language, Handler<JsonArray> handler) {
-		String i18n = eventsI18n.get(language.split(",")[0].split("-")[0]);
-		final JsonObject timelineI18n;
-		if (i18n == null) {
-			timelineI18n = new JsonObject();
-		} else {
-			timelineI18n = new JsonObject("{" + i18n.substring(0, i18n.length() - 1) + "}");
-		}
-		timelineI18n.mergeIn(I18n.getInstance().load(language, domain));
 		JsonArray translations = new JsonArray();
 		for(Object keyObj : i18nKeys){
 			String key = (String) keyObj;
-			translations.add(timelineI18n.getString(key, key));
+			translations.add(TimelineLambda.translate(language, key, domain, eventsI18n, lazyEventsI18n));
 		}
 		handler.handle(translations);
 	}

--- a/timeline/src/main/java/org/entcore/timeline/services/impl/PeriodicTimelineMailerService.java
+++ b/timeline/src/main/java/org/entcore/timeline/services/impl/PeriodicTimelineMailerService.java
@@ -114,7 +114,7 @@ public class PeriodicTimelineMailerService implements CronMailerService {
         this.lazyEventsI18n = lazyEventsI18n;
     }
 
-    public void translateTimeline(JsonArray i18nKeys,HttpServerRequest req, String language, Handler<JsonArray> handler) {
+    public void translateTimeline(JsonArray i18nKeys, HttpServerRequest req, String language, Handler<JsonArray> handler) {
         JsonArray translations = new JsonArray();
         for(Object keyObj : i18nKeys){
             String key = (String) keyObj;


### PR DESCRIPTION
# Description

Subject translation on timeline mailing take to much time and resource, provoking hang on the server for each translation

## Fixes

https://edifice-community.atlassian.net/browse/COCO-5724

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: