### PR TITLE
fix: #ENABLING-686, add deduplication access events and sessionId tracking

### DIFF
--- a/common/src/main/java/org/entcore/common/events/impl/GenericEventStore.java
+++ b/common/src/main/java/org/entcore/common/events/impl/GenericEventStore.java
@@ -25,9 +25,13 @@ import fr.wseduc.webutils.request.CookieHelper;
 import io.vertx.core.*;
 import io.vertx.core.file.FileSystem;
 import org.entcore.common.events.EventStore;
+import org.entcore.common.events.EventHelper;
 import org.entcore.common.neo4j.Neo4j;
 import org.entcore.common.user.UserInfos;
 import org.entcore.common.user.UserUtils;
+import org.entcore.common.utils.Hash;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.http.HttpServerRequest;
@@ -40,9 +44,11 @@ import static fr.wseduc.webutils.Utils.getOrElse;
 import static io.vertx.core.Future.succeededFuture;
 
 import java.util.HashMap;
+import java.util.Objects;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.net.URLDecoder;
@@ -59,6 +65,8 @@ public abstract class GenericEventStore implements EventStore {
 	private static Validator eventsValidator;
 	private static boolean validatorInitialized = false;
 
+
+	private boolean accessDedupEnabled = true;
 
 	@Override
 	public void createAndStoreEvent(String eventType, UserInfos user) {
@@ -246,6 +254,30 @@ public abstract class GenericEventStore implements EventStore {
 	}
 
 	private void execute(UserInfos user, String eventType, HttpServerRequest request, JsonObject customAttributes) {
+		if (accessDedupEnabled && EventHelper.ACCESS_EVENT.equals(eventType) && request != null) {
+			checkAndStoreAccessEvent(user, request, customAttributes);
+			return;
+		}
+		doStore(user, eventType, request, customAttributes);
+	}
+
+	private void checkAndStoreAccessEvent(UserInfos user, HttpServerRequest request, JsonObject customAttributes) {
+		if (request != null && module != null) {
+			final Object lastAccessModuleObj = user.getAttribute("lastAccessModule");
+			final String lastAccessModule = lastAccessModuleObj != null ? lastAccessModuleObj.toString() : null;
+			if (Objects.equals(module, lastAccessModule)) {
+				logger.warn("Skipping duplicate ACCESS event - same module as last access. module=" + module + ", url=" + request.uri());
+				return;
+			}
+			final String userId = user.getUserId();
+			if (userId != null) {
+				UserUtils.addSessionAttribute(eventBus, userId, "lastAccessModule", module, ok -> {});
+			}
+		}
+		doStore(user, EventHelper.ACCESS_EVENT, request, customAttributes);
+	}
+
+	private void doStore(UserInfos user, String eventType, HttpServerRequest request, JsonObject customAttributes) {
 		if (user == null || !userBlacklist.contains(user.getUserId())) {
 			final JsonObject event = generateEvent(eventType, user, request, customAttributes);
 			validateEvent(event, this.vertx)
@@ -320,8 +352,34 @@ public abstract class GenericEventStore implements EventStore {
 			if (ip != null) {
 				event.put("ip", ip);
 			}
+			final String sessionId = getSessionId(request);
+			if (sessionId != null) {
+				event.put("sessionId", sessionId);
+			}
 		}
 		return event;
+	}
+
+	private String getSessionId(HttpServerRequest request) {
+		// Priority: UserUtils.getSessionId() -> Authorization header
+		final Optional<String> userUtilsSessionId = UserUtils.getSessionId(request);
+		if (userUtilsSessionId.isPresent()) {
+			return hashSessionId(userUtilsSessionId.get());
+		}
+		final String token = request.headers().get("Authorization");
+		if (token != null && !token.isEmpty()) {
+			return hashSessionId(token);
+		}
+		return null;
+	}
+
+	private String hashSessionId(String value) {
+		try {
+			return Hash.sha256(value);
+		} catch (Exception e) {
+			logger.warn("Failed to hash sessionId", e);
+			return null;
+		}
 	}
 	
 	private String decodeCookie(String value) {
@@ -362,6 +420,15 @@ public abstract class GenericEventStore implements EventStore {
 
 	public void setVertx(Vertx vertx) {
 		this.vertx = vertx;
+		vertx.sharedData().<String, String>getLocalAsyncMap("server")
+			.compose(serverMap -> serverMap.get("event-store"))
+			.onSuccess(eventStoreConf -> {
+				if (eventStoreConf != null) {
+					final JsonObject eventStoreConfig = new JsonObject(eventStoreConf);
+					accessDedupEnabled = eventStoreConfig.getBoolean("access-dedup-enabled", true);
+				}
+			})
+			.onFailure(ex -> logger.warn("Could not read event-store config for access-dedup-*", ex));
 	}
 
 	public static Future<Validator> loadJsonSchema(final Vertx vertx) {

--- a/common/src/main/java/org/entcore/common/events/impl/GenericEventStore.java
+++ b/common/src/main/java/org/entcore/common/events/impl/GenericEventStore.java
@@ -255,26 +255,39 @@ public abstract class GenericEventStore implements EventStore {
 
 	private void execute(UserInfos user, String eventType, HttpServerRequest request, JsonObject customAttributes) {
 		if (accessDedupEnabled && EventHelper.ACCESS_EVENT.equals(eventType) && request != null) {
-			checkAndStoreAccessEvent(user, request, customAttributes);
+			checkAndStoreAccessEvent(user, eventType, request, customAttributes);
 			return;
 		}
 		doStore(user, eventType, request, customAttributes);
 	}
 
-	private void checkAndStoreAccessEvent(UserInfos user, HttpServerRequest request, JsonObject customAttributes) {
-		if (request != null && module != null) {
-			final Object lastAccessModuleObj = user.getAttribute("lastAccessModule");
-			final String lastAccessModule = lastAccessModuleObj != null ? lastAccessModuleObj.toString() : null;
-			if (Objects.equals(module, lastAccessModule)) {
-				logger.warn("Skipping duplicate ACCESS event - same module as last access. module=" + module + ", url=" + request.uri());
-				return;
-			}
-			final String userId = user.getUserId();
-			if (userId != null) {
-				UserUtils.addSessionAttribute(eventBus, userId, "lastAccessModule", module, ok -> {});
-			}
+	/**
+	 * Checks session to detect a duplicate ACCESS event for the same module.
+	 * Side effect: updates "lastAccessModule" in session if not a duplicate.
+	 * Returns true if the event is a duplicate and should be skipped.
+	 */
+	public static boolean isDuplicateAccessModule(EventBus eventBus, UserInfos user, String module, String eventType) {
+		if (!EventHelper.ACCESS_EVENT.equals(eventType)) {
+			return false;
 		}
-		doStore(user, EventHelper.ACCESS_EVENT, request, customAttributes);
+		final Object lastAccessModuleObj = user.getAttribute("lastAccessModule");
+		final String lastAccessModule = lastAccessModuleObj != null ? lastAccessModuleObj.toString() : null;
+		if (Objects.equals(module, lastAccessModule)) {
+			return true;
+		}
+		final String userId = user.getUserId();
+		if (userId != null) {
+			UserUtils.addSessionAttribute(eventBus, userId, "lastAccessModule", module, ok -> {});
+		}
+		return false;
+	}
+
+	private void checkAndStoreAccessEvent(UserInfos user, String eventType, HttpServerRequest request, JsonObject customAttributes) {
+		if (request != null && module != null && isDuplicateAccessModule(eventBus, user, module, eventType)) {
+			logger.warn("Skipping duplicate ACCESS event - same module as last access. module=" + module + ", url=" + request.uri());
+			return;
+		}
+		doStore(user, eventType, request, customAttributes);
 	}
 
 	private void doStore(UserInfos user, String eventType, HttpServerRequest request, JsonObject customAttributes) {
@@ -360,7 +373,7 @@ public abstract class GenericEventStore implements EventStore {
 		return event;
 	}
 
-	private String getSessionId(HttpServerRequest request) {
+	public static String getSessionId(HttpServerRequest request) {
 		// Priority: UserUtils.getSessionId() -> Authorization header
 		final Optional<String> userUtilsSessionId = UserUtils.getSessionId(request);
 		if (userUtilsSessionId.isPresent()) {
@@ -373,7 +386,7 @@ public abstract class GenericEventStore implements EventStore {
 		return null;
 	}
 
-	private String hashSessionId(String value) {
+	private static String hashSessionId(String value) {
 		try {
 			return Hash.sha256(value);
 		} catch (Exception e) {

--- a/common/src/main/java/org/entcore/common/events/impl/GenericEventStore.java
+++ b/common/src/main/java/org/entcore/common/events/impl/GenericEventStore.java
@@ -439,6 +439,7 @@ public abstract class GenericEventStore implements EventStore {
 				if (eventStoreConf != null) {
 					final JsonObject eventStoreConfig = new JsonObject(eventStoreConf);
 					accessDedupEnabled = eventStoreConfig.getBoolean("access-dedup-enabled", true);
+					logger.info("Event store ACCESS dedup (web) : " + (accessDedupEnabled ? "ENABLED" : "DISABLED"));
 				}
 			})
 			.onFailure(ex -> logger.warn("Could not read event-store config for access-dedup-*", ex));

--- a/common/src/main/java/org/entcore/common/utils/Hash.java
+++ b/common/src/main/java/org/entcore/common/utils/Hash.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © "Open Digital Education", 2024
+ *
+ * This program is published by "Open Digital Education".
+ * You must indicate the name of the software and the company in any production /contribution
+ * using the software and indicate on the home page of the software industry in question,
+ * "powered by Open Digital Education" with a reference to the website: https://opendigitaleducation.com/.
+ *
+ * This program is free software, licensed under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, version 3 of the License.
+ *
+ * You can redistribute this application and/or modify it since you respect the terms of the GNU Affero General Public License.
+ * If you modify the source code and then use this modified source code in your creation, you must make available the source code of your modifications.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with the software.
+ * If not, please see : <http://www.gnu.org/licenses/>. Full compliance requires reading the terms of this license and following its directives.
+ */
+
+package org.entcore.common.utils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Formatter;
+
+public final class Hash {
+
+	private Hash() {
+	}
+
+	public static String sha1(byte[] data) throws NoSuchAlgorithmException {
+		MessageDigest md = MessageDigest.getInstance("SHA-1");
+		return byteArray2Hex(md.digest(data));
+	}
+
+	public static String sha1(String data) throws NoSuchAlgorithmException {
+		return sha1(data.getBytes(StandardCharsets.UTF_8));
+	}
+
+	public static String sha256(byte[] data) throws NoSuchAlgorithmException {
+		MessageDigest md = MessageDigest.getInstance("SHA-256");
+		return byteArray2Hex(md.digest(data));
+	}
+
+	public static String sha256(String data) throws NoSuchAlgorithmException {
+		return sha256(data.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private static String byteArray2Hex(final byte[] hash) {
+		Formatter formatter = new Formatter();
+		for (byte b : hash) {
+			formatter.format("%02x", b);
+		}
+		String result = formatter.toString();
+		formatter.close();
+		return result;
+	}
+}

--- a/infra/src/main/java/org/entcore/infra/controllers/EventStoreController.java
+++ b/infra/src/main/java/org/entcore/infra/controllers/EventStoreController.java
@@ -116,7 +116,7 @@ public class EventStoreController extends BaseController {
 							event.put("ip", Renders.getIp(request));
 						}
 
-						eventStoreService.store(event, voidResponseHandler(request));
+						eventStoreService.storeWithCheck(event, user, event.getString("module"), eventType, voidResponseHandler(request));
 					} else {
 						Renders.badRequest(request, "bad event:"+eventType);
 					}

--- a/infra/src/main/java/org/entcore/infra/services/EventStoreService.java
+++ b/infra/src/main/java/org/entcore/infra/services/EventStoreService.java
@@ -39,6 +39,30 @@ public interface EventStoreService {
 
 	void store(JsonObject event, Handler<Either<String, Void>> handler);
 
+	/**
+	 * Stores an event after checking for duplicates.
+	 * <p>
+	 * For ACCESS events, this method checks whether the same user has already accessed
+	 * the same module recently (via session attribute {@code lastAccessModule}). If a
+	 * duplicate is detected the event is silently dropped and the handler is called with
+	 * a successful result, avoiding double-counting in analytics.
+	 * </p>
+	 * <p>
+	 * The default implementation performs no deduplication and delegates directly to
+	 * {@link #store(JsonObject, Handler)}. Override to provide deduplication logic.
+	 * </p>
+	 *
+	 * @param event     the event payload to store
+	 * @param user      the authenticated user, used to read and update the session dedup state
+	 * @param module    the application module name (passed explicitly to avoid unreliable JSON extraction)
+	 * @param eventType the event type (e.g. {@code "ACCESS"}); non-ACCESS events are always stored
+	 * @param handler   called with {@code Right<Void>} on success (including skipped duplicates),
+	 *                  or {@code Left<String>} on storage error
+	 */
+	default void storeWithCheck(JsonObject event, UserInfos user, String module, String eventType, Handler<Either<String, Void>> handler) {
+		store(event, handler);
+	}
+
 	void generateMobileEvent(String eventType, UserInfos user, HttpServerRequest request, String module, final Handler<Either<String, Void>> handler);
 
 	void storeCustomEvent(String baseEventType, JsonObject payload);

--- a/infra/src/main/java/org/entcore/infra/services/impl/MongoDbEventStore.java
+++ b/infra/src/main/java/org/entcore/infra/services/impl/MongoDbEventStore.java
@@ -64,6 +64,7 @@ public class MongoDbEventStore implements EventStoreService {
 	private static final String FORMAT_ERROR_COLLECTION = "events_format_error";
     private int eventsBatchSize;
     private static final int DEFAULT_EVENT_BATCH_SIZE = 50_000;
+    private boolean accessMobileDedupEnabled = false;
     private static final Logger log = LoggerFactory.getLogger(MongoDbEventStore.class);
 	private final Vertx vertx;
 
@@ -82,9 +83,11 @@ public class MongoDbEventStore implements EventStoreService {
 						pgEventStore.setVertx(vertx);
 						pgEventStore.init();
 					}
-					eventsBatchSize = eventStoreConfig.getInteger("events-batch-size", DEFAULT_EVENT_BATCH_SIZE);
-				} else {
-					eventsBatchSize = DEFAULT_EVENT_BATCH_SIZE;
+				eventsBatchSize = eventStoreConfig.getInteger("events-batch-size", DEFAULT_EVENT_BATCH_SIZE);
+				accessMobileDedupEnabled = eventStoreConfig.getBoolean("access-mobile-dedup-enabled", false);
+				log.info("Event store ACCESS dedup (mobile) : " + (accessMobileDedupEnabled ? "ENABLED" : "DISABLED"));
+			} else {
+				eventsBatchSize = DEFAULT_EVENT_BATCH_SIZE;
 				}
 			}).onFailure(ex -> log.error("Error when get event-store conf in server map", ex));
 	}
@@ -160,7 +163,11 @@ public class MongoDbEventStore implements EventStoreService {
 				event.put("ip", ip);
 			}
 		}
-		storeWithCheck(event, user, module, eventType, handler);
+		if (accessMobileDedupEnabled) {
+			storeWithCheck(event, user, module, eventType, handler);
+		} else {
+			store(event, handler);
+		}
 	}
 
 	@Override

--- a/infra/src/main/java/org/entcore/infra/services/impl/MongoDbEventStore.java
+++ b/infra/src/main/java/org/entcore/infra/services/impl/MongoDbEventStore.java
@@ -114,6 +114,16 @@ public class MongoDbEventStore implements EventStoreService {
 	}
 
 	@Override
+	public void storeWithCheck(JsonObject event, UserInfos user, String module, String eventType, final Handler<Either<String, Void>> handler) {
+		if (user != null && module != null && isDuplicateAccessModule(this.vertx.eventBus(), user, module, eventType)) {
+			log.warn("Skipping duplicate ACCESS event - module=" + module);
+			handler.handle(new Either.Right<>(null));
+			return;
+		}
+		store(event, handler);
+	}
+
+	@Override
 	public void generateMobileEvent(String eventType, UserInfos user, HttpServerRequest request,
 									 String module, final Handler<Either<String, Void>> handler) {
 		JsonObject event = new JsonObject();
@@ -140,14 +150,17 @@ public class MongoDbEventStore implements EventStoreService {
 		}
 		if (request != null) {
 			event.put("referer", request.headers().get("Referer"));
-			event.put("sessionId", CookieHelper.getInstance().getSigned("oneSessionId", request));
+			final String sessionId = getSessionId(request);
+			if (sessionId != null) {
+				event.put("sessionId", sessionId);
+			}
 
 			final String ip = Renders.getIp(request);
 			if (ip != null) {
 				event.put("ip", ip);
 			}
 		}
-		store(event, handler);
+		storeWithCheck(event, user, module, eventType, handler);
 	}
 
 	@Override


### PR DESCRIPTION
# Description

Ce commit ajoute un mécanisme configurable pour éviter les event access en double (redirection...)
Une tentative a été faite pour utiliser les referer, mais il n'est pas envoyé pour tout les types de redirection (en fonction du navigateur) et sur mobile tout passe par /infra/events

Il ajoute aussi un moyen d'inclure l'id de session dans les event sans divulguer de secret (utilisation d'un hash)

## Fixes

#ENABLING-686

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [X] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: