### PR TITLE
feat: #IMPULS-5747, plages silencieuses US5 back

### DIFF
--- a/admin/src/main/java/org/entcore/admin/Admin.java
+++ b/admin/src/main/java/org/entcore/admin/Admin.java
@@ -27,6 +27,7 @@ import org.entcore.admin.controllers.AdminController;
 import org.entcore.admin.controllers.BlockProfileTraceController;
 import org.entcore.admin.controllers.PlatformInfoController;
 import org.entcore.admin.controllers.ConfigController;
+import org.entcore.admin.controllers.StructureQuietHoursController;
 import org.entcore.admin.services.BlockProfileTraceService;
 import org.entcore.admin.services.impl.DefaultBlockProfileTraceService;
 import org.entcore.common.http.BaseServer;
@@ -58,7 +59,9 @@ public class Admin extends BaseServer {
 		blockProfileTraceController.setBlockProfileTraceService(blockProfileTraceService);
 		addController(blockProfileTraceController);
 		addController(new ConfigController());
-		
+
+		addController(new StructureQuietHoursController());
+
 		final PlatformInfoController platformInfoController = new PlatformInfoController();
 		platformInfoController.setHidePersonalData((Boolean) adminMap.get("hidePersonalData"));
 

--- a/admin/src/main/java/org/entcore/admin/controllers/StructureQuietHoursController.java
+++ b/admin/src/main/java/org/entcore/admin/controllers/StructureQuietHoursController.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © "Open Digital Education", 2024
+ *
+ * This program is published by "Open Digital Education".
+ * You must indicate the name of the software and the company in any production /contribution
+ * using the software and indicate on the home page of the software industry in question,
+ * "powered by Open Digital Education" with a reference to the website: https://opendigitaleducation.com/.
+ *
+ * This program is free software, licensed under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, version 3 of the License.
+ *
+ * You can redistribute this application and/or modify it since you respect the terms of the GNU Affero General Public License.
+ * If you modify the source code and then use this modified source code in your creation, you must make available the source code of your modifications.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with the software.
+ * If not, please see : <http://www.gnu.org/licenses/>. Full compliance requires reading the terms of this license and following its directives.
+ */
+
+package org.entcore.admin.controllers;
+
+import fr.wseduc.rs.Get;
+import fr.wseduc.rs.Post;
+import fr.wseduc.security.ActionType;
+import fr.wseduc.security.MfaProtected;
+import fr.wseduc.security.SecuredAction;
+import fr.wseduc.webutils.http.BaseController;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
+import org.entcore.common.http.filter.AdmlOfStructure;
+import org.entcore.common.http.filter.ResourceFilter;
+
+public class StructureQuietHoursController extends BaseController {
+
+    private static final String STRUCTURE_PREFERENCES_ADDRESS = "directory.structure.quiethours.preferences";
+    private static final String USERBOOK_PREFERENCES_ADDRESS  = "userbook.preferences";
+
+    @Get("api/structure/:structureId/quiethours-preferences")
+    @SecuredAction(type = ActionType.RESOURCE, value = "")
+    @ResourceFilter(AdmlOfStructure.class)
+    @MfaProtected()
+    public void getPreferences(HttpServerRequest request) {
+        final String structureId = request.params().get("structureId");
+        final JsonObject message = new JsonObject()
+                .put("action", "get")
+                .put("structureId", structureId);
+        sendAndReply(request, STRUCTURE_PREFERENCES_ADDRESS, message);
+    }
+
+    @Post("api/structure/:structureId/quiethours-preferences")
+    @SecuredAction(type = ActionType.RESOURCE, value = "")
+    @ResourceFilter(AdmlOfStructure.class)
+    @MfaProtected()
+    public void setPreferences(HttpServerRequest request) {
+        final String structureId = request.params().get("structureId");
+        bodyToJson(request).compose(preferences -> {
+            final JsonObject saveMessage = new JsonObject()
+                    .put("action", "set")
+                    .put("structureId", structureId)
+                    .put("preferences", preferences);
+            return busRequest(STRUCTURE_PREFERENCES_ADDRESS, saveMessage);
+        }).compose(savedPreferences -> {
+            final JsonObject cascadeMessage = new JsonObject()
+                    .put("action", "cascade.structure.quiethours.preferences")
+                    .put("structureId", structureId);
+            return busRequest(USERBOOK_PREFERENCES_ADDRESS, cascadeMessage)
+                    .map(cascadeResult -> new JsonObject().put("preferences", savedPreferences).put("cascade", cascadeResult))
+                    .recover(error -> Future.succeededFuture(
+                            new JsonObject()
+                                    .put("preferences", savedPreferences)
+                                    .put("cascade", new JsonObject().put("error", error.getMessage()))));
+        }).onSuccess(result -> renderJson(request, result))
+          .onFailure(failure -> renderJson(request, new JsonObject().put("error", failure.getMessage()), 400));
+    }
+
+    private void sendAndReply(HttpServerRequest request, String address, JsonObject message) {
+        busRequest(address, message)
+                .onSuccess(payload -> renderJson(request, payload))
+                .onFailure(failure -> renderJson(request, new JsonObject().put("error", failure.getMessage()), 400));
+    }
+
+    private Future<JsonObject> busRequest(String address, JsonObject message) {
+        Promise<JsonObject> promise = Promise.promise();
+        
+        vertx.eventBus().request(address, message, reply -> {
+            if (reply.failed()) {
+                promise.fail(reply.cause());
+                return;
+            }
+            
+            if (!(reply.result().body() instanceof JsonObject)) {
+                promise.fail("invalid.bus.response");
+                return;
+            }
+            
+            JsonObject response = (JsonObject) reply.result().body();
+            if (!"ok".equals(response.getString("status"))) {
+                promise.fail(response.getString("message", "bus.error"));
+                return;
+            }
+            
+            Object payload = response.getValue("message");
+            promise.complete(payload instanceof JsonObject ? (JsonObject) payload : new JsonObject());
+        });
+        
+        return promise.future();
+    }
+
+    private Future<JsonObject> bodyToJson(HttpServerRequest request) {
+        Promise<JsonObject> promise = Promise.promise();
+        
+        request.bodyHandler(buffer -> {
+            if (buffer == null || buffer.length() == 0) {
+                promise.fail("body is missing");
+                return;
+            }
+            
+            try {
+                promise.complete(buffer.toJsonObject());
+            }
+            catch (Exception exception) {
+                promise.fail("invalid json body");
+            }
+        });
+        
+        return promise.future();
+    }
+}

--- a/common/src/main/java/org/entcore/common/user/dto/ManagedBy.java
+++ b/common/src/main/java/org/entcore/common/user/dto/ManagedBy.java
@@ -1,0 +1,11 @@
+package org.entcore.common.user.dto;
+
+/**
+ * Indicates who manages a preference configuration.
+ */
+public enum ManagedBy {
+    /** Set by the user themselves */
+    USER,
+    /** Set by the structure (school/organization) */
+    STRUCTURE
+}

--- a/common/src/main/java/org/entcore/common/user/dto/QuietHoursPreference.java
+++ b/common/src/main/java/org/entcore/common/user/dto/QuietHoursPreference.java
@@ -11,16 +11,6 @@ import java.util.Set;
 public class QuietHoursPreference implements Preference {
 
     /**
-     * Indicates who manages the quiet hours configuration.
-     */
-    public enum ManagedBy {
-        /** Set by the user themselves */
-        USER,
-        /** Set by the structure (school/organization) */
-        STRUCTURE
-    }
-
-    /**
      * Weekly schedule of quiet hours.
      * Array of 7 days (0=Monday, 6=Sunday), each containing the hours (0-23) that are quiet.
      * Null means no schedule is defined.
@@ -71,6 +61,7 @@ public class QuietHoursPreference implements Preference {
     @Override
     public boolean validate() {
         if (schedule == null) return true;
+        if (schedule.length == 0) return !enabled;
         if (schedule.length != 7) return false;
         for (int[] day : schedule) {
             if (day == null) return false;

--- a/common/src/main/java/org/entcore/common/user/dto/TimezonePreference.java
+++ b/common/src/main/java/org/entcore/common/user/dto/TimezonePreference.java
@@ -1,5 +1,7 @@
 package org.entcore.common.user.dto;
 
+import io.vertx.core.json.Json;
+
 import java.time.ZoneId;
 
 /**
@@ -9,6 +11,7 @@ import java.time.ZoneId;
 public class TimezonePreference implements Preference {
 
     private String timezone;
+    private ManagedBy managedBy;
 
     public String getTimezone() {
         return timezone;
@@ -18,9 +21,17 @@ public class TimezonePreference implements Preference {
         this.timezone = timezone;
     }
 
+    public ManagedBy getManagedBy() {
+        return managedBy;
+    }
+
+    public void setManagedBy(ManagedBy managedBy) {
+        this.managedBy = managedBy;
+    }
+
     @Override
     public String encode() {
-        return timezone;
+        return Json.encode(this);
     }
 
     @Override
@@ -29,7 +40,7 @@ public class TimezonePreference implements Preference {
         try {
             ZoneId.of(timezone);
             return true;
-        } catch (Exception e) {
+        } catch (Exception invalidZone) {
             return false;
         }
     }

--- a/common/src/main/java/org/entcore/common/user/mapper/UserPreferenceDtoMapper.java
+++ b/common/src/main/java/org/entcore/common/user/mapper/UserPreferenceDtoMapper.java
@@ -50,8 +50,8 @@ public final class UserPreferenceDtoMapper {
         }
         if (pref.containsKey(TIMEZONE.getMappingName())) {
            dto.getPreferences().add(TIMEZONE);
-           dto.setTimezone(new TimezonePreference());
-           dto.getTimezone().setTimezone(pref.getString(TIMEZONE.getMappingName()));
+           String encoded = pref.getString(TIMEZONE.getMappingName());
+           dto.setTimezone(decodeSafely(encoded, TimezonePreference.class));
         }
         if (pref.containsKey(QUIET_HOURS.getMappingName())) {
            dto.getPreferences().add(QUIET_HOURS);

--- a/common/src/test/java/org/entcore/common/user/QuietHoursPreferenceTest.java
+++ b/common/src/test/java/org/entcore/common/user/QuietHoursPreferenceTest.java
@@ -1,7 +1,7 @@
 package org.entcore.common.user;
 
 import org.entcore.common.user.dto.QuietHoursPreference;
-import org.entcore.common.user.dto.QuietHoursPreference.ManagedBy;
+import org.entcore.common.user.dto.ManagedBy;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -120,5 +120,31 @@ public class QuietHoursPreferenceTest {
         QuietHoursPreference pref = new QuietHoursPreference();
         pref.setManagedBy(ManagedBy.USER);
         assertEquals(ManagedBy.USER, pref.getManagedBy());
+    }
+
+    // --- validate with empty schedule ---
+
+    @Test
+    public void testValidate_EmptySchedule_Disabled_Valid() {
+        QuietHoursPreference pref = new QuietHoursPreference();
+        pref.setSchedule(new int[0][]);
+        pref.setEnabled(false);
+        assertTrue(pref.validate());
+    }
+
+    @Test
+    public void testValidate_EmptySchedule_Enabled_Invalid() {
+        QuietHoursPreference pref = new QuietHoursPreference();
+        pref.setSchedule(new int[0][]);
+        pref.setEnabled(true);
+        assertFalse(pref.validate());
+    }
+
+    @Test
+    public void testValidate_EmptySchedule_NullEnabled_Valid() {
+        // enabled defaults to false, empty schedule should be valid
+        QuietHoursPreference pref = new QuietHoursPreference();
+        pref.setSchedule(new int[0][]);
+        assertTrue(pref.validate());
     }
 }

--- a/directory/src/main/java/org/entcore/directory/controllers/StructureController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/StructureController.java
@@ -19,6 +19,7 @@
 
 package org.entcore.directory.controllers;
 
+import fr.wseduc.bus.BusAddress;
 import fr.wseduc.rs.Delete;
 import fr.wseduc.rs.Get;
 import fr.wseduc.rs.Post;
@@ -33,7 +34,15 @@ import fr.wseduc.webutils.http.BaseController;
 import fr.wseduc.webutils.http.Renders;
 
 import fr.wseduc.webutils.request.RequestUtils;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.Message;
 import io.vertx.core.file.FileSystem;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.entcore.common.appregistry.ApplicationUtils;
@@ -45,20 +54,13 @@ import org.entcore.common.notification.NotificationUtils;
 import org.entcore.common.user.DefaultFunctions;
 import org.entcore.common.user.UserInfos;
 import org.entcore.common.user.UserUtils;
+
 import org.entcore.common.utils.StringUtils;
 import org.entcore.directory.pojo.Ent;
 import org.entcore.directory.security.AdminStructureFilter;
 import org.entcore.directory.security.AnyAdminOfUser;
 import org.entcore.directory.services.MassMailService;
 import org.entcore.directory.services.SchoolService;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.eventbus.Message;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import org.vertx.java.core.http.RouteMatcher;
 
 import javax.xml.bind.JAXBContext;
@@ -954,5 +956,78 @@ public class StructureController extends BaseController {
 		});
 	}
 
-}
+	@BusAddress("directory.structure.quiethours.preferences")
+	public void structureQuietHoursPreferences(final Message<JsonObject> message) {
+		final String action = message.body().getString("action", "");
+		final String structureId = message.body().getString("structureId");
 
+		switch (action) {
+			case "get":
+				structureService.getQuietHoursPreferences(structureId, event -> {
+					if (event.isRight()) {
+						message.reply(new JsonObject()
+						        .put("status", "ok")
+								.put("message", toQuietHoursPreferencesResponse(event.right().getValue(), structureId)));
+					} else {
+						message.reply(new JsonObject()
+						        .put("status", "error")
+								.put("message", event.left().getValue()));
+					}
+				});
+				break;
+			case "set":
+				final JsonObject preferences = message.body().getJsonObject("preferences", new JsonObject());
+				structureService.setQuietHoursPreferences(structureId, preferences, event -> {
+					if (event.isRight()) {
+						message.reply(new JsonObject()
+						        .put("status", "ok")
+								.put("message", toQuietHoursPreferencesResponse(event.right().getValue(), structureId)));
+					} else {
+						message.reply(new JsonObject()
+						        .put("status", "error")
+								.put("message", event.left().getValue()));
+					}
+				});
+				break;
+			default:
+				message.reply(new JsonObject()
+				        .put("status", "error")
+						.put("message", "Invalid action: " + action));
+		}
+	}
+
+	private JsonObject toQuietHoursPreferencesResponse(JsonObject data, String structureId) {
+		final JsonObject output = new JsonObject();
+		
+		if (data == null) {
+			return output;
+		}
+		
+		final String timezoneStr = data.getString("notificationTimezone");
+		if (timezoneStr != null) {
+			try {
+				final JsonObject parsedTimezone = new JsonObject(timezoneStr);
+				final String timezone = parsedTimezone.getString("timezone");
+				if (timezone != null) {
+					output.put("timezone", timezone);
+				}
+			} catch (Exception decodeException) {
+				log.error("Failed to decode timezone preference for structure " + structureId, decodeException);
+			}
+		}
+
+		final String quietHoursStr = data.getString("notificationQuietHours");
+		if (quietHoursStr != null) {
+			try {
+				final JsonObject quietHours = new JsonObject(quietHoursStr);
+				quietHours.remove("managedBy");
+				output.put("quietHours", quietHours);
+			} catch (Exception decodeException) {
+				log.error("Failed to decode quietHours preference for structure " + structureId, decodeException);
+			}
+		}
+		
+		return output;
+	}
+
+}

--- a/directory/src/main/java/org/entcore/directory/controllers/UserBookController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/UserBookController.java
@@ -36,6 +36,7 @@ import fr.wseduc.webutils.request.RequestUtils;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.Message;
@@ -621,6 +622,22 @@ public class UserBookController extends BaseController {
 										.put("message", e.getMessage()));
 							});
 				break;
+			case "cascade.structure.quiethours.preferences":
+				final String structureId = message.body().getString("structureId");
+				if (structureId == null) {
+					message.reply(new JsonObject()
+					        .put("status", "error")
+							.put("message", "structureId is required"));
+					break;
+				}
+				cascadeQuietHoursPreferences(structureId)
+						.onSuccess(result -> message.reply(new JsonObject()
+								.put("status", "ok")
+								.put("message", result)))
+						.onFailure(error -> message.reply(new JsonObject()
+								.put("status", "error")
+								.put("message", error.getMessage())));
+				break;
 			default:
 				message.reply(new JsonObject().put("status", "error")
 						.put("message", "Invalid action."));
@@ -628,6 +645,53 @@ public class UserBookController extends BaseController {
 		}
 
 
+	}
+
+	private static final String USER_MANAGED_MARKER = "\"managedBy\":\"USER\"";
+
+	private Future<JsonObject> cascadeQuietHoursPreferences(String structureId) {
+		final Promise<JsonObject> promise = Promise.promise();
+
+		final String query =
+			"MATCH (s:Structure {id: {structureId}})<-[:DEPENDS]-(:ProfileGroup)<-[:IN]-(u:User) " +
+			"WITH s, collect(DISTINCT u) AS allUsers " +
+			"WITH s, allUsers, size(allUsers) AS totalUsers " +
+			"WHERE s.notificationTimezone IS NOT NULL OR s.notificationQuietHours IS NOT NULL " +
+			"UNWIND allUsers AS u " +
+			"OPTIONAL MATCH (u)-[:PREFERS]->(uac:UserAppConf) " +
+			"WITH s, u, uac, totalUsers, " +
+			"  (s.notificationTimezone IS NOT NULL AND (uac IS NULL OR uac.timezone IS NULL OR NOT uac.timezone CONTAINS {userManagedMarker})) AS shouldUpdateTimezone, " +
+			"  (s.notificationQuietHours IS NOT NULL AND (uac IS NULL OR uac.quietHours IS NULL OR NOT uac.quietHours CONTAINS {userManagedMarker})) AS shouldUpdateQuietHours " +
+			"WHERE shouldUpdateTimezone OR shouldUpdateQuietHours " +
+			"MERGE (u)-[:PREFERS]->(uac2:UserAppConf) " +
+			"FOREACH (_ IN CASE WHEN shouldUpdateTimezone THEN [1] ELSE [] END | SET uac2.timezone = s.notificationTimezone) " +
+			"FOREACH (_ IN CASE WHEN shouldUpdateQuietHours THEN [1] ELSE [] END | SET uac2.quietHours = s.notificationQuietHours) " +
+			"RETURN totalUsers, count(DISTINCT u) AS updatedUsers";
+
+		final JsonObject params = new JsonObject()
+				.put("structureId", structureId)
+				.put("userManagedMarker", USER_MANAGED_MARKER);
+
+		Neo4j.getInstance().execute(query, params, validUniqueResultHandler(event -> {
+			if (event.isRight()) {
+				final JsonObject row = event.right().getValue();
+				if (row == null || row.isEmpty()) {
+					promise.complete(new JsonObject()
+							.put("updatedUsers", 0)
+							.put("skippedUsers", 0));
+				} else {
+					final int updated = row.getInteger("updatedUsers", 0);
+					final int total = row.getInteger("totalUsers", 0);
+					promise.complete(new JsonObject()
+							.put("updatedUsers", updated)
+							.put("skippedUsers", Math.max(total - updated, 0)));
+				}
+			} else {
+				promise.fail(event.left().getValue());
+			}
+		}));
+
+		return promise.future();
 	}
 
 	@Get("/avatar/")

--- a/directory/src/main/java/org/entcore/directory/services/SchoolService.java
+++ b/directory/src/main/java/org/entcore/directory/services/SchoolService.java
@@ -25,6 +25,7 @@ import org.entcore.common.user.UserInfos;
 
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -108,5 +109,40 @@ public interface SchoolService {
 	void activateGar(String garId, JsonArray targetUAIs, String groupName, String appName, String roleName, JsonObject raAssignmentPolicy, Handler<Either<String, JsonObject>> handler);
 
     Future<JsonArray> listContacts(String structureId);
+
+    /**
+     * Retrieve structure quiet hours preferences (notificationTimezone + notificationQuietHours).
+     */
+    void getQuietHoursPreferences(String structureId, Handler<Either<String, JsonObject>> handler);
+
+    /**
+     * Save structure-level quiet hours/timezone preferences.
+     * Normalizes input: adds managedBy=STRUCTURE, handles empty schedule -> enabled=false.
+     */
+    void setQuietHoursPreferences(String structureId, JsonObject body, Handler<Either<String, JsonObject>> handler);
+
+    default Future<JsonObject> getQuietHoursPreferences(String structureId) {
+        Promise<JsonObject> promise = Promise.promise();
+        getQuietHoursPreferences(structureId, result -> {
+            if (result.isRight()) {
+                promise.complete(result.right().getValue());
+            } else {
+                promise.fail(result.left().getValue());
+            }
+        });
+        return promise.future();
+    }
+
+    default Future<JsonObject> setQuietHoursPreferences(String structureId, JsonObject body) {
+        Promise<JsonObject> promise = Promise.promise();
+        setQuietHoursPreferences(structureId, body, result -> {
+            if (result.isRight()) {
+                promise.complete(result.right().getValue());
+            } else {
+                promise.fail(result.left().getValue());
+            }
+        });
+        return promise.future();
+    }
 
 }

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultSchoolService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultSchoolService.java
@@ -26,6 +26,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
@@ -34,6 +35,9 @@ import org.entcore.common.neo4j.Neo4j;
 import org.entcore.common.neo4j.Neo4jResult;
 import org.entcore.common.neo4j.StatementsBuilder;
 import org.entcore.common.user.UserInfos;
+import org.entcore.common.user.dto.ManagedBy;
+import org.entcore.common.user.dto.QuietHoursPreference;
+import org.entcore.common.user.dto.TimezonePreference;
 import org.entcore.common.utils.StringUtils;
 import org.entcore.common.validation.StringValidation;
 import org.entcore.directory.Directory;
@@ -798,6 +802,121 @@ public class DefaultSchoolService implements SchoolService {
 			}
 		}));
 		return promise.future();
+	}
+
+	@Override
+	public void getQuietHoursPreferences(String structureId, Handler<Either<String, JsonObject>> handler) {
+		String query = "MATCH (s:Structure {id: {structureId}}) RETURN s.notificationTimezone as notificationTimezone, s.notificationQuietHours as notificationQuietHours";
+		JsonObject params = new JsonObject().put("structureId", structureId);
+		neo.execute(query, params, validUniqueResultHandler(handler));
+	}
+
+	@Override
+	public void setQuietHoursPreferences(String structureId, JsonObject body, Handler<Either<String, JsonObject>> handler) {
+		final QuietHoursPreference quietHours = buildQuietHoursPreference(body);
+		if (quietHours == null) {
+			handler.handle(new Either.Left<>("invalid.preference.data"));
+			return;
+		}
+
+		final TimezonePreference timezone = buildTimezonePreferenceFromBody(body);
+
+		if (!timezone.validate() || !quietHours.validate()) {
+			handler.handle(new Either.Left<>("invalid.preference.data"));
+			return;
+		}
+
+		final boolean overwriteTimezone = hasExplicitTimezone(body);
+		doUpdate(structureId, timezone, quietHours, overwriteTimezone, handler);
+	}
+
+	private static boolean hasExplicitTimezone(JsonObject body) {
+		final String value = body.getString("timezone");
+		return !StringUtils.isEmpty(value);
+	}
+
+	private static TimezonePreference buildTimezonePreferenceFromBody(JsonObject body) {
+		final TimezonePreference timezone = new TimezonePreference();
+		final String value = body.getString("timezone");
+		if (!StringUtils.isEmpty(value)) {
+			timezone.setTimezone(value);
+		}
+		timezone.setManagedBy(ManagedBy.STRUCTURE);
+		return timezone;
+	}
+
+	private QuietHoursPreference buildQuietHoursPreference(JsonObject body) {
+		final JsonObject quietHoursBody = body.getJsonObject("quietHours", new JsonObject());
+		final JsonArray schedule = quietHoursBody.getJsonArray("schedule", new JsonArray());
+		if (schedule.size() > 7) return null;
+
+		final Boolean enabled = quietHoursBody.getBoolean("enabled");
+		if (enabled == null) return null;
+
+		final int[][] converted;
+		try {
+			converted = convertSchedule(schedule);
+		} catch (IllegalArgumentException parsingError) {
+			return null;
+		}
+
+		final QuietHoursPreference quietHours = new QuietHoursPreference();
+		quietHours.setSchedule(converted);
+		quietHours.setEnabled(enabled);
+		quietHours.setManagedBy(ManagedBy.STRUCTURE);
+		
+		return quietHours;
+	}
+
+	private void doUpdate(String structureId, TimezonePreference timezonePreference, QuietHoursPreference quietHoursPreference, boolean overwriteTimezone, Handler<Either<String, JsonObject>> handler) {
+		final JsonObject params = new JsonObject()
+				.put("structureId", structureId)
+				.put("notificationQuietHours", quietHoursPreference.encode());
+
+		final String query;
+		if (overwriteTimezone) {
+			query = "MATCH (s:Structure {id: {structureId}}) " +
+					"SET s.notificationTimezone = {notificationTimezone}, " +
+					"    s.notificationQuietHours = {notificationQuietHours} " +
+					"RETURN s.notificationTimezone as notificationTimezone, s.notificationQuietHours as notificationQuietHours";
+			params.put("notificationTimezone", timezonePreference.encode());
+		} else {
+			query = "MATCH (s:Structure {id: {structureId}}) " +
+					"SET s.notificationTimezone = CASE WHEN s.notificationTimezone IS NOT NULL AND s.notificationTimezone <> '' " +
+					"  THEN s.notificationTimezone ELSE {notificationTimezone} END, " +
+					"    s.notificationQuietHours = {notificationQuietHours} " +
+					"RETURN s.notificationTimezone as notificationTimezone, s.notificationQuietHours as notificationQuietHours";
+			params.put("notificationTimezone", timezonePreference.encode());
+		}
+
+		neo.execute(query, params, validUniqueResultHandler(handler));
+	}
+
+	private static int[][] convertSchedule(JsonArray schedule) {
+		if (schedule == null || schedule.isEmpty()) {
+			return new int[0][];
+		}
+		
+		int[][] result = new int[schedule.size()][];
+		for (int dayIndex = 0; dayIndex < result.length; dayIndex++) {
+			final Object dayValue = schedule.getValue(dayIndex);
+			if (!(dayValue instanceof JsonArray)) {
+				throw new IllegalArgumentException("Each day must be an array");
+			}
+
+			JsonArray day = (JsonArray) dayValue;
+			result[dayIndex] = new int[day.size()];
+			
+			for (int hourIndex = 0; hourIndex < day.size(); hourIndex++) {
+				final Integer hour = day.getInteger(hourIndex);
+				if (hour == null) {
+					throw new IllegalArgumentException("Schedule must contain integers only");
+				}
+				result[dayIndex][hourIndex] = hour;
+			}
+		}
+		
+		return result;
 	}
 
 }

--- a/directory/src/test/java/org/entcore/directory/services/impl/DefaultSchoolServiceTest.java
+++ b/directory/src/test/java/org/entcore/directory/services/impl/DefaultSchoolServiceTest.java
@@ -1,7 +1,9 @@
 package org.entcore.directory.services.impl;
 
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
@@ -9,6 +11,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.entcore.common.events.EventStoreFactory;
 import org.entcore.common.neo4j.Neo4j;
+import org.entcore.common.user.dto.TimezonePreference;
 import org.entcore.test.TestHelper;
 import org.entcore.test.preparation.*;
 import org.junit.BeforeClass;
@@ -102,5 +105,217 @@ public class DefaultSchoolServiceTest {
                 .withUser(adml)
                     .adml(adml.getId(), "my-structure-01")
                 .execute();
+    }
+
+    // -----------------------------------------------------------------------
+    //  Helper methods for quiet hours / timezone preference tests
+    // -----------------------------------------------------------------------
+
+    private Future<JsonObject> setQuietHoursPreferences(String structureId, JsonObject body) {
+        final Promise<JsonObject> promise = Promise.promise();
+        defaultSchoolService.setQuietHoursPreferences(structureId, body, result -> {
+            if (result.isRight()) {
+                promise.complete(result.right().getValue());
+            } else {
+                promise.fail(result.left().getValue());
+            }
+        });
+        return promise.future();
+    }
+
+    private Future<JsonObject> getQuietHoursPreferences(String structureId) {
+        final Promise<JsonObject> promise = Promise.promise();
+        defaultSchoolService.getQuietHoursPreferences(structureId, result -> {
+            if (result.isRight()) {
+                promise.complete(result.right().getValue());
+            } else {
+                promise.fail(result.left().getValue());
+            }
+        });
+        return promise.future();
+    }
+
+    // -----------------------------------------------------------------------
+    //  Timezone preservation tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSetQuietHoursPreferences_timezoneAbsent_preservesExisting(final TestContext context) {
+        final Async async = context.async();
+        final String structureId = "my-structure-01";
+
+        final JsonObject initialBody = new JsonObject()
+                .put("timezone", "Europe/Paris")
+                .put("quietHours", new JsonObject()
+                        .put("schedule", new JsonArray())
+                        .put("enabled", true));
+
+        // Update without any "timezone" key at all
+        final JsonObject updateBody = new JsonObject()
+                .put("quietHours", new JsonObject()
+                        .put("schedule", new JsonArray())
+                        .put("enabled", true));
+
+        setQuietHoursPreferences(structureId, initialBody)
+                .compose(ignored -> setQuietHoursPreferences(structureId, updateBody))
+                .compose(ignored -> getQuietHoursPreferences(structureId))
+                .onComplete(asyncResult -> {
+                    if (asyncResult.succeeded()) {
+                        final JsonObject preferences = asyncResult.result();
+                        final String timezoneJson = preferences.getString("notificationTimezone");
+                        context.assertNotNull(timezoneJson, "timezone should be preserved when absent from request");
+                        final TimezonePreference timezone = Json.decodeValue(timezoneJson, TimezonePreference.class);
+                        context.assertEquals("Europe/Paris", timezone.getTimezone());
+                    } else {
+                        context.fail(asyncResult.cause());
+                    }
+                    async.complete();
+                });
+    }
+
+
+
+    @Test
+    public void testSetQuietHoursPreferences_explicitTimezoneUpdate_works(final TestContext context) {
+        final Async async = context.async();
+        final String structureId = "my-structure-01";
+
+        final JsonObject initialBody = new JsonObject()
+                .put("timezone", "Europe/Paris")
+                .put("quietHours", new JsonObject()
+                        .put("schedule", new JsonArray())
+                        .put("enabled", true));
+
+        // Update with a different explicit timezone
+        final JsonObject updateBody = new JsonObject()
+                .put("timezone", "America/Chicago")
+                .put("quietHours", new JsonObject()
+                        .put("schedule", new JsonArray())
+                        .put("enabled", true));
+
+        setQuietHoursPreferences(structureId, initialBody)
+                .compose(ignored -> setQuietHoursPreferences(structureId, updateBody))
+                .compose(ignored -> getQuietHoursPreferences(structureId))
+                .onComplete(asyncResult -> {
+                    if (asyncResult.succeeded()) {
+                        final JsonObject preferences = asyncResult.result();
+                        final String timezoneJson = preferences.getString("notificationTimezone");
+                        context.assertNotNull(timezoneJson);
+                        final TimezonePreference timezone = Json.decodeValue(timezoneJson, TimezonePreference.class);
+                        context.assertEquals("America/Chicago", timezone.getTimezone(),
+                                "explicit timezone update should replace previous value");
+                    } else {
+                        context.fail(asyncResult.cause());
+                    }
+                    async.complete();
+                });
+    }
+
+    // -----------------------------------------------------------------------
+    //  Schedule validation hardening tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSetQuietHoursPreferences_invalidScheduleTooManyDays_rejected(final TestContext context) {
+        final Async async = context.async();
+        final String structureId = "my-structure-01";
+
+        // More than 7 days is invalid
+        final JsonArray badSchedule = new JsonArray();
+        for (int dayCounter = 0; dayCounter < 8; dayCounter++) {
+            badSchedule.add(new JsonArray());
+        }
+
+        final JsonObject body = new JsonObject()
+                .put("quietHours", new JsonObject()
+                        .put("schedule", badSchedule)
+                        .put("enabled", true));
+
+        defaultSchoolService.setQuietHoursPreferences(structureId, body, result -> {
+            context.assertTrue(result.isLeft(), "schedule with >7 days should be rejected");
+            context.assertEquals("invalid.preference.data", result.left().getValue());
+            async.complete();
+        });
+    }
+
+    @Test
+    public void testSetQuietHoursPreferences_invalidScheduleNonInteger_rejected(final TestContext context) {
+        final Async async = context.async();
+        final String structureId = "my-structure-01";
+
+        // 7 days but with non-integer hour values
+        final JsonArray badSchedule = new JsonArray();
+        for (int dayCounter = 0; dayCounter < 7; dayCounter++) {
+            badSchedule.add(new JsonArray().add("not-a-number"));
+        }
+
+        final JsonObject body = new JsonObject()
+                .put("quietHours", new JsonObject()
+                        .put("schedule", badSchedule)
+                        .put("enabled", true));
+
+        defaultSchoolService.setQuietHoursPreferences(structureId, body, result -> {
+            context.assertTrue(result.isLeft(), "schedule with non-integer values should be rejected");
+            context.assertEquals("invalid.preference.data", result.left().getValue());
+            async.complete();
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    //  Enabled validation tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSetQuietHoursPreferences_enabledAbsent_rejected(final TestContext context) {
+        final Async async = context.async();
+        final String structureId = "my-structure-01";
+
+        final JsonObject body = new JsonObject()
+                .put("timezone", "Europe/Paris")
+                .put("quietHours", new JsonObject()
+                        .put("schedule", new JsonArray()));
+        // No "enabled" in quietHours
+
+        defaultSchoolService.setQuietHoursPreferences(structureId, body, result -> {
+            context.assertTrue(result.isLeft(), "missing 'enabled' should be rejected");
+            context.assertEquals("invalid.preference.data", result.left().getValue());
+            async.complete();
+        });
+    }
+
+    @Test
+    public void testSetQuietHoursPreferences_enabledFalse_emptySchedule_accepted(final TestContext context) {
+        final Async async = context.async();
+        final String structureId = "my-structure-01";
+
+        final JsonObject body = new JsonObject()
+                .put("timezone", "Europe/Paris")
+                .put("quietHours", new JsonObject()
+                        .put("schedule", new JsonArray())
+                        .put("enabled", false));
+
+        defaultSchoolService.setQuietHoursPreferences(structureId, body, result -> {
+            context.assertTrue(result.isRight(), "enabled=false with empty schedule should be accepted");
+            async.complete();
+        });
+    }
+
+    @Test
+    public void testSetQuietHoursPreferences_enabledTrue_emptySchedule_rejected(final TestContext context) {
+        final Async async = context.async();
+        final String structureId = "my-structure-01";
+
+        final JsonObject body = new JsonObject()
+                .put("timezone", "Europe/Paris")
+                .put("quietHours", new JsonObject()
+                        .put("schedule", new JsonArray())
+                        .put("enabled", true));
+
+        defaultSchoolService.setQuietHoursPreferences(structureId, body, result -> {
+            // validate() returns false when enabled=true and schedule.length==0
+            context.assertTrue(result.isLeft(), "enabled=true with empty schedule should be rejected");
+            context.assertEquals("invalid.preference.data", result.left().getValue());
+            async.complete();
+        });
     }
 }

--- a/timeline/src/main/java/org/entcore/timeline/controllers/helper/NotificationHelper.java
+++ b/timeline/src/main/java/org/entcore/timeline/controllers/helper/NotificationHelper.java
@@ -163,11 +163,15 @@ public class NotificationHelper {
      * Returns null if absent or malformed.
      */
     static TimezonePreference parseTimezone(JsonObject user) {
-        String tz = user.getString("timezone");
-        if (tz == null) return null;
-        TimezonePreference pref = new TimezonePreference();
-        pref.setTimezone(tz);
-        return pref;
+        String json = user.getString("timezone");
+        if (json == null) return null;
+
+        try {
+            return Json.decodeValue(json, TimezonePreference.class);
+        } catch (Exception e) {
+            log.warn("[NotificationHelper] Cannot parse timezone preference: " + e.getMessage());
+            return null;
+        }
     }
 
 


### PR DESCRIPTION
# Description

Plages silencieuses US5, partie back.
Requêtes pour tester dispo dans Postman.

## Fixes

[#IMPULS-5747](https://edifice-community.atlassian.net/browse/IMPULS-5747)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [x] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [x] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [x] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: