### PR TITLE
fix(timeline): #IMPULS-5456 persist notification panel open state

### DIFF
--- a/conversation/frontend/src/components/MessageAttachments/MessageAttachments.tsx
+++ b/conversation/frontend/src/components/MessageAttachments/MessageAttachments.tsx
@@ -23,7 +23,7 @@ export function MessageAttachments({
   message,
   editMode = false,
 }: MessageAttachmentsProps) {
-  const { common_t, t } = useI18n();
+  const { t } = useI18n();
   const inputRef = useRef<HTMLInputElement | null>(null);
   const { downloadAllUrl, attachFiles, detachFiles, isMutating, detachFile } =
     useMessageAttachments();
@@ -75,9 +75,7 @@ export function MessageAttachments({
       {!!attachments.length && (
         <>
           <div className="d-flex align-items-center justify-content-between border-bottom">
-            <span className="caption fw-bold my-8">
-              {common_t('attachments')}
-            </span>
+            <span className="caption fw-bold my-8">{t('attachments')}</span>
             {attachments.length > 1 && (
               <div>
                 <IconButton
@@ -90,7 +88,7 @@ export function MessageAttachments({
                 />
                 <a href={downloadAllUrl} download>
                   <IconButton
-                    title={common_t('download.all.attachment')}
+                    title={t('download.all.attachment')}
                     color="tertiary"
                     type="button"
                     icon={<IconDownload />}

--- a/timeline/frontend/package.json
+++ b/timeline/frontend/package.json
@@ -27,9 +27,9 @@
     ]
   },
   "dependencies": {
-    "@edifice.io/bootstrap": "link:../../../edifice-frontend-framework/packages/bootstrap",
-    "@edifice.io/client": "link:../../../edifice-frontend-framework/packages/client",
-    "@edifice.io/react": "link:../../../edifice-frontend-framework/packages/react",
+    "@edifice.io/bootstrap": "epic-homepage",
+    "@edifice.io/client": "epic-homepage",
+    "@edifice.io/react": "epic-homepage",
     "@react-spring/web": "9.7.5",
     "@tanstack/react-query": "5.90.21",
     "@uidotdev/usehooks": "2.4.1",

--- a/timeline/frontend/package.json
+++ b/timeline/frontend/package.json
@@ -27,9 +27,9 @@
     ]
   },
   "dependencies": {
-    "@edifice.io/bootstrap": "epic-homepage",
-    "@edifice.io/client": "epic-homepage",
-    "@edifice.io/react": "epic-homepage",
+    "@edifice.io/bootstrap": "link:../../../edifice-frontend-framework/packages/bootstrap",
+    "@edifice.io/client": "link:../../../edifice-frontend-framework/packages/client",
+    "@edifice.io/react": "link:../../../edifice-frontend-framework/packages/react",
     "@react-spring/web": "9.7.5",
     "@tanstack/react-query": "5.90.21",
     "@uidotdev/usehooks": "2.4.1",

--- a/timeline/frontend/src/routes/root/hooks/useNotificationsLayout.ts
+++ b/timeline/frontend/src/routes/root/hooks/useNotificationsLayout.ts
@@ -12,7 +12,7 @@ export const useNotificationsLayout = () => {
   const { updateOverlayOpen } = useOverlay();
 
   const toggleNotifications = () => {
-    setIsNotificationsOpen(!isNotificationsOpen);
+    setIsNotificationsOpen((prev) => !prev);
   };
 
   const closeNotifications = () => {

--- a/timeline/frontend/src/routes/root/hooks/useNotificationsLayout.ts
+++ b/timeline/frontend/src/routes/root/hooks/useNotificationsLayout.ts
@@ -1,38 +1,38 @@
 import { useBreakpoint, useOverlay } from '@edifice.io/react';
 import { useEffect, useState } from 'react';
 
+const NOTIFICATIONS_OPEN_KEY = 'timeline:notificationsOpen';
+
 export const useNotificationsLayout = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [isNotificationsOpen, setIsNotificationsOpen] = useState(
+    () => localStorage.getItem(NOTIFICATIONS_OPEN_KEY) === 'true',
+  );
   const { md, sm } = useBreakpoint();
-  const { toggleOverlay, closeOverlay, openOverlay, isOverlayOpen } =
-    useOverlay();
+  const { updateOverlayOpen } = useOverlay();
 
   const toggleNotifications = () => {
-    if (md) {
-      setIsSidebarOpen((prev) => !prev);
-    } else {
-      toggleOverlay();
-    }
+    setIsNotificationsOpen(!isNotificationsOpen);
   };
 
   const closeNotifications = () => {
-    if (md) {
-      setIsSidebarOpen(false);
-    } else {
-      closeOverlay();
-    }
+    setIsNotificationsOpen(false);
   };
+
+  useEffect(() => {
+    localStorage.setItem(NOTIFICATIONS_OPEN_KEY, String(isNotificationsOpen));
+  }, [isNotificationsOpen]);
 
   // Close sidebar or overlay when resizing window to avoid inappropriate display
   useEffect(() => {
-    if (md && isOverlayOpen) {
-      closeOverlay();
-      setIsSidebarOpen(true);
-    } else if (sm && isSidebarOpen) {
+    if (md) {
+      updateOverlayOpen(false);
+      setIsSidebarOpen(isNotificationsOpen);
+    } else if (sm) {
+      updateOverlayOpen(isNotificationsOpen);
       setIsSidebarOpen(false);
-      openOverlay();
     }
-  }, [md, sm]);
+  }, [md, sm, isNotificationsOpen]);
 
   return {
     isSidebarOpen,


### PR DESCRIPTION
## Résumé
Persiste l'état ouvert/fermé du panneau de notifications dans le localStorage afin qu'il soit restauré à la navigation.

## Contexte
Le panneau de notifications se refermait systématiquement lors des transitions de route, ce qui forçait l'utilisateur à le rouvrir à chaque fois.
Ticket : [IMPULS-5456](https://edifice-community.atlassian.net/browse/IMPULS-5456)

## Changements
- Ajout d'une clé `timeline:notificationsOpen` en localStorage pour persister l'état du panneau
- Unification de l'état en un seul `isNotificationsOpen` (remplace la dualité `isSidebarOpen` / `isOverlayOpen`)
- Simplification du hook `useNotificationsLayout` : la logique responsive (sidebar md / overlay sm) dérive désormais de cet état unique

## Comment tester
1. Ouvrir la timeline et déplier le panneau de notifications
2. Naviguer vers une autre route puis revenir — le panneau doit rester ouvert
3. Fermer le panneau, naviguer et revenir — le panneau doit rester fermé
4. Redimensionner la fenêtre entre mobile (sm) et desktop (md) et vérifier que l'overlay / la sidebar s'affichent correctement selon le breakpoint

[IMPULS-5456]: https://edifice-community.atlassian.net/browse/IMPULS-5456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ