### PR TITLE
Feat impuls 5915 add federated flag on class admin

### DIFF
--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultClassService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultClassService.java
@@ -97,13 +97,18 @@ public class DefaultClassService implements ClassService {
 				"MATCH (c:`Class` { id : {classId}})<-[:DEPENDS]-(cpg:ProfileGroup)" +
 				"-[:DEPENDS]->(spg:ProfileGroup)-[:HAS_PROFILE]->(p:Profile), cpg<-[:IN]-(m:User)-[:IN]->spg " +
 						filterPart + collectPart +
+				" OPTIONAL MATCH m-[:IN]->(:ProfileGroup)-[:DEPENDS]->(s:Structure) WITH COLLECT(distinct s) as structureNodes, m, p, relativeList 	" +
+				" OPTIONAL MATCH (sAuth:Structure)-[:HAS_AUTH_DEFAULT]->(auths:AuthDefault { profile: HEAD(m.profiles), auth: 'FEDERATED' }) WHERE sAuth IN structureNodes " +
+				" WITH COLLECT(auths) as auths, m, p, relativeList "	+
 				"RETURN distinct m.lastName as lastName, m.firstName as firstName, m.id as id, " +
 				"(LENGTH(m.email)>0 AND EXISTS(m.email)) as hasEmail, " +
 				"CASE WHEN m.loginAlias IS NOT NULL THEN m.loginAlias ELSE m.login END as login, m.login as originalLogin, m.activationCode as activationCode, m.displayName as displayName, m.birthDate as birthDate, m.lastLogin as lastLogin, " +
 				(ine 
 					? "m.ine as ine, " 
 					: "") +
-				"p.name as type, m.blocked as blocked, m.source as source, relativeList " +
+				"p.name as type, m.blocked as blocked, m.source as source, relativeList, " +
+				" (HAS(m.federatedIDP) AND NOT(m.federatedIDP IS NULL) AND HAS(m.federated) AND m.federated = true) OR " +
+				"  size(auths) > 0 AND (m.source in ['AAF', 'AAF1D', 'CSV']) as hasFederatedIdentity " +
 				"ORDER BY type, lastName ";
 		neo.execute(query, params, validResultHandler(results));
 	}

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultClassService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultClassService.java
@@ -97,7 +97,7 @@ public class DefaultClassService implements ClassService {
 				"MATCH (c:`Class` { id : {classId}})<-[:DEPENDS]-(cpg:ProfileGroup)" +
 				"-[:DEPENDS]->(spg:ProfileGroup)-[:HAS_PROFILE]->(p:Profile), cpg<-[:IN]-(m:User)-[:IN]->spg " +
 						filterPart + collectPart +
-				" OPTIONAL MATCH m-[:IN]->(:ProfileGroup)-[:DEPENDS]->(s:Structure) WITH COLLECT(distinct s) as structureNodes, m, p, relativeList 	" +
+				" OPTIONAL MATCH m-[:IN]->(:ProfileGroup)-[:DEPENDS]->(s:Structure) WITH COLLECT(distinct s) as structureNodes, m, p, relativeList " +
 				" OPTIONAL MATCH (sAuth:Structure)-[:HAS_AUTH_DEFAULT]->(auths:AuthDefault { profile: HEAD(m.profiles), auth: 'FEDERATED' }) WHERE sAuth IN structureNodes " +
 				" WITH COLLECT(auths) as auths, m, p, relativeList "	+
 				"RETURN distinct m.lastName as lastName, m.firstName as firstName, m.id as id, " +

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
@@ -1271,9 +1271,13 @@ public class DefaultUserService implements UserService {
 				"OPTIONAL MATCH s<-[:BELONGS]-(c:Class)<-[:DEPENDS]-(cpg:ProfileGroup)-[:DEPENDS]->(spg:ProfileGroup)-[:HAS_PROFILE]->(Profile), cpg<-[:IN]-u-[:IN]->spg WITH s, COLLECT(distinct {name: c.name, id: c.id}) as c, motto, health, mood, hobbies, u " +
 				"WITH COLLECT(distinct {name: s.name, id: s.id, classes: c, source: s.source}) as schools, motto, health, mood, hobbies, u " +
 				"OPTIONAL MATCH u-[:RELATED]-(u2: User) WITH COLLECT(distinct {relatedName: u2.displayName, relatedId: u2.id, relatedType: u2.profiles}) as relativeList, schools, motto, health, mood, hobbies, u " +
+				"OPTIONAL MATCH u-[:IN]->(:ProfileGroup)-[:DEPENDS]->(s:Structure) WITH COLLECT(distinct s) as structureNodes, relativeList, schools, motto, health, mood, hobbies, u 	" +
+				"OPTIONAL MATCH (sAuth:Structure)-[:HAS_AUTH_DEFAULT]->(auths:AuthDefault { profile: HEAD(u.profiles), auth: 'FEDERATED' }) WHERE sAuth IN structureNodes " +
+				" WITH COLLECT(auths) as auths, schools, motto, health, mood, hobbies, u, relativeList "	+
 				"RETURN DISTINCT u.profiles as profiles, u.id as id, u.firstName as firstName, u.lastName as lastName, u.displayName as displayName, "+
 				"u.email as email, u.homePhone as homePhone, u.mobile as mobile, u.birthDate as birthDate, u.login as originalLogin, relativeList, " +
 				"motto, health, mood, hobbies, " +
+				" (HAS(u.federatedIDP) AND NOT(u.federatedIDP IS NULL) AND HAS(u.federated) AND u.federated = true) OR size(auths) > 0 AND (u.source in ['AAF', 'AAF1D', 'CSV']) as hasFederatedIdentity, " +
 				"CASE WHEN u.totp IS NOT NULL AND u.totp <> '' THEN true ELSE false END as hasTotp, " +
 				"CASE WHEN schools IS NULL THEN [] ELSE schools END as schools ";
 		} catch (ValidationException exception) {

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
@@ -1271,7 +1271,7 @@ public class DefaultUserService implements UserService {
 				"OPTIONAL MATCH s<-[:BELONGS]-(c:Class)<-[:DEPENDS]-(cpg:ProfileGroup)-[:DEPENDS]->(spg:ProfileGroup)-[:HAS_PROFILE]->(Profile), cpg<-[:IN]-u-[:IN]->spg WITH s, COLLECT(distinct {name: c.name, id: c.id}) as c, motto, health, mood, hobbies, u " +
 				"WITH COLLECT(distinct {name: s.name, id: s.id, classes: c, source: s.source}) as schools, motto, health, mood, hobbies, u " +
 				"OPTIONAL MATCH u-[:RELATED]-(u2: User) WITH COLLECT(distinct {relatedName: u2.displayName, relatedId: u2.id, relatedType: u2.profiles}) as relativeList, schools, motto, health, mood, hobbies, u " +
-				"OPTIONAL MATCH u-[:IN]->(:ProfileGroup)-[:DEPENDS]->(s:Structure) WITH COLLECT(distinct s) as structureNodes, relativeList, schools, motto, health, mood, hobbies, u 	" +
+				"OPTIONAL MATCH u-[:IN]->(:ProfileGroup)-[:DEPENDS]->(s:Structure) WITH COLLECT(distinct s) as structureNodes, relativeList, schools, motto, health, mood, hobbies, u " +
 				"OPTIONAL MATCH (sAuth:Structure)-[:HAS_AUTH_DEFAULT]->(auths:AuthDefault { profile: HEAD(u.profiles), auth: 'FEDERATED' }) WHERE sAuth IN structureNodes " +
 				" WITH COLLECT(auths) as auths, schools, motto, health, mood, hobbies, u, relativeList "	+
 				"RETURN DISTINCT u.profiles as profiles, u.id as id, u.firstName as firstName, u.lastName as lastName, u.displayName as displayName, "+

--- a/directory/src/test/java/org/entcore/directory/services/impl/DefaultClassServiceTest.java
+++ b/directory/src/test/java/org/entcore/directory/services/impl/DefaultClassServiceTest.java
@@ -1,0 +1,166 @@
+package org.entcore.directory.services.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.entcore.test.TestHelper;
+import org.entcore.test.preparation.ClassTest;
+import org.entcore.test.preparation.DataHelper;
+import org.entcore.test.preparation.Profile;
+import org.entcore.test.preparation.StructureTest;
+import org.entcore.test.preparation.UserTest;
+import org.entcore.test.preparation.UserTestBuilder;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.containers.Neo4jContainer;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RunWith(VertxUnitRunner.class)
+public class DefaultClassServiceTest {
+    private static final TestHelper test = TestHelper.helper();
+    @ClassRule
+    public static Neo4jContainer<?> neo4jContainer = test.database().createNeo4jContainer();
+
+    private static DefaultClassService defaultClassService;
+
+    private static DataHelper dataHelper;
+    static final UserTest student = UserTestBuilder.anUserTest().id("class-student")
+            .login("class.student")
+            .firstName("Eleve").lastName("Simple")
+            .displayName("Eleve Simple")
+            .profile(Profile.Student)
+            .build();
+    static final UserTest studentFederated = UserTestBuilder.anUserTest().id("class-student-federated")
+            .login("class.student.federated")
+            .firstName("Eleve").lastName("Federe")
+            .displayName("Eleve Federe")
+            .profile(Profile.Student)
+            .federated(true)
+            .build();
+    static final UserTest studentOnStructureWithIdp = UserTestBuilder.anUserTest().id("class-student-structure-with-idp")
+            .login("class.student.structure.with.idp")
+            .firstName("Eleve").lastName("StructureFederee")
+            .displayName("Eleve StructureFederee")
+            .profile(Profile.Student)
+            .build();
+    static final UserTest parent = UserTestBuilder.anUserTest().id("class-parent")
+            .login("class.parent")
+            .firstName("Parent").lastName("Simple")
+            .displayName("Parent Simple")
+            .profile(Profile.Relative)
+            .build();
+
+    @BeforeClass
+    public static void setUp(TestContext context) {
+        final Vertx vertx = test.vertx();
+        defaultClassService = new DefaultClassService(vertx.eventBus());
+        dataHelper = DataHelper.init(context, neo4jContainer);
+        prepareData().onComplete(context.asyncAssertSuccess());
+    }
+
+    private static JsonObject findById(final JsonArray users, final String id) {
+        return users.stream()
+                .map(JsonObject.class::cast)
+                .filter(u -> id.equals(u.getString("id")))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * <h1>Goal</h1>
+     * <p>Ensures that the function returns the users of the class with federated flag = false when the user is not
+     * federated and federated flag = true when federated = true and federatedIDP != null.</p>
+     */
+    @Test
+    public void testFindUsersReturnsFederatedFlag(final TestContext testContext) {
+        final Async async = testContext.async();
+        defaultClassService.findUsers("class-structure-01-class-01", null, false, false, h -> {
+            testContext.assertTrue(h.isRight(), "Failed to find users of class " + h);
+            final JsonArray users = h.right().getValue();
+            final JsonObject simpleStudent = findById(users, student.getId());
+            testContext.assertNotNull(simpleStudent, "Simple student should be in the class");
+            testContext.assertEquals(Boolean.FALSE, simpleStudent.getBoolean("hasFederatedIdentity"));
+            final JsonObject federatedStudent = findById(users, studentFederated.getId());
+            testContext.assertNotNull(federatedStudent, "Federated student should be in the class");
+            testContext.assertEquals(Boolean.TRUE, federatedStudent.getBoolean("hasFederatedIdentity"));
+            async.complete();
+        });
+    }
+
+    /**
+     * <h1>Goal</h1>
+     * <p>Ensures that the function returns the users of the class with federated flag = true when the user is in a
+     * structure with a federated auth default.</p>
+     */
+    @Test
+    public void testFindUsersOnFederatedStructure(final TestContext testContext) {
+        final Async async = testContext.async();
+        defaultClassService.findUsers("class-structure-02-class-01", null, false, false, h -> {
+            testContext.assertTrue(h.isRight(), "Failed to find users of class " + h);
+            final JsonArray users = h.right().getValue();
+            final JsonObject studentOnFederatedStructure = findById(users, studentOnStructureWithIdp.getId());
+            testContext.assertNotNull(studentOnFederatedStructure, "Student of the federated structure should be in the class");
+            testContext.assertEquals(Boolean.TRUE, studentOnFederatedStructure.getBoolean("hasFederatedIdentity"));
+            async.complete();
+        });
+    }
+
+    /**
+     * <h1>Goal</h1>
+     * <p>Ensures that the function still returns the relatives and the federated flag when types are filtered and
+     * relatives are collected.</p>
+     */
+    @Test
+    public void testFindUsersWithTypesAndCollectRelative(final TestContext testContext) {
+        final Async async = testContext.async();
+        defaultClassService.findUsers("class-structure-01-class-01", new JsonArray().add(Profile.Student.name), true, false, h -> {
+            testContext.assertTrue(h.isRight(), "Failed to find users of class " + h);
+            final JsonArray users = h.right().getValue();
+            final Set<String> types = users.stream()
+                    .map(JsonObject.class::cast)
+                    .map(u -> u.getString("type"))
+                    .collect(Collectors.toSet());
+            testContext.assertEquals(1, types.size(), "Should only contain students but got " + types);
+            testContext.assertTrue(types.contains(Profile.Student.name));
+            final JsonObject simpleStudent = findById(users, student.getId());
+            testContext.assertNotNull(simpleStudent, "Simple student should be in the class");
+            testContext.assertEquals(Boolean.FALSE, simpleStudent.getBoolean("hasFederatedIdentity"));
+            final Set<String> relativesId = simpleStudent.getJsonArray("relativeList").stream()
+                    .map(JsonObject.class::cast)
+                    .map(r -> r.getString("relatedId"))
+                    .collect(Collectors.toSet());
+            testContext.assertTrue(relativesId.contains(parent.getId()), "Should have one relative which is " + parent.getId() + " but got : " + relativesId);
+            final JsonObject federatedStudent = findById(users, studentFederated.getId());
+            testContext.assertNotNull(federatedStudent, "Federated student should be in the class");
+            testContext.assertEquals(Boolean.TRUE, federatedStudent.getBoolean("hasFederatedIdentity"));
+            async.complete();
+        });
+    }
+
+    public static Future<Void> prepareData() {
+        dataHelper
+            .start()
+            .withStructure(new StructureTest("class-structure-01", "class structure 01"))
+                .withClass(new ClassTest("class-structure-01-class-01", "class structure 01 class 01"), "class-structure-01")
+            .withStructure(new StructureTest("class-structure-02", "class structure 02", true))
+                .withClass(new ClassTest("class-structure-02-class-01", "class structure 02 class 01"), "class-structure-02")
+            .withUser(student)
+                .studentInClass(student.getId(), "class-structure-01-class-01")
+            .withUser(studentFederated)
+                .studentInClass(studentFederated.getId(), "class-structure-01-class-01")
+            .withUser(studentOnStructureWithIdp)
+                .studentInClass(studentOnStructureWithIdp.getId(), "class-structure-02-class-01")
+            .withUser(parent)
+                .parentOf(parent.getId(), student.getId());
+        return dataHelper.execute();
+    }
+
+}

--- a/directory/src/test/java/org/entcore/directory/services/impl/DefaultUserServiceTest.java
+++ b/directory/src/test/java/org/entcore/directory/services/impl/DefaultUserServiceTest.java
@@ -46,6 +46,18 @@ public class DefaultUserServiceTest {
             .firstName("prenom").lastName("NdF")
             .displayName("Prenom NdF")
             .build();
+    static final UserTest userFederated = UserTestBuilder.anUserTest().id("simple-user-fedreated")
+            .login("simple.user.federated")
+            .firstName("prenom").lastName("NdF")
+            .displayName("Prenom NdF")
+            .federated(true)
+            .build();
+    static final UserTest userOnStructureWithIdp = UserTestBuilder.anUserTest().id("simple-user-structure-with-idp")
+            .login("simple.user.structure.with.idp")
+            .firstName("prenom").lastName("NdF")
+            .displayName("Prenom NdF")
+            .profile(Profile.Student)
+            .build();
     static final UserTest child1 = UserTestBuilder.anUserTest().id("child")
             .login("child")
             .firstName("Enfant").lastName("Child")
@@ -140,8 +152,45 @@ public class DefaultUserServiceTest {
             testContext.assertEquals(user0.getId(), userInfos.getString("id"));
             testContext.assertEquals(user0.getFirstName(), userInfos.getString("firstName"));
             testContext.assertEquals(user0.getLastName(), userInfos.getString("lastName"));
+            testContext.assertEquals(Boolean.FALSE, userInfos.getBoolean("hasFederatedIdentity"));
             testContext.assertEquals(null, userInfos.getString("profiles"));
             testContext.assertEquals(null, userInfos.getJsonArray("schools").getJsonObject(0).getString("id"));
+            async.complete();
+        });
+    }
+
+    /**
+     * <h1>Goal</h1>
+     * <p>Ensures that the function returns user's info with federated flag = true when federated = true and federatedIDP != null.</p>
+     */
+    @Test
+    public void testGetUserInfosUserFederated(final TestContext testContext) {
+        final Async async = testContext.async();
+        defaultUserService.getUserInfos(userFederated.getId(), h -> {
+            testContext.assertTrue(h.isRight(), "Failed to get user infos of existing user " + h);
+            final JsonObject userInfos = h.right().getValue();
+            testContext.assertTrue(!userInfos.containsKey("lockedEmail") || userInfos.getBoolean("lockedEmail"));
+            testContext.assertFalse(userInfos.isEmpty(), "Should not have returned data for the user");
+            testContext.assertEquals(userFederated.getId(), userInfos.getString("id"));
+            testContext.assertEquals(userFederated.getFirstName(), userInfos.getString("firstName"));
+            testContext.assertEquals(userFederated.getLastName(), userInfos.getString("lastName"));
+            testContext.assertEquals(Boolean.TRUE, userInfos.getBoolean("hasFederatedIdentity"));
+            async.complete();
+        });
+    }
+
+
+    /**
+     * <h1>Goal</h1>
+     * <p>Ensures that the function returns user's info with federated flag = true when the user is in federated structure.</p>
+     */
+    @Test
+    public void testGetUserInfosUserOnFederatedStructure(final TestContext testContext) {
+        final Async async = testContext.async();
+        defaultUserService.getUserInfos(userOnStructureWithIdp.getId(), h -> {
+            testContext.assertTrue(h.isRight(), "Failed to get user infos of existing user " + h);
+            final JsonObject userInfos = h.right().getValue();
+            testContext.assertEquals(Boolean.TRUE, userInfos.getBoolean("hasFederatedIdentity"));
             async.complete();
         });
     }
@@ -293,6 +342,7 @@ public class DefaultUserServiceTest {
             .withStructure(new StructureTest("my-structure-02", "my structure 02"))
                 .withClass(new ClassTest("my-structure-02-class-01", "my structure 02 class 01"), "my-structure-02")
                 .withClass(new ClassTest("my-structure-02-class-02", "my structure 02 class 02"), "my-structure-02")
+            .withStructure(new StructureTest("my-structure-03", "my structure 03", true))
             .withUser(user0)
             .withUser(child1)
                 .studentInClass(child1.getId(), "my-structure-01-class-02")
@@ -301,6 +351,8 @@ public class DefaultUserServiceTest {
                 .teacherInClass(teacher.getId(), "my-structure-02-class-01")
             .withUser(parent)
                 .parentOf(parent.getId(), child1.getId())
+            .withUser(userFederated)
+            .withUser(userOnStructureWithIdp, "my-structure-03")
             .withUser(adml)
                 .adml(adml.getId(), "my-structure-01");
         return dataHelper.execute();


### PR DESCRIPTION
# Description

Propagate federated flag to endpoints used in class admin

## Fixes

https://edifice-community.atlassian.net/browse/IMPULS-5915

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [X ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: