### PR TITLE
fix(infra): #PEDAGO-3997, add ConfigBrokerListener to expose config from shared map

### DIFF
--- a/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/config/AuthLocationConfigDTO.java
+++ b/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/config/AuthLocationConfigDTO.java
@@ -1,0 +1,45 @@
+package org.entcore.broker.api.dto.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Configuration for a specific host's authentication location.
+ */
+public class AuthLocationConfigDTO {
+
+    private final String host;
+    private final String loginUri;
+    private final String callbackParam;
+
+    @JsonCreator
+    public AuthLocationConfigDTO(
+            @JsonProperty("host") String host,
+            @JsonProperty("loginUri") String loginUri,
+            @JsonProperty("callbackParam") String callbackParam) {
+        this.host = host;
+        this.loginUri = loginUri;
+        this.callbackParam = callbackParam;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public String getLoginUri() {
+        return loginUri;
+    }
+
+    public String getCallbackParam() {
+        return callbackParam;
+    }
+
+    @Override
+    public String toString() {
+        return "AuthLocationConfigDTO{" +
+                "host='" + host + '\'' +
+                ", loginUri='" + loginUri + '\'' +
+                ", callbackParam='" + callbackParam + '\'' +
+                '}';
+    }
+}

--- a/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/config/GetRedirectConfigRequestDTO.java
+++ b/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/config/GetRedirectConfigRequestDTO.java
@@ -1,0 +1,15 @@
+package org.entcore.broker.api.dto.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Request DTO for config.redirect broker listener.
+ * Currently empty as the endpoint doesn't require any parameters.
+ */
+public class GetRedirectConfigRequestDTO {
+
+    @JsonCreator
+    public GetRedirectConfigRequestDTO() {
+    }
+}

--- a/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/config/RedirectConfigResponseDTO.java
+++ b/broker-parent/broker-api/src/main/java/org/entcore/broker/api/dto/config/RedirectConfigResponseDTO.java
@@ -1,0 +1,56 @@
+package org.entcore.broker.api.dto.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Response DTO for redirect configuration.
+ * Contains the login URI, callback parameter, and per-host auth locations.
+ */
+public class RedirectConfigResponseDTO {
+
+    private final String loginUri;
+    private final String callbackParam;
+    private final List<AuthLocationConfigDTO> authLocations;
+    private final List<String> allowedHosts;
+
+    @JsonCreator
+    public RedirectConfigResponseDTO(
+            @JsonProperty("loginUri") String loginUri,
+            @JsonProperty("callbackParam") String callbackParam,
+            @JsonProperty("authLocations") List<AuthLocationConfigDTO> authLocations,
+            @JsonProperty("allowedHosts") List<String> allowedHosts) {
+        this.loginUri = loginUri;
+        this.callbackParam = callbackParam;
+        this.authLocations = authLocations;
+        this.allowedHosts = allowedHosts;
+    }
+
+    public String getLoginUri() {
+        return loginUri;
+    }
+
+    public String getCallbackParam() {
+        return callbackParam;
+    }
+
+    public List<AuthLocationConfigDTO> getAuthLocations() {
+        return authLocations;
+    }
+
+    public List<String> getAllowedHosts() {
+        return allowedHosts;
+    }
+
+    @Override
+    public String toString() {
+        return "RedirectConfigResponseDTO{" +
+                "loginUri='" + loginUri + '\'' +
+                ", callbackParam='" + callbackParam + '\'' +
+                ", authLocations=" + authLocations +
+                ", allowedHosts=" + allowedHosts +
+                '}';
+    }
+}

--- a/broker-parent/broker-proxy/src/main/java/org/entcore/broker/proxy/ConfigBrokerListener.java
+++ b/broker-parent/broker-proxy/src/main/java/org/entcore/broker/proxy/ConfigBrokerListener.java
@@ -1,0 +1,22 @@
+package org.entcore.broker.proxy;
+
+import io.vertx.core.Future;
+import org.entcore.broker.api.BrokerListener;
+import org.entcore.broker.api.dto.config.GetRedirectConfigRequestDTO;
+import org.entcore.broker.api.dto.config.RedirectConfigResponseDTO;
+
+/**
+ * Broker listener interface for accessing shared server configuration.
+ */
+public interface ConfigBrokerListener {
+
+    /**
+     * Retrieves the redirect configuration from the shared server map.
+     * This includes loginUri, callbackParam, and per-host authLocations.
+     *
+     * @param request - Empty request DTO (placeholder for future parameters)
+     * @return Future containing the redirect configuration
+     */
+    @BrokerListener(subject = "config.redirect", proxy = true)
+    Future<RedirectConfigResponseDTO> getRedirectConfig(GetRedirectConfigRequestDTO request);
+}

--- a/infra/src/main/java/org/entcore/infra/Starter.java
+++ b/infra/src/main/java/org/entcore/infra/Starter.java
@@ -37,9 +37,11 @@ import org.entcore.common.http.BaseServer;
 import org.entcore.common.notification.TimelineHelper;
 import org.entcore.common.pdf.PdfFactory;
 import org.entcore.common.utils.MapFactory;
+import org.entcore.broker.api.utils.BrokerProxyUtils;
 import org.entcore.infra.controllers.*;
 import org.entcore.infra.cron.HardBounceTask;
 import org.entcore.infra.cron.MonitoringEventsChecker;
+import org.entcore.infra.listeners.ConfigBrokerListenerImpl;
 import org.entcore.infra.metrics.MicrometerInfraMetricsRecorder;
 import org.entcore.infra.services.EventStoreService;
 import org.entcore.infra.services.impl.ClamAvService;
@@ -102,6 +104,7 @@ public class Starter extends BaseServer {
 		addController(eventStoreController);
 		addController(new MonitoringController());
 		addController(new EmbedController());
+		BrokerProxyUtils.addBrokerProxy(new ConfigBrokerListenerImpl(), vertx);
 		if (config.getJsonObject("node-pdf-generator") != null) {
 			try {
 				PdfController pdfController = new PdfController();

--- a/infra/src/main/java/org/entcore/infra/listeners/ConfigBrokerListenerImpl.java
+++ b/infra/src/main/java/org/entcore/infra/listeners/ConfigBrokerListenerImpl.java
@@ -1,0 +1,96 @@
+package org.entcore.infra.listeners;
+
+import fr.wseduc.webutils.collections.SharedDataHelper;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.entcore.broker.api.dto.config.AuthLocationConfigDTO;
+import org.entcore.broker.api.dto.config.GetRedirectConfigRequestDTO;
+import org.entcore.broker.api.dto.config.RedirectConfigResponseDTO;
+import org.entcore.broker.proxy.ConfigBrokerListener;
+import org.entcore.broker.api.dto.config.RedirectConfigResponseDTO;
+
+import java.util.ArrayList;
+import java.util.List;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+/**
+ * Broker listener for accessing shared server configuration.
+ */
+public class ConfigBrokerListenerImpl implements ConfigBrokerListener {
+
+    private static final Logger log = LoggerFactory.getLogger(ConfigBrokerListenerImpl.class);
+
+    @Override
+    public Future<RedirectConfigResponseDTO> getRedirectConfig(GetRedirectConfigRequestDTO request) {
+        final Promise<RedirectConfigResponseDTO> promise = Promise.promise();
+
+        SharedDataHelper.getInstance().<String, Object>getLocalMulti(
+                "server",
+                "loginUri",
+                "callbackParam",
+                "authLocations",
+                "skins"
+        ).onSuccess(configMap -> {
+            final String loginUri = (String) configMap.get("loginUri");
+            final String callbackParam = (String) configMap.get("callbackParam");
+            final String authLocationsStr = (String) configMap.get("authLocations");
+            final JsonObject authLocationsJson = isNotBlank(authLocationsStr) ? new JsonObject(authLocationsStr) : null;
+            final JsonObject skinsJson = (JsonObject) configMap.get("skins");
+
+            List<AuthLocationConfigDTO> authLocations = null;
+            if (authLocationsJson != null) {
+                try {
+                    authLocations = parseAuthLocations(authLocationsJson);
+                } catch (Exception e) {
+                    log.warn("Failed to parse authLocations JSON: {}", e.getMessage());
+                }
+            }
+
+            final List<String> allowedHosts = new ArrayList<>();
+            if (skinsJson != null) {
+                try {
+                    for (String host : skinsJson.fieldNames()) {
+                        if (isNotBlank(host)) {
+                            allowedHosts.add(host);
+                        }
+                    }
+                } catch (Exception e) {
+                    log.warn("Failed to parse skins JSON for allowedHosts: {}", e.getMessage());
+                }
+            }
+
+            final RedirectConfigResponseDTO response = new RedirectConfigResponseDTO(
+                    loginUri,
+                    callbackParam,
+                    authLocations,
+                    allowedHosts
+            );
+            promise.complete(response);
+        }).onFailure(err -> {
+            log.error("Failed to get redirect config from shared map", err);
+            promise.fail(err);
+        });
+
+        return promise.future();
+    }
+
+    private List<AuthLocationConfigDTO> parseAuthLocations(JsonObject json) {
+        final List<AuthLocationConfigDTO> result = new ArrayList<>();
+
+        for (String key : json.fieldNames()) {
+            final JsonObject location = json.getJsonObject(key);
+            if (location != null) {
+                result.add(new AuthLocationConfigDTO(
+                        key,
+                        location.getString("loginUri"),
+                        location.getString("callbackParam")
+                ));
+            }
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
# Description

Ce commit permet d'exposer les config partagé via un service NATS.
Pour le moment il expose la config de redirection d'auth.

## Fixes

#PEDAGO-3997

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [X] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [X] All done ! :smiley: