### PR TITLE
Feat impuls 5922 dont process federated user by default

### DIFF
--- a/directory/src/main/java/org/entcore/directory/controllers/StructureController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/StructureController.java
@@ -507,6 +507,10 @@ public class StructureController extends BaseController {
 			filter.put("activated", request.params().get("a"));
 		}
 
+		if (request.params().contains("includeFederated")) {
+			filter.put("includeFederated", true);
+		}
+
         if(request.params().contains("adml")){
             filter.put("adml", request.params().get("adml"));
         }
@@ -535,40 +539,38 @@ public class StructureController extends BaseController {
 			final String templatePath = assetsPath + "/template/directory/";
 			final String baseUrl = getScheme(request) + "://" + Renders.getHost(request) + "/assets/themes/" + skin + "/img/";
 
-			UserUtils.getUserInfos(eb, request, new Handler<UserInfos>() {
-				public void handle(final UserInfos infos) {
+			UserUtils.getUserInfos(eb, request, infos -> {
 
-					//PDF
-					if("pdf".equals(type) || "newPdf".equals(type) || "simplePdf".equals(type)){
-						massMailService.massmailUsers(structureId, filter, filterMail, true, infos, new Handler<Either<String,JsonArray>>() {
-							public void handle(Either<String, JsonArray> result) {
-								if(result.isLeft()){
-									forbidden(request);
-									return;
-								}
+                //PDF
+                if("pdf".equals(type) || "newPdf".equals(type) || "simplePdf".equals(type)){
+                    massMailService.massmailUsers(structureId, filter, filterMail, true, infos, new Handler<Either<String,JsonArray>>() {
+                        public void handle(Either<String, JsonArray> result1) {
+                            if(result1.isLeft()){
+                                forbidden(request);
+                                return;
+                            }
 
-								massMailService.massMailTypePdf(infos, request, templatePath, baseUrl, filename, type, result.right().getValue());
-							}
-						});
-					}
-					//Mail
-					else if("mail".equals(type)){
-						massMailService.massmailUsers(structureId, filter, filterMail, true, infos, new Handler<Either<String,JsonArray>>() {
-							public void handle(final Either<String, JsonArray> result) {
-								if(result.isLeft()){
-									forbidden(request);
-									return;
-								}
+                            massMailService.massMailTypePdf(infos, request, templatePath, baseUrl, filename, type, result1.right().getValue());
+                        }
+                    });
+                }
+                //Mail
+                else if("mail".equals(type)){
+                    massMailService.massmailUsers(structureId, filter, filterMail, true, infos, new Handler<Either<String,JsonArray>>() {
+                        public void handle(final Either<String, JsonArray> result1) {
+                            if(result1.isLeft()){
+                                forbidden(request);
+                                return;
+                            }
 
-								massMailService.massMailTypeMail(infos, request, templatePath, result.right().getValue());
-							}
-						});
-					} else {
-						badRequest(request);
-					}
+                            massMailService.massMailTypeMail(infos, request, templatePath, result1.right().getValue());
+                        }
+                    });
+                } else {
+                    badRequest(request);
+                }
 
-				}
-			});
+            });
 		});
 	}
 

--- a/directory/src/main/java/org/entcore/directory/controllers/StructureController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/StructureController.java
@@ -507,7 +507,7 @@ public class StructureController extends BaseController {
 			filter.put("activated", request.params().get("a"));
 		}
 
-		if (request.params().contains("includeFederated")) {
+		if (request.params().contains("includeFederated") && Boolean.parseBoolean(request.params().get("includeFederated"))) {
 			filter.put("includeFederated", true);
 		}
 

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultClassService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultClassService.java
@@ -108,7 +108,7 @@ public class DefaultClassService implements ClassService {
 					: "") +
 				"p.name as type, m.blocked as blocked, m.source as source, relativeList, " +
 				" (HAS(m.federatedIDP) AND NOT(m.federatedIDP IS NULL) AND HAS(m.federated) AND m.federated = true) OR " +
-				"  size(auths) > 0 AND (m.source in ['AAF', 'AAF1D', 'CSV']) AND m.activationCode IS NULL as hasFederatedIdentity " +
+				"  (size(auths) > 0 AND (m.source in ['AAF', 'AAF1D', 'CSV']) AND m.activationCode IS NULL) as hasFederatedIdentity " +
 				"ORDER BY type, lastName ";
 		neo.execute(query, params, validResultHandler(results));
 	}

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultMassMailService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultMassMailService.java
@@ -400,6 +400,10 @@ public class DefaultMassMailService extends Renders implements MassMailService {
               +"c IN (collect(distinct {firstName: child.firstName, lastName: child.lastName, classname: c.name})) WHERE not(c.firstName is null)"
            +") END as children ";
 
+        if (!filterObj.containsKey("includeFederated")) {
+            withStr += " WHERE NOT ((HAS(u.federatedIDP) AND NOT(u.federatedIDP IS NULL) AND HAS(u.federated) AND u.federated = true) OR size(auths) > 0 AND (u.source in ['AAF', 'AAF1D', 'CSV'])) ";
+        }
+
         //Return clause
         String returnStr =
             " RETURN distinct collect(p.name)[0] as profile"

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultMassMailService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultMassMailService.java
@@ -401,7 +401,7 @@ public class DefaultMassMailService extends Renders implements MassMailService {
            +") END as children ";
 
         if (!filterObj.containsKey("includeFederated")) {
-            withStr += " WHERE NOT ((HAS(u.federatedIDP) AND NOT(u.federatedIDP IS NULL) AND HAS(u.federated) AND u.federated = true) OR size(auths) > 0 AND (u.source in ['AAF', 'AAF1D', 'CSV'])) ";
+            withStr += " WHERE NOT ((HAS(u.federatedIDP) AND NOT(u.federatedIDP IS NULL) AND HAS(u.federated) AND u.federated = true) OR size(auths) > 0 AND (u.source in ['AAF', 'AAF1D', 'CSV']) AND u.activationCode IS NULL) ";
         }
 
         //Return clause

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultMassMailService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultMassMailService.java
@@ -419,7 +419,7 @@ public class DefaultMassMailService extends Renders implements MassMailService {
             // Deprecated fields below
             +", classname, isInClass"
             +", CASE WHEN size(children) = 0 THEN null ELSE head(children) END as child"
-            +", (HAS(u.federatedIDP) AND NOT(u.federatedIDP IS NULL) AND HAS(u.federated) AND u.federated = true) OR size(auths) > 0 AND (u.source in ['AAF', 'AAF1D', 'CSV']) AND u.activationCode IS NULL as hasFederatedIdentity ";;
+            +", (HAS(u.federatedIDP) AND NOT(u.federatedIDP IS NULL) AND HAS(u.federated) AND u.federated = true) OR (size(auths) > 0 AND (u.source in ['AAF', 'AAF1D', 'CSV']) AND u.activationCode IS NULL) as hasFederatedIdentity ";
 
         //Order by
         String sort = " ORDER BY ";
@@ -520,7 +520,7 @@ public class DefaultMassMailService extends Renders implements MassMailService {
         returnStr += ", classes, classname, isInClass ";
 
         withStr += ", CASE count(child) WHEN 0 THEN null ELSE collect(distinct {firstName: child.firstName, lastName: child.lastName, classname: c.name}) END as children ";
-        returnStr += ", filter(c IN children WHERE not(c.firstName is null)) as children, (HAS(u.federatedIDP) AND NOT(u.federatedIDP IS NULL) AND HAS(u.federated) AND u.federated = true) OR size(auths) > 0 AND (u.source in ['AAF', 'AAF1D', 'CSV'] AND u.activationCode IS NULL )  as hasFederatedIdentity ";
+        returnStr += ", filter(c IN children WHERE not(c.firstName is null)) as children, (HAS(u.federatedIDP) AND NOT(u.federatedIDP IS NULL) AND HAS(u.federated) AND u.federated = true) OR (size(auths) > 0 AND (u.source in ['AAF', 'AAF1D', 'CSV'] AND u.activationCode IS NULL ))  as hasFederatedIdentity ";
 
         String sort = "ORDER BY lastName";
 

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
@@ -412,7 +412,7 @@ public class DefaultUserService implements UserService {
 		}
 
 		query += " (HAS(u.federatedIDP) AND NOT(u.federatedIDP IS NULL) AND HAS(u.federated) AND u.federated = true) OR " +
-				"  size(auths) > 0 AND (u.source in ['AAF', 'AAF1D', 'CSV']) AND u.activationCode IS NULL as hasFederatedIdentity, ";
+				"  (size(auths) > 0 AND (u.source in ['AAF', 'AAF1D', 'CSV']) AND u.activationCode IS NULL) as hasFederatedIdentity, ";
 
 		if (getManualGroups)
 			query += "CASE WHEN manualGroups IS NULL THEN [] ELSE manualGroups END as manualGroups, ";
@@ -1277,7 +1277,7 @@ public class DefaultUserService implements UserService {
 				"RETURN DISTINCT u.profiles as profiles, u.id as id, u.firstName as firstName, u.lastName as lastName, u.displayName as displayName, "+
 				"u.email as email, u.homePhone as homePhone, u.mobile as mobile, u.birthDate as birthDate, u.login as originalLogin, relativeList, " +
 				"motto, health, mood, hobbies, " +
-				" (HAS(u.federatedIDP) AND NOT(u.federatedIDP IS NULL) AND HAS(u.federated) AND u.federated = true) OR size(auths) > 0 AND (u.source in ['AAF', 'AAF1D', 'CSV']) AND u.activationCode IS NULL as hasFederatedIdentity, " +
+				" (HAS(u.federatedIDP) AND NOT(u.federatedIDP IS NULL) AND HAS(u.federated) AND u.federated = true) OR (size(auths) > 0 AND (u.source in ['AAF', 'AAF1D', 'CSV']) AND u.activationCode IS NULL) as hasFederatedIdentity, " +
 				"CASE WHEN u.totp IS NOT NULL AND u.totp <> '' THEN true ELSE false END as hasTotp, " +
 				"CASE WHEN schools IS NULL THEN [] ELSE schools END as schools ";
 		} catch (ValidationException exception) {

--- a/directory/src/test/java/org/entcore/directory/services/impl/DefaultMassMailServiceTest.java
+++ b/directory/src/test/java/org/entcore/directory/services/impl/DefaultMassMailServiceTest.java
@@ -76,13 +76,14 @@ public class DefaultMassMailServiceTest {
 
     /**
      * <h1>Goal</h1>
-     * <p>Ensures that massmailUsers returns the users of the structure with federated flag = false when the user is
-     * not federated and federated flag = true when federated = true and federatedIDP != null.</p>
+     * <p>Ensures that massmailUsers, when "includeFederated" is set, returns the users of the structure with
+     * federated flag = false when the user is not federated and federated flag = true when federated = true and
+     * federatedIDP != null.</p>
      */
     @Test
     public void testMassmailUsersReturnsFederatedFlag(final TestContext testContext) {
         final Async async = testContext.async();
-        defaultMassMailService.massmailUsers("massmail-structure-01", new JsonObject().put("activated", "all"), superAdmin(), h -> {
+        defaultMassMailService.massmailUsers("massmail-structure-01", new JsonObject().put("activated", "all").put("includeFederated", true), superAdmin(), h -> {
             testContext.assertTrue(h.isRight(), "Failed to find users of structure " + h);
             final JsonArray users = h.right().getValue();
             final JsonObject simpleStudent = findById(users, student.getId());
@@ -97,18 +98,51 @@ public class DefaultMassMailServiceTest {
 
     /**
      * <h1>Goal</h1>
-     * <p>Ensures that massmailUsers returns the users with federated flag = true when the user is in a structure
-     * with a federated auth default.</p>
+     * <p>Ensures that massmailUsers, when "includeFederated" is set, returns the users with federated flag = true
+     * when the user is in a structure with a federated auth default.</p>
      */
     @Test
     public void testMassmailUsersOnFederatedStructure(final TestContext testContext) {
         final Async async = testContext.async();
-        defaultMassMailService.massmailUsers("massmail-structure-02", new JsonObject().put("activated", "all"), superAdmin(), h -> {
+        defaultMassMailService.massmailUsers("massmail-structure-02", new JsonObject().put("activated", "all").put("includeFederated", true), superAdmin(), h -> {
             testContext.assertTrue(h.isRight(), "Failed to find users of structure " + h);
             final JsonArray users = h.right().getValue();
             final JsonObject studentOnFederatedStructure = findById(users, studentOnStructureWithIdp.getId());
             testContext.assertNotNull(studentOnFederatedStructure, "Student of the federated structure should be in the structure");
             testContext.assertEquals(Boolean.TRUE, studentOnFederatedStructure.getBoolean("hasFederatedIdentity"));
+            async.complete();
+        });
+    }
+
+    /**
+     * <h1>Goal</h1>
+     * <p>Ensures that massmailUsers excludes federated users (federated identity) by default, i.e. when the
+     * "includeFederated" filter is not set, while still returning non-federated users.</p>
+     */
+    @Test
+    public void testMassmailUsersExcludesFederatedUsersByDefault(final TestContext testContext) {
+        final Async async = testContext.async();
+        defaultMassMailService.massmailUsers("massmail-structure-01", new JsonObject().put("activated", "all"), superAdmin(), h -> {
+            testContext.assertTrue(h.isRight(), "Failed to find users of structure " + h);
+            final JsonArray users = h.right().getValue();
+            testContext.assertNotNull(findById(users, student.getId()), "Simple student should be in the structure");
+            testContext.assertNull(findById(users, studentFederated.getId()), "Federated student should be excluded by default");
+            async.complete();
+        });
+    }
+
+    /**
+     * <h1>Goal</h1>
+     * <p>Ensures that massmailUsers excludes users belonging to a structure with a federated auth default by
+     * default, i.e. when the "includeFederated" filter is not set.</p>
+     */
+    @Test
+    public void testMassmailUsersExcludesFederatedStructureUsersByDefault(final TestContext testContext) {
+        final Async async = testContext.async();
+        defaultMassMailService.massmailUsers("massmail-structure-02", new JsonObject().put("activated", "all"), superAdmin(), h -> {
+            testContext.assertTrue(h.isRight(), "Failed to find users of structure " + h);
+            final JsonArray users = h.right().getValue();
+            testContext.assertNull(findById(users, studentOnStructureWithIdp.getId()), "Student of the federated structure should be excluded by default");
             async.complete();
         });
     }


### PR DESCRIPTION
# Description

Filter in mail and pdf mass mail account in admin by default. Add a param includeFederated to bypass the filter

## Fixes

https://edifice-community.atlassian.net/browse/IMPULS-5922

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [X ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: