### PR TITLE
feat: #PEDAGO-3968, register timeline i18n through broker

### DIFF
--- a/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/timeline/RegisterTimelineI18nRequestDTO.java
+++ b/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/timeline/RegisterTimelineI18nRequestDTO.java
@@ -1,0 +1,76 @@
+package org.entcore.broker.api.dto.timeline;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.beans.Transient;
+
+import java.util.Map;
+import java.io.IOException;
+
+/**
+ * Data Transfer Object for registering timeline i18n files.
+ */
+public class RegisterTimelineI18nRequestDTO {
+    
+    /**
+     * The application name for which to register translations.
+     */
+    private final String application;
+    
+    /**
+     * A map of language files to their key-value translation pairs.
+     * Format: {"fr.json": {"hello": "bonjour"}, "en.json": {"hello": "hello"}}
+     */
+    private final Map<String, Map<String, String>> translationsByLanguage;
+    
+    /**
+     * Creates a new instance of RegisterTimelineI18nRequestDTO.
+     *
+     * @param application The application name
+     * @param translationsByLanguage A map of language files to their key-value translation pairs
+     */
+    @JsonCreator
+    public RegisterTimelineI18nRequestDTO(
+            @JsonProperty("application") String application,
+            @JsonProperty("translationsByLanguage") Map<String, Map<String, String>> translationsByLanguage) {
+        this.application = application;
+        this.translationsByLanguage = translationsByLanguage;
+    }
+    
+    /**
+     * Gets the application name.
+     * @return The application name
+     */
+    public String getApplication() {
+        return application;
+    }
+    
+    /**
+     * Gets the translations by language map.
+     * @return A map of language files to their key-value translation pairs
+     */
+    public Map<String, Map<String, String>> getTranslationsByLanguage() {
+        return translationsByLanguage;
+    }
+    
+    /**
+     * Validates the request.
+     * @return true if the request is valid, false otherwise
+     */
+    @Transient()
+    public boolean isValid() {
+        return application != null && !application.isEmpty() && 
+               translationsByLanguage != null && !translationsByLanguage.isEmpty();
+    }
+    
+    @Override
+    public String toString() {
+        return "RegisterTimelineI18nRequestDTO{" +
+                "application='" + application + '\'' +
+                ", translationsByLanguage=" + translationsByLanguage +
+                '}';
+    }
+}

--- a/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/timeline/RegisterTimelineI18nResponseDTO.java
+++ b/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/timeline/RegisterTimelineI18nResponseDTO.java
@@ -1,0 +1,75 @@
+package org.entcore.broker.api.dto.timeline;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Data Transfer Object for the response to a timeline i18n registration request.
+ */
+public class RegisterTimelineI18nResponseDTO {
+    
+    /**
+     * The application name for which translations were registered.
+     */
+    private final String application;
+    
+    /**
+     * The number of languages registered.
+     */
+    private final int languagesCount;
+    
+    /**
+     * The number of translation keys registered.
+     */
+    private final int keysCount;
+    
+    /**
+     * Creates a new instance of RegisterTimelineI18nResponseDTO.
+     *
+     * @param application The application name
+     * @param languagesCount The number of languages registered
+     * @param keysCount The number of translation keys registered
+     */
+    @JsonCreator
+    public RegisterTimelineI18nResponseDTO(
+            @JsonProperty("application") String application,
+            @JsonProperty("languagesCount") int languagesCount,
+            @JsonProperty("keysCount") int keysCount) {
+        this.application = application;
+        this.languagesCount = languagesCount;
+        this.keysCount = keysCount;
+    }
+    
+    /**
+     * Gets the application name.
+     * @return The application name
+     */
+    public String getApplication() {
+        return application;
+    }
+    
+    /**
+     * Gets the number of languages registered.
+     * @return The number of languages registered
+     */
+    public int getLanguagesCount() {
+        return languagesCount;
+    }
+    
+    /**
+     * Gets the number of translation keys registered.
+     * @return The number of translation keys registered
+     */
+    public int getKeysCount() {
+        return keysCount;
+    }
+    
+    @Override
+    public String toString() {
+        return "RegisterTimelineI18nResponseDTO{" +
+                "application='" + application + '\'' +
+                ", languagesCount=" + languagesCount +
+                ", keysCount=" + keysCount +
+                '}';
+    }
+}

--- a/broker-parent/broker-proxy/src/main/java/org/entcore/broker/proxy/TimelineBrokerListener.java
+++ b/broker-parent/broker-proxy/src/main/java/org/entcore/broker/proxy/TimelineBrokerListener.java
@@ -5,6 +5,8 @@ import org.entcore.broker.api.BrokerListener;
 import org.entcore.broker.api.dto.timeline.RegisterNotificationBatchRequestDTO;
 import org.entcore.broker.api.dto.timeline.RegisterNotificationRequestDTO;
 import org.entcore.broker.api.dto.timeline.RegisterNotificationResponseDTO;
+import org.entcore.broker.api.dto.timeline.RegisterTimelineI18nRequestDTO;
+import org.entcore.broker.api.dto.timeline.RegisterTimelineI18nResponseDTO;
 import org.entcore.broker.api.dto.timeline.SendNotificationRequestDTO;
 import org.entcore.broker.api.dto.timeline.SendNotificationResponseDTO;
 
@@ -43,4 +45,14 @@ public interface TimelineBrokerListener {
    */
   @BrokerListener(subject = "timeline.notification.send", proxy = true)
   Future<SendNotificationResponseDTO> sendNotification(SendNotificationRequestDTO request);
+
+  /**
+   * Registers timeline i18n files for the Timeline system.
+   * The translations will be stored in the shared timelineEventsI18n map and be available for notifications.
+   *
+   * @param request Request object containing timeline i18n details
+   * @return Response indicating success or failure of the registration
+   */
+  @BrokerListener(subject = "timeline.i18n.register", proxy = true, broadcast = true)
+  Future<RegisterTimelineI18nResponseDTO> registerTimelineI18n(RegisterTimelineI18nRequestDTO request);
 }

--- a/common/src/main/java/org/entcore/common/notification/TimelineHelper.java
+++ b/common/src/main/java/org/entcore/common/notification/TimelineHelper.java
@@ -310,7 +310,30 @@ public class TimelineHelper {
 		});
 	}
 
-	private void replaceEventsI18n(AsyncMap<String, String> eventsI18n, String key, String old, String append, int retry) {
+	/**
+	 * Public static method to append timeline i18n entries to the shared map.
+	 * Can be called from TimelineBrokerListenerImpl.
+	 *
+	 * @param vertx The Vertx instance
+	 * @param i18ns Map of language codes to their translation JsonObjects
+	 */
+	public static Future<Void> appendTimelineEventsI18n(final Vertx vertx, final Map<String, JsonObject> i18ns) {
+		final Promise<Void> promise = Promise.promise();
+		vertx.sharedData().<String, String>getAsyncMap("timelineEventsI18n").onSuccess(eventsI18n -> {
+			for (Map.Entry<String, JsonObject> e : i18ns.entrySet()) {
+				String json = e.getValue().encode();
+				if (StringUtils.isEmpty(json) || "{}".equals(StringUtils.stripSpaces(json))) continue;
+				final String j = json.substring(1, json.length() - 1) + ",";
+				eventsI18n.putIfAbsent(e.getKey(), j)
+					.onSuccess(oldJson -> replaceEventsI18n(eventsI18n, e.getKey(), oldJson, j, 0))
+					.onFailure(ex -> log.error("Error when try put eventsI18n on key " + e.getKey(), ex));
+			}
+			promise.complete();
+		}).onFailure(promise::fail);
+		return promise.future();
+	}
+
+	private static void replaceEventsI18n(AsyncMap<String, String> eventsI18n, String key, String old, String append, int retry) {
 		if (old == null || old.equals(append) || retry > MAX_RETRY) {
 			if (retry > MAX_RETRY) {
 				log.warn("Replace eventi18n not updated after max retries : " + retry);

--- a/timeline/src/main/java/org/entcore/timeline/listeners/TimelineBrokerListenerImpl.java
+++ b/timeline/src/main/java/org/entcore/timeline/listeners/TimelineBrokerListenerImpl.java
@@ -1,6 +1,7 @@
 package org.entcore.timeline.listeners;
 
 import io.vertx.core.*;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -29,6 +30,8 @@ public class TimelineBrokerListenerImpl implements TimelineBrokerListener {
     private static final String ERR_REGISTRATION = "timeline.notification.register.error";
     private static final String ERR_SEND_INVALID = "timeline.notification.send.invalid";
     private static final String ERR_SEND_ERROR = "timeline.notification.send.error";
+    private static final String ERR_I18N_INVALID = "timeline.i18n.register.invalid";
+    private static final String ERR_I18N_REGISTER = "timeline.i18n.register.error";
 
     private final Vertx vertx;
     private final TimelineHelper timelineHelper;
@@ -143,6 +146,52 @@ public class TimelineBrokerListenerImpl implements TimelineBrokerListener {
             log.error(ERR_SEND_ERROR + ": " + e.getMessage(), e);
             return Future.failedFuture(ERR_SEND_ERROR);
         }
+    }
+
+    @Override
+    public Future<RegisterTimelineI18nResponseDTO> registerTimelineI18n(RegisterTimelineI18nRequestDTO request) {
+        if (request == null || !request.isValid()) {
+            log.error(ERR_I18N_INVALID + ": Request is null or invalid");
+            return Future.failedFuture(ERR_I18N_INVALID);
+        }
+
+        final String application = request.getApplication();
+        final Map<String, Map<String, String>> translationsByLanguage = request.getTranslationsByLanguage();
+
+        // Convert Map<String, Map<String, String>> to Map<String, JsonObject>
+        final Map<String, JsonObject> i18ns = new HashMap<>();
+        int keysCount = 0;
+
+        for (Map.Entry<String, Map<String, String>> entry : translationsByLanguage.entrySet()) {
+            // Strip .json extension if present ("fr.json" -> "fr")
+            String langKey = entry.getKey();
+            if (langKey.endsWith(".json")) {
+                langKey = langKey.substring(0, langKey.lastIndexOf(".json"));
+            }
+
+            final JsonObject jsonTranslations = new JsonObject();
+            final Map<String, String> translations = entry.getValue();
+            if (translations != null && !translations.isEmpty()) {
+                translations.forEach(jsonTranslations::put);
+                keysCount += translations.size();
+            }
+            i18ns.put(langKey, jsonTranslations);
+        }
+
+        final int totalKeys = keysCount;
+        final int langsCount = i18ns.size();
+
+        log.info("Registering timeline i18n for application: " + application + " (" + langsCount + " languages, " + totalKeys + " keys)");
+
+        // Use the static method from TimelineHelper
+        return TimelineHelper.appendTimelineEventsI18n(vertx, i18ns)
+                .map(v -> {
+                    log.info("Successfully registered timeline i18n for application: " + application);
+                    return new RegisterTimelineI18nResponseDTO(application, langsCount, totalKeys);
+                })
+                .onFailure(err -> {
+                    log.error(ERR_I18N_REGISTER + ": " + err.getMessage(), err);
+                });
     }
 
     /**


### PR DESCRIPTION
# Description

Ce commit ajoute la possibilité d'enregistrer les i18n de notifications via nats.


## Fixes

(Enter here Jira or Redmine ticket(s) links)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [X] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: