### PR TITLE
feat(directory): #IMPULS-5911 add endpoint to update and retreive default auth configuration

### DIFF
--- a/directory/src/main/java/org/entcore/directory/controllers/StructureController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/StructureController.java
@@ -28,16 +28,13 @@ import fr.wseduc.security.ActionType;
 import fr.wseduc.security.MfaProtected;
 import fr.wseduc.security.SecuredAction;
 import fr.wseduc.webutils.Either;
-import fr.wseduc.webutils.data.FileResolver;
 import fr.wseduc.webutils.email.EmailSender;
 import fr.wseduc.webutils.http.BaseController;
 import fr.wseduc.webutils.http.Renders;
-
 import fr.wseduc.webutils.request.RequestUtils;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.http.HttpServerRequest;
@@ -46,17 +43,17 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.entcore.common.appregistry.ApplicationUtils;
-import org.entcore.common.http.filter.AdmlOfStructure;
 import org.entcore.common.http.filter.AdminFilter;
+import org.entcore.common.http.filter.AdmlOfStructure;
 import org.entcore.common.http.filter.ResourceFilter;
 import org.entcore.common.http.filter.SuperAdminFilter;
 import org.entcore.common.notification.NotificationUtils;
 import org.entcore.common.user.DefaultFunctions;
 import org.entcore.common.user.UserInfos;
 import org.entcore.common.user.UserUtils;
-
 import org.entcore.common.utils.StringUtils;
 import org.entcore.directory.pojo.Ent;
+import org.entcore.directory.pojo.structure.DefaultAuthModeConfig;
 import org.entcore.directory.security.AdminStructureFilter;
 import org.entcore.directory.security.AnyAdminOfUser;
 import org.entcore.directory.services.MassMailService;
@@ -66,18 +63,14 @@ import org.vertx.java.core.http.RouteMatcher;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
-
-import java.io.IOException;
-import java.io.StringReader;
 import java.io.StringWriter;
-import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static fr.wseduc.webutils.Utils.handlerToAsyncHandler;
 import static fr.wseduc.webutils.Utils.isEmpty;
+import static fr.wseduc.webutils.request.RequestUtils.bodyToClass;
 import static fr.wseduc.webutils.request.RequestUtils.bodyToJson;
 import static org.entcore.common.http.response.DefaultResponseHandler.*;
 
@@ -121,6 +114,31 @@ public class StructureController extends BaseController {
 				});
 			}
 		});
+	}
+
+	@Put("/structure/:structureId/default-auth-config")
+	@SecuredAction(value = "", type = ActionType.RESOURCE)
+	@MfaProtected()
+	@ResourceFilter(SuperAdminFilter.class)
+	public void updateDefaultAuth(final HttpServerRequest request) {
+		bodyToClass(request, DefaultAuthModeConfig.class)
+				.onSuccess(	body -> UserUtils.getUserInfos(eb, request, user -> {
+            String structureId = request.params().get("structureId");
+			log.info(String.format("Updating default auth config by %s for structure %s", user.getUserId(), structureId));
+            structureService.updateDefaultAuth(user, structureId, body)
+					.onSuccess( v -> ok(request))
+					.onFailure( th -> new JsonObject().put("error", th.getMessage()));
+        })).onFailure(th -> badRequest(request));
+	}
+
+	@Get("/structure/:structureId/default-auth-config")
+	@SecuredAction(value = "", type = ActionType.RESOURCE)
+	@MfaProtected()
+	public void getDefaultAuth(final HttpServerRequest request) {
+		String structureId = request.params().get("structureId");
+		structureService.getDefaultAuth(structureId)
+				.onSuccess( (defaultAuth) -> renderJson(request, JsonObject.mapFrom(defaultAuth)))
+				.onFailure( th -> new JsonObject().put("error", th.getMessage()));
 	}
 
 	@Put("/structure/:structureId/link/:userId")
@@ -750,7 +768,7 @@ public class StructureController extends BaseController {
 									if (block) {
 										NotificationUtils.deleteFcmTokens(usersId, ar -> {
 											if (ar.isLeft()) {
-												log.error("Failed to delete FCM tokens when block structure : " + structureId, ar.left().getValue());
+												log.error("Failed to delete FCM tokens when block structure : " + structureId + " " + ar.left().getValue());
 											}
 										});
 									}
@@ -990,11 +1008,11 @@ public class StructureController extends BaseController {
 
 	private JsonObject toQuietHoursPreferencesResponse(JsonObject data, String structureId) {
 		final JsonObject output = new JsonObject();
-		
+
 		if (data == null) {
 			return output;
 		}
-		
+
 		final String timezoneStr = data.getString("notificationTimezone");
 		if (timezoneStr != null) {
 			try {
@@ -1018,7 +1036,7 @@ public class StructureController extends BaseController {
 				log.error("Failed to decode quietHours preference for structure " + structureId, decodeException);
 			}
 		}
-		
+
 		return output;
 	}
 

--- a/directory/src/main/java/org/entcore/directory/pojo/structure/DefaultAuthModeConfig.java
+++ b/directory/src/main/java/org/entcore/directory/pojo/structure/DefaultAuthModeConfig.java
@@ -1,0 +1,48 @@
+package org.entcore.directory.pojo.structure;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DefaultAuthModeConfig {
+
+    private final Map<Profile, DefaultAuthMode> defaultAuthModes = new HashMap<>();
+
+    public Map<Profile, DefaultAuthMode> getDefaultAuthModes() {
+        return defaultAuthModes;
+    }
+
+    public enum DefaultAuthMode {
+        ENT,
+        FEDERATED;
+    }
+
+    public enum Profile {
+
+        PERSONNEL("Personnel"),
+        STUDENT("Student"),
+        TEACHER("Teacher"),
+        RELATIVE("Relative"),
+        GUEST("Guest");
+
+        private final String neo4jName;
+
+        Profile(String neo4jName) {
+            this.neo4jName = neo4jName;
+        }
+
+        public static Profile fromNeo4j(String profile) {
+            for (Profile p : Profile.values()) {
+                if (p.neo4jName.equals(profile)) {
+                    return p;
+                }
+            }
+            return null;
+        }
+
+        public String getNeo4jName(){
+            return neo4jName;
+        }
+
+
+    }
+}

--- a/directory/src/main/java/org/entcore/directory/services/SchoolService.java
+++ b/directory/src/main/java/org/entcore/directory/services/SchoolService.java
@@ -20,13 +20,12 @@
 package org.entcore.directory.services;
 
 import fr.wseduc.webutils.Either;
-
-import org.entcore.common.user.UserInfos;
-
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.entcore.common.user.UserInfos;
+import org.entcore.directory.pojo.structure.DefaultAuthModeConfig;
 
 import java.util.List;
 
@@ -109,6 +108,7 @@ public interface SchoolService {
 
     Future<JsonArray> listContacts(String structureId);
 
+<<<<<<< HEAD
     /**
      * Retrieve structure quiet hours preferences (notificationTimezone + notificationQuietHours).
      */
@@ -125,4 +125,9 @@ public interface SchoolService {
      */
     Future<JsonObject> cascadeQuietHoursPreferences(String structureId);
 
+=======
+    Future<Void> updateDefaultAuth(UserInfos user, String structureId, DefaultAuthModeConfig body);
+
+	Future<DefaultAuthModeConfig> getDefaultAuth(String structureId);
+>>>>>>> 374ec0bcb (feat(directory): #IMPULS-5911 add endpoint to update and retreive default auth configuration)
 }

--- a/directory/src/main/java/org/entcore/directory/services/SchoolService.java
+++ b/directory/src/main/java/org/entcore/directory/services/SchoolService.java
@@ -108,7 +108,6 @@ public interface SchoolService {
 
     Future<JsonArray> listContacts(String structureId);
 
-<<<<<<< HEAD
     /**
      * Retrieve structure quiet hours preferences (notificationTimezone + notificationQuietHours).
      */
@@ -125,9 +124,19 @@ public interface SchoolService {
      */
     Future<JsonObject> cascadeQuietHoursPreferences(String structureId);
 
-=======
-    Future<Void> updateDefaultAuth(UserInfos user, String structureId, DefaultAuthModeConfig body);
+	/**
+	 * Add default autheentication method of the structure
+	 * @param user Current user
+	 * @param structureId target structure
+	 * @param config List of authentication method by profile
+	 * @return
+	 */
+    Future<Void> updateDefaultAuth(UserInfos user, String structureId, DefaultAuthModeConfig config);
 
+	/**
+	 * Get current authentication default method by structure
+	 * @param structureId
+	 * @return
+	 */
 	Future<DefaultAuthModeConfig> getDefaultAuth(String structureId);
->>>>>>> 374ec0bcb (feat(directory): #IMPULS-5911 add endpoint to update and retreive default auth configuration)
 }

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultSchoolService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultSchoolService.java
@@ -41,11 +41,13 @@ import org.entcore.common.user.dto.TimezonePreference;
 import org.entcore.common.utils.StringUtils;
 import org.entcore.common.validation.StringValidation;
 import org.entcore.directory.Directory;
+import org.entcore.directory.pojo.structure.DefaultAuthModeConfig;
 import org.entcore.directory.services.SchoolService;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
@@ -805,6 +807,7 @@ public class DefaultSchoolService implements SchoolService {
 	}
 
 	@Override
+<<<<<<< HEAD
 	public Future<JsonObject> getQuietHoursPreferences(String structureId) {
 		Promise<JsonObject> promise = Promise.promise();
 		String query = "MATCH (s:Structure {id: {structureId}}) RETURN s.notificationTimezone as notificationTimezone, s.notificationQuietHours as notificationQuietHours";
@@ -814,12 +817,33 @@ public class DefaultSchoolService implements SchoolService {
 				promise.complete(either.right().getValue());
 			} else {
 				promise.fail(either.left().getValue());
+=======
+	public Future<Void> updateDefaultAuth(UserInfos user, String structureId, DefaultAuthModeConfig body) {
+		final Promise<Void> promise = Promise.promise();
+		final StringBuilder query = new StringBuilder(
+				"MATCH (s:Structure {id: {structureId}}) ")
+		.append("OPTIONAL MATCH (s)-[:HAS_AUTH_DEFAULT]->(d:AuthDefault) ")
+		.append("DETACH DELETE d ");
+		for (Map.Entry<DefaultAuthModeConfig.Profile, DefaultAuthModeConfig.DefaultAuthMode> entry : body.getDefaultAuthModes().entrySet()) {
+			query.append(String.format(" MERGE (s)-[:HAS_AUTH_DEFAULT]->(:AuthDefault { profile: '%s', auth: '%s' }) ",
+					entry.getKey().getNeo4jName(),
+					entry.getValue().name()));
+		}
+		final JsonObject params = new JsonObject().put("structureId", structureId);
+
+		neo.execute(query.toString(), params, validResultHandler(results -> {
+			if (results.isRight()) {
+				promise.complete();
+			} else {
+				promise.fail(results.left().getValue());
+>>>>>>> 374ec0bcb (feat(directory): #IMPULS-5911 add endpoint to update and retreive default auth configuration)
 			}
 		}));
 		return promise.future();
 	}
 
 	@Override
+<<<<<<< HEAD
 	public Future<JsonObject> setQuietHoursPreferences(String structureId, JsonObject body) {
 		Promise<JsonObject> promise = Promise.promise();
 
@@ -997,4 +1021,32 @@ public class DefaultSchoolService implements SchoolService {
 		return result;
 	}
 
+=======
+	public Future<DefaultAuthModeConfig> getDefaultAuth(String structureId) {
+		final Promise<DefaultAuthModeConfig> promise = Promise.promise();
+		final StringBuilder query = new StringBuilder(
+				"MATCH (s:Structure {id: {structureId}})-[:HAS_AUTH_DEFAULT]->(d:AuthDefault) ")
+				.append(" WITH collect({ profile: d.profile, auth: d.auth }) as defaultAuthConfig ")
+				.append("RETURN defaultAuthConfig ");
+		final JsonObject params = new JsonObject().put("structureId", structureId);
+
+		neo.execute(query.toString(), params, validUniqueResultHandler( results -> {
+			if (results.isRight()) {
+				JsonArray data = results.right().getValue().getJsonArray("defaultAuthConfig");
+				DefaultAuthModeConfig config = new DefaultAuthModeConfig();
+				for (Object o : data) {
+					JsonObject json = (JsonObject) o;
+					config.getDefaultAuthModes().put(
+							DefaultAuthModeConfig.Profile.fromNeo4j(json.getString("profile")),
+							DefaultAuthModeConfig.DefaultAuthMode.valueOf(json.getString("auth")));
+				}
+				promise.complete(config);
+			} else {
+				promise.fail(results.left().getValue());
+			}
+		}));
+		return promise.future();
+	}
+
+>>>>>>> 374ec0bcb (feat(directory): #IMPULS-5911 add endpoint to update and retreive default auth configuration)
 }

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultSchoolService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultSchoolService.java
@@ -821,6 +821,7 @@ public class DefaultSchoolService implements SchoolService {
 		return promise.future();
 	}
 
+	@Override
 	public Future<JsonObject> setQuietHoursPreferences(String structureId, JsonObject body) {
 		Promise<JsonObject> promise = Promise.promise();
 

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultSchoolService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultSchoolService.java
@@ -807,7 +807,6 @@ public class DefaultSchoolService implements SchoolService {
 	}
 
 	@Override
-<<<<<<< HEAD
 	public Future<JsonObject> getQuietHoursPreferences(String structureId) {
 		Promise<JsonObject> promise = Promise.promise();
 		String query = "MATCH (s:Structure {id: {structureId}}) RETURN s.notificationTimezone as notificationTimezone, s.notificationQuietHours as notificationQuietHours";
@@ -817,33 +816,11 @@ public class DefaultSchoolService implements SchoolService {
 				promise.complete(either.right().getValue());
 			} else {
 				promise.fail(either.left().getValue());
-=======
-	public Future<Void> updateDefaultAuth(UserInfos user, String structureId, DefaultAuthModeConfig body) {
-		final Promise<Void> promise = Promise.promise();
-		final StringBuilder query = new StringBuilder(
-				"MATCH (s:Structure {id: {structureId}}) ")
-		.append("OPTIONAL MATCH (s)-[:HAS_AUTH_DEFAULT]->(d:AuthDefault) ")
-		.append("DETACH DELETE d ");
-		for (Map.Entry<DefaultAuthModeConfig.Profile, DefaultAuthModeConfig.DefaultAuthMode> entry : body.getDefaultAuthModes().entrySet()) {
-			query.append(String.format(" MERGE (s)-[:HAS_AUTH_DEFAULT]->(:AuthDefault { profile: '%s', auth: '%s' }) ",
-					entry.getKey().getNeo4jName(),
-					entry.getValue().name()));
-		}
-		final JsonObject params = new JsonObject().put("structureId", structureId);
-
-		neo.execute(query.toString(), params, validResultHandler(results -> {
-			if (results.isRight()) {
-				promise.complete();
-			} else {
-				promise.fail(results.left().getValue());
->>>>>>> 374ec0bcb (feat(directory): #IMPULS-5911 add endpoint to update and retreive default auth configuration)
 			}
 		}));
 		return promise.future();
 	}
 
-	@Override
-<<<<<<< HEAD
 	public Future<JsonObject> setQuietHoursPreferences(String structureId, JsonObject body) {
 		Promise<JsonObject> promise = Promise.promise();
 
@@ -1021,7 +998,6 @@ public class DefaultSchoolService implements SchoolService {
 		return result;
 	}
 
-=======
 	public Future<DefaultAuthModeConfig> getDefaultAuth(String structureId) {
 		final Promise<DefaultAuthModeConfig> promise = Promise.promise();
 		final StringBuilder query = new StringBuilder(
@@ -1048,5 +1024,27 @@ public class DefaultSchoolService implements SchoolService {
 		return promise.future();
 	}
 
->>>>>>> 374ec0bcb (feat(directory): #IMPULS-5911 add endpoint to update and retreive default auth configuration)
+	public Future<Void> updateDefaultAuth(UserInfos user, String structureId, DefaultAuthModeConfig body) {
+		final Promise<Void> promise = Promise.promise();
+		final StringBuilder query = new StringBuilder(
+				"MATCH (s:Structure {id: {structureId}}) ")
+				.append("OPTIONAL MATCH (s)-[:HAS_AUTH_DEFAULT]->(d:AuthDefault) ")
+				.append("DETACH DELETE d ");
+		for (Map.Entry<DefaultAuthModeConfig.Profile, DefaultAuthModeConfig.DefaultAuthMode> entry : body.getDefaultAuthModes().entrySet()) {
+			query.append(String.format(" MERGE (s)-[:HAS_AUTH_DEFAULT]->(:AuthDefault { profile: '%s', auth: '%s' }) ",
+					entry.getKey().getNeo4jName(),
+					entry.getValue().name()));
+		}
+		final JsonObject params = new JsonObject().put("structureId", structureId);
+
+		neo.execute(query.toString(), params, validResultHandler(results -> {
+			if (results.isRight()) {
+				promise.complete();
+			} else {
+				promise.fail(results.left().getValue());
+			}
+		}));
+		return promise.future();
+	}
+
 }


### PR DESCRIPTION
# Description

Add GET and PUT default-auth-config on structure to persist and retreive default auth method

## Fixes

https://edifice-community.atlassian.net/browse/IMPULS-5911

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [X ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: