### PR TITLE
feat(admin): #IMPULS-5914 griser boutons pour user federés

### DIFF
--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -1642,7 +1642,7 @@
   "user.communication.section.title.sending-rules": "Avec qui l'utilisateur peut-il communiquer",
   "user.communication.title": "Communication de {{ lastName }} {{ firstName }}",
   "user.connection.activationCode.unlock": "Débloquer pour voir le code d’activation",
-  "user.connection.field.title.disabled.federatedUser": "Le champ est bloqué car l'utilisateur possède une identité fédérée (voir la bulle d'info ci-dessus).",
+  "user.connection.field.title.disabled.federatedUser": "Champs verrouillé car l'utilisateur est en authentification externe (voir message ci-dessus)",
   "user.error": "Erreur lors du chargement de l'utilisateur",
   "user.has.duplicates": "Utilisateur en doublon",
   "user.icons.tooltip.blocked": "Compte bloqué",

--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -1642,7 +1642,7 @@
   "user.communication.section.title.sending-rules": "Avec qui l'utilisateur peut-il communiquer",
   "user.communication.title": "Communication de {{ lastName }} {{ firstName }}",
   "user.connection.activationCode.unlock": "Débloquer pour voir le code d’activation",
-  "user.connection.field.title.disabled.federatedUser": "Le champs est bloqué car l'utilisateur possède une identité fédérée (voir bulle info ci-dessus).",
+  "user.connection.field.title.disabled.federatedUser": "Le champ est bloqué car l'utilisateur possède une identité fédérée (voir la bulle d'info ci-dessus).",
   "user.error": "Erreur lors du chargement de l'utilisateur",
   "user.has.duplicates": "Utilisateur en doublon",
   "user.icons.tooltip.blocked": "Compte bloqué",

--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -1642,7 +1642,7 @@
   "user.communication.section.title.sending-rules": "Avec qui l'utilisateur peut-il communiquer",
   "user.communication.title": "Communication de {{ lastName }} {{ firstName }}",
   "user.connection.activationCode.unlock": "Débloquer pour voir le code d’activation",
-  "user.connection.field.title.disabled.federatedUser": "Champs verrouillé car l'utilisateur est en authentification externe (voir message ci-dessus)",
+  "user.connection.field.title.disabled.federatedUser": "Champ verrouillé car l'utilisateur est en authentification externe (voir message ci-dessus)",
   "user.error": "Erreur lors du chargement de l'utilisateur",
   "user.has.duplicates": "Utilisateur en doublon",
   "user.icons.tooltip.blocked": "Compte bloqué",

--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -1641,6 +1641,8 @@
   "user.communication.section.title.receiving-rules": "Qui peut communiquer avec l'utilisateur",
   "user.communication.section.title.sending-rules": "Avec qui l'utilisateur peut-il communiquer",
   "user.communication.title": "Communication de {{ lastName }} {{ firstName }}",
+  "user.connection.activationCode.unlock": "Débloquer pour voir le code d’activation",
+  "user.connection.field.title.disabled.federatedUser": "Le champs est bloqué car l'utilisateur possède une identité fédérée (voir bulle info ci-dessus).",
   "user.error": "Erreur lors du chargement de l'utilisateur",
   "user.has.duplicates": "Utilisateur en doublon",
   "user.icons.tooltip.blocked": "Compte bloqué",

--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -1693,7 +1693,7 @@
   "users.details.section.functional.groups": "Groupe(s) d'enseignement",
   "users.details.section.infos": "Identité",
   "users.details.section.infos.federatedInfo.title": "Comment cet utilisateur peut se connecter ?",
-  "users.details.section.infos.federatedInfo.content": "Pour se connecter, cet utilisateur doit passer par une authentification externe à l'ENT (par exemple: EduConnect, E Arena, LiÀ, FranceConnect...). II doit s'adresser au service concerné pour gérer ses accès. Donc, depuis cette fiche, il n'est pas possible de publiposter sa fiche de connexion et de renouveler son mot de passe.",
+  "users.details.section.infos.federatedInfo.content": "Pour se connecter, cet utilisateur doit passer par une authentification externe à l'ENT (par exemple: EduConnect, E Arena, LiÀ, FranceConnect...). Il doit s'adresser au service concerné pour gérer ses accès. Donc, depuis cette fiche, il n'est pas possible de publiposter sa fiche de connexion et de renouveler son mot de passe.",
   "users.details.section.manual.groups": "Groupe(s) manuel(s)",
   "users.details.section.positions": "Fonctions",
   "users.details.section.quota": "Quota de stockage",

--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -1690,6 +1690,8 @@
   "users.details.section.duplicates": "Doublon(s)",
   "users.details.section.functional.groups": "Groupe(s) d'enseignement",
   "users.details.section.infos": "Identité",
+  "users.details.section.infos.federatedInfo.title": "Comment cet utilisateur peut se connecter ?",
+  "users.details.section.infos.federatedInfo.content": "Pour se connecter, cet utilisateur doit passer par une authentification externe à l'ENT (par exemple: EduConnect, E Arena, LiÀ, FranceConnect...). II doit s'adresser au service concerné pour gérer ses accès. Donc, depuis cette fiche, il n'est pas possible de publiposter sa fiche de connexion et de renouveler son mot de passe.",
   "users.details.section.manual.groups": "Groupe(s) manuel(s)",
   "users.details.section.positions": "Fonctions",
   "users.details.section.quota": "Quota de stockage",

--- a/admin/src/main/ts/src/app/core/store/models/userdetails.model.ts
+++ b/admin/src/main/ts/src/app/core/store/models/userdetails.model.ts
@@ -1,5 +1,5 @@
-import {Model} from 'entcore-toolkit';
-import {GroupModel} from '../../store/models/group.model';
+import { Model } from 'entcore-toolkit';
+import { GroupModel } from '../../store/models/group.model';
 import { StructureModel } from './structure.model';
 import { UserPosition } from './userPosition.model';
 
@@ -43,7 +43,7 @@ export class UserDetailsModel extends Model<UserDetailsModel> {
     mobile?: string;
     totp?: string;
     hasTotp?: boolean;
-    hasFederatedIdentity?: boolean;
+    hasFederatedIdentity: boolean = false;
     profiles: Array<String> = [];
     type?: Array<string>;
     functions?: Array<[string, Array<string>]>;

--- a/admin/src/main/ts/src/app/core/store/models/userdetails.model.ts
+++ b/admin/src/main/ts/src/app/core/store/models/userdetails.model.ts
@@ -43,6 +43,7 @@ export class UserDetailsModel extends Model<UserDetailsModel> {
     mobile?: string;
     totp?: string;
     hasTotp?: boolean;
+    hasFederatedIdentity?: boolean;
     profiles: Array<String> = [];
     type?: Array<string>;
     functions?: Array<[string, Array<string>]>;

--- a/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.html
+++ b/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.html
@@ -15,10 +15,10 @@
   </div>
   
   <form #loginForm="ngForm">
-    <fieldset>
+    <fieldset [title]="federatedDisabledTitle">
       <ode-form-field label="login">
-        <span *ngIf="isAdmc == false">{{ details.login }}</span>
-        <div *ngIf="isAdmc">
+        <span *ngIf="!isAdmc" >{{ details.login }}</span>
+        <div *ngIf="isAdmc" >
           <input
             type="text"
             [(ngModel)]="details.login"
@@ -28,8 +28,6 @@
             (ngModelChange)="isUpdateLoginSaved = false"
             maxlength="64"
             [disabled]="!!details.hasFederatedIdentity"
-            [title]="federatedDisabledTitle"
-
           />
           <button
             type="button"
@@ -65,15 +63,15 @@
     </fieldset>
   </form>
   
-  <div [class.field-disabled]="!!details.hasFederatedIdentity">
-    <ode-form-field label="activation.code">
-      <span *ngIf="!!details.hasFederatedIdentity" class="is-disabled" [title]="federatedDisabledTitle"><s5l>user.connection.activationCode.unlock</s5l></span>
+  <div [class.field-disabled]="!!details.hasFederatedIdentity" [title]="federatedDisabledTitle">
+    <ode-form-field label="activation.code" >
+      <span *ngIf="!!details.hasFederatedIdentity" class="is-disabled" ><s5l>user.connection.activationCode.unlock</s5l></span>
       <span *ngIf="!!details.activationCode && !details.hasFederatedIdentity">{{ details.activationCode }}</span>
     </ode-form-field>
   </div>
 
   <form #connectionForm="ngForm">
-    <fieldset>
+    <fieldset [title]="federatedDisabledTitle">
       <ode-form-field label="loginAlias">
         <div>
           <input
@@ -83,9 +81,7 @@
             [pattern]="loginAliasPattern"
             #loginAliasInput="ngModel"
             [disabled]="isForbidden || !!details.hasFederatedIdentity"
-            maxlength="64" 
-            [title]="federatedDisabledTitle"
-
+            maxlength="64"
           />
           <button
             type="button"
@@ -440,14 +436,13 @@
           >
         </div>
       </ode-form-field>
-        <div [class.field-disabled]="!!details.hasFederatedIdentity">
+        <div [class.field-disabled]="!!details.hasFederatedIdentity" [title]="federatedDisabledTitle">
           <ode-form-field label="massmail">
-            <div>
-              <button 
-                type="button" 
-                (click)="sendIndividualMassMail('pdf')" 
-                [disabled]="!!details.hasFederatedIdentity"             
-                [title]="federatedDisabledTitle"
+            <div >
+              <button
+                type="button"
+                (click)="sendIndividualMassMail('pdf')"
+                [disabled]="!!details.hasFederatedIdentity"
               >
                 <span><s5l>individual.massmail.pdf</s5l></span>
                 <i class="fa fa-file-pdf-o"></i>
@@ -456,8 +451,6 @@
                 type="button"
                 (click)="showMassMailConfirmation = true"
                 [disabled]="!details.email || !!details.hasFederatedIdentity"
-                [title]="federatedDisabledTitle"
-
               >
                 <span><s5l>individual.massmail.mail</s5l></span>
                 <i class="fa fa-envelope"></i>

--- a/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.html
+++ b/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.html
@@ -2,6 +2,17 @@
   <div class="message is-info" *ngIf="isForbidden">
     <div class="message-body">&nbsp;<s5l>notify.user.email.info</s5l></div>
   </div>
+
+  <div class="cell flashmsg blue" *ngIf="details.hasFederatedIdentity">
+      <svg class="icon-svg flash-icon" width="20" height="20" viewBox="0 0 24 24">
+      <use [attr.href]="'/admin/public/icons/icons.svg#alert-triangle'"></use>
+    </svg>
+    <div class="flash-content">
+      <!-- <p></p> -->
+      <h3><s5l>users.details.section.infos.federatedInfo.title</s5l></h3> 
+      <p><s5l>users.details.section.infos.federatedInfo.content</s5l></p>
+    </div>
+  </div>
   
   <form #loginForm="ngForm">
     <fieldset>
@@ -16,11 +27,15 @@
             #loginInput="ngModel"
             (ngModelChange)="isUpdateLoginSaved = false"
             maxlength="64"
+            [disabled]="!!details.hasFederatedIdentity"
+            [title]="federatedDisabledTitle"
+
           />
           <button
             type="button"
             (click)="showChangeLoginConfirmation = true"
             [disabled]="
+              !!details.hasFederatedIdentity ||
               isUpdateLoginSaved ||
               loginForm.pristine ||
               loginForm.invalid ||
@@ -45,6 +60,50 @@
               <s5l>user.change.login.disclaimer.confirm</s5l>
             </p>
           </ode-lightbox-confirm>
+        </div>
+      </ode-form-field>
+    </fieldset>
+  </form>
+  
+  <div [class.field-disabled]="!!details.hasFederatedIdentity">
+    <ode-form-field label="activation.code">
+      <span *ngIf="!!details.hasFederatedIdentity" class="is-disabled" [title]="federatedDisabledTitle"><s5l>user.connection.activationCode.unlock</s5l></span>
+      <span *ngIf="!!details.activationCode && !details.hasFederatedIdentity">{{ details.activationCode }}</span>
+    </ode-form-field>
+  </div>
+
+  <form #connectionForm="ngForm">
+    <fieldset>
+      <ode-form-field label="loginAlias">
+        <div>
+          <input
+            type="text"
+            [(ngModel)]="details.loginAlias"
+            name="loginAlias"
+            [pattern]="loginAliasPattern"
+            #loginAliasInput="ngModel"
+            [disabled]="isForbidden || !!details.hasFederatedIdentity"
+            maxlength="64" 
+            [title]="federatedDisabledTitle"
+
+          />
+          <button
+            type="button"
+            (click)="updateLoginAlias()"
+            [disabled]="
+              connectionForm.pristine ||
+              connectionForm.invalid ||
+              spinner.isLoading('portal-content')
+            "
+          >
+            <s5l>login.update</s5l>
+            <i class="fa fa-floppy-o"></i>
+          </button>
+          <ode-form-errors
+            [control]="loginAliasInput"
+            [expectedPatternMsg]="'form.user.alias.pattern' | translate"
+          >
+          </ode-form-errors>
         </div>
       </ode-form-field>
     </fieldset>
@@ -85,46 +144,11 @@
     </fieldset>
   </form>
 
-  <form #connectionForm="ngForm">
-    <fieldset>
-      <ode-form-field label="loginAlias">
-        <div>
-          <input
-            type="text"
-            [(ngModel)]="details.loginAlias"
-            name="loginAlias"
-            [pattern]="loginAliasPattern"
-            #loginAliasInput="ngModel"
-            [disabled]="isForbidden"
-            maxlength="64"
-          />
-          <button
-            type="button"
-            (click)="updateLoginAlias()"
-            [disabled]="
-              connectionForm.pristine ||
-              connectionForm.invalid ||
-              spinner.isLoading('portal-content')
-            "
-          >
-            <s5l>login.update</s5l>
-            <i class="fa fa-floppy-o"></i>
-          </button>
-          <ode-form-errors
-            [control]="loginAliasInput"
-            [expectedPatternMsg]="'form.user.alias.pattern' | translate"
-          >
-          </ode-form-errors>
-        </div>
-      </ode-form-field>
-    </fieldset>
-  </form>
+  
 
   <form>
     <fieldset>
-      <ode-form-field label="activation.code" *ngIf="details.activationCode">
-        <span>{{ details.activationCode }}</span>
-      </ode-form-field>
+   
       <ode-form-field label="mergeKey" *ngIf="user.type === 'Relative'">
         <div>
           <span *ngIf="details.mergeKey">{{ details.mergeKey }}</span>
@@ -416,31 +440,39 @@
           >
         </div>
       </ode-form-field>
+        <div [class.field-disabled]="!!details.hasFederatedIdentity">
+          <ode-form-field label="massmail">
+            <div>
+              <button 
+                type="button" 
+                (click)="sendIndividualMassMail('pdf')" 
+                [disabled]="!!details.hasFederatedIdentity"             
+                [title]="federatedDisabledTitle"
+              >
+                <span><s5l>individual.massmail.pdf</s5l></span>
+                <i class="fa fa-file-pdf-o"></i>
+              </button>
+              <button
+                type="button"
+                (click)="showMassMailConfirmation = true"
+                [disabled]="!details.email || !!details.hasFederatedIdentity"
+                [title]="federatedDisabledTitle"
 
-      <ode-form-field label="massmail">
-        <div>
-          <button type="button" (click)="sendIndividualMassMail('pdf')">
-            <span><s5l>individual.massmail.pdf</s5l></span>
-            <i class="fa fa-file-pdf-o"></i>
-          </button>
-          <button
-            type="button"
-            (click)="showMassMailConfirmation = true"
-            [disabled]="!details.email"
-          >
-            <span><s5l>individual.massmail.mail</s5l></span>
-            <i class="fa fa-envelope"></i>
-          </button>
-          <ode-lightbox-confirm
-            [show]="showMassMailConfirmation"
-            [lightboxTitle]="'warning'"
-            (onConfirm)="sendIndividualMassMail('mail')"
-            (onCancel)="showMassMailConfirmation = false"
-          >
-            <s5l>individual.massmail.confirm</s5l>
-          </ode-lightbox-confirm>
-        </div>
-      </ode-form-field>
+              >
+                <span><s5l>individual.massmail.mail</s5l></span>
+                <i class="fa fa-envelope"></i>
+              </button>
+              <ode-lightbox-confirm
+                [show]="showMassMailConfirmation"
+                [lightboxTitle]="'warning'"
+                (onConfirm)="sendIndividualMassMail('mail')"
+                (onCancel)="showMassMailConfirmation = false"
+              >
+                <s5l>individual.massmail.confirm</s5l>
+              </ode-lightbox-confirm>
+            </div>
+          </ode-form-field>
+      </div>
     </fieldset>
   </form>
 </ode-panel-section>

--- a/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.html
+++ b/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.html
@@ -8,7 +8,6 @@
       <use [attr.href]="'/admin/public/icons/icons.svg#alert-triangle'"></use>
     </svg>
     <div class="flash-content">
-      <!-- <p></p> -->
       <h3><s5l>users.details.section.infos.federatedInfo.title</s5l></h3> 
       <p><s5l>users.details.section.infos.federatedInfo.content</s5l></p>
     </div>
@@ -27,13 +26,13 @@
             #loginInput="ngModel"
             (ngModelChange)="isUpdateLoginSaved = false"
             maxlength="64"
-            [disabled]="!!details.hasFederatedIdentity"
+            [disabled]="details.hasFederatedIdentity"
           />
           <button
             type="button"
             (click)="showChangeLoginConfirmation = true"
             [disabled]="
-              !!details.hasFederatedIdentity ||
+              details.hasFederatedIdentity ||
               isUpdateLoginSaved ||
               loginForm.pristine ||
               loginForm.invalid ||
@@ -63,9 +62,9 @@
     </fieldset>
   </form>
   
-  <div [class.field-disabled]="!!details.hasFederatedIdentity" [title]="federatedDisabledTitle">
+  <div [class.field-disabled]="details.hasFederatedIdentity" [title]="federatedDisabledTitle">
     <ode-form-field label="activation.code" >
-      <span *ngIf="!!details.hasFederatedIdentity" class="is-disabled" ><s5l>user.connection.activationCode.unlock</s5l></span>
+      <span *ngIf="details.hasFederatedIdentity" class="is-disabled" ><s5l>user.connection.activationCode.unlock</s5l></span>
       <span *ngIf="!!details.activationCode && !details.hasFederatedIdentity">{{ details.activationCode }}</span>
     </ode-form-field>
   </div>
@@ -80,7 +79,7 @@
             name="loginAlias"
             [pattern]="loginAliasPattern"
             #loginAliasInput="ngModel"
-            [disabled]="isForbidden || !!details.hasFederatedIdentity"
+            [disabled]="isForbidden || details.hasFederatedIdentity"
             maxlength="64"
           />
           <button
@@ -436,13 +435,13 @@
           >
         </div>
       </ode-form-field>
-        <div [class.field-disabled]="!!details.hasFederatedIdentity" [title]="federatedDisabledTitle">
+        <div [class.field-disabled]="details.hasFederatedIdentity" [title]="federatedDisabledTitle">
           <ode-form-field label="massmail">
             <div >
               <button
                 type="button"
                 (click)="sendIndividualMassMail('pdf')"
-                [disabled]="!!details.hasFederatedIdentity"
+                [disabled]="details.hasFederatedIdentity"
               >
                 <span><s5l>individual.massmail.pdf</s5l></span>
                 <i class="fa fa-file-pdf-o"></i>
@@ -450,7 +449,7 @@
               <button
                 type="button"
                 (click)="showMassMailConfirmation = true"
-                [disabled]="!details.email || !!details.hasFederatedIdentity"
+                [disabled]="!details.email || details.hasFederatedIdentity"
               >
                 <span><s5l>individual.massmail.mail</s5l></span>
                 <i class="fa fa-envelope"></i>

--- a/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.scss
+++ b/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.scss
@@ -1,3 +1,10 @@
+
+:host ::ng-deep ode-form-field:has(input:disabled) label,
+:host ::ng-deep .field-disabled ode-form-field label, .is-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .merge-info {
   h2 {
     margin-right: 30px;

--- a/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.scss
+++ b/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.scss
@@ -1,6 +1,6 @@
-
 :host ::ng-deep ode-form-field:has(input:disabled) label,
-:host ::ng-deep .field-disabled ode-form-field label, .is-disabled {
+:host ::ng-deep .field-disabled ode-form-field label,
+:host .is-disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }

--- a/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.ts
+++ b/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.ts
@@ -106,6 +106,12 @@ export class UserConnectionSectionComponent
     super();
   }
 
+  get federatedDisabledTitle(): string {
+    return this.details?.hasFederatedIdentity
+      ? this.bundles.translate('user.connection.field.title.disabled.federatedUser')
+      : '';
+  }
+
   get shouldShowTotpField(): boolean {
     // Show TOTP field if at least one structure does not ignore MFA
     if (!this.details || !this.details.structureNodes || this.details.structureNodes.length === 0) {

--- a/admin/src/main/ts/src/app/users/details/sections/info/user-info-section.component.html
+++ b/admin/src/main/ts/src/app/users/details/sections/info/user-info-section.component.html
@@ -1,4 +1,15 @@
 <ode-panel-section section-title="users.details.section.infos" [folded]="false">
+  <div class="cell flashmsg blue" *ngIf="details.hasFederatedIdentity">
+        <svg class="icon-svg flash-icon" width="20" height="20" viewBox="0 0 24 24">
+      <use [attr.href]="'/admin/public/icons/icons.svg#alert-triangle'"></use>
+    </svg>
+    <div class="flash-content">
+      <!-- <p></p> -->
+      <h3><s5l>users.details.section.infos.federatedInfo.title</s5l></h3> 
+      <p><s5l>users.details.section.infos.federatedInfo.content</s5l></p>
+    </div>
+
+  </div>
   <form>
     <fieldset>
       <ode-form-field label="profile">

--- a/admin/src/main/ts/src/app/users/details/sections/info/user-info-section.component.html
+++ b/admin/src/main/ts/src/app/users/details/sections/info/user-info-section.component.html
@@ -1,22 +1,8 @@
 <ode-panel-section section-title="users.details.section.infos" [folded]="false">
-  <div class="cell flashmsg blue" *ngIf="details.hasFederatedIdentity">
-        <svg class="icon-svg flash-icon" width="20" height="20" viewBox="0 0 24 24">
-      <use [attr.href]="'/admin/public/icons/icons.svg#alert-triangle'"></use>
-    </svg>
-    <div class="flash-content">
-      <!-- <p></p> -->
-      <h3><s5l>users.details.section.infos.federatedInfo.title</s5l></h3> 
-      <p><s5l>users.details.section.infos.federatedInfo.content</s5l></p>
-    </div>
-
-  </div>
   <form>
     <fieldset>
       <ode-form-field label="profile">
         <span>{{ user.type | translate }}</span>
-      </ode-form-field>
-      <ode-form-field label="activation.code" *ngIf="details.activationCode">
-        <span>{{ details.activationCode }}</span>
       </ode-form-field>
       <ode-form-field label="id">
         <span>{{ user.id }}</span>

--- a/admin/src/main/ts/src/app/users/details/sections/info/user-info-section.component.ts
+++ b/admin/src/main/ts/src/app/users/details/sections/info/user-info-section.component.ts
@@ -1,26 +1,23 @@
+import { HttpClient } from "@angular/common/http";
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   Input,
-  OnInit,
-  ViewChild,
+  OnInit
 } from "@angular/core";
-import { HttpClient } from "@angular/common/http";
-import { AbstractControl } from "@angular/forms";
-import { Subscription } from "rxjs";
 import { BundlesService } from "ngx-ode-sijil";
+import { Subscription } from "rxjs";
 
-import { AbstractSection } from "../abstract.section";
-import { UserInfoService } from "./user-info.service";
-import { Config } from "../../../../core/resolvers/Config";
+import { SpinnerService } from "ngx-ode-ui";
+import { NotifyService } from "src/app/core/services/notify.service";
+import { Session } from "src/app/core/store/mappings/session";
+import { SessionModel } from "src/app/core/store/models/session.model";
 import { StructureModel } from "src/app/core/store/models/structure.model";
 import { UserModel } from "src/app/core/store/models/user.model";
-import { NotifyService } from "src/app/core/services/notify.service";
-import { SpinnerService } from "ngx-ode-ui";
-import { PlatformInfoService } from "src/app/core/services/platform-info.service";
-import { SessionModel } from "src/app/core/store/models/session.model";
-import { Session } from "src/app/core/store/mappings/session";
+import { Config } from "../../../../core/resolvers/Config";
+import { AbstractSection } from "../abstract.section";
+import { UserInfoService } from "./user-info.service";
 
 @Component({
   selector: "ode-user-info-section",


### PR DESCRIPTION
# Description

Ajoute des indicateurs visuels de désactivation sur les champs de la section Connexion lorsqu'un utilisateur possède une identité fédérée (`hasFederatedIdentity`). Les champs login, loginAlias et code d'activation sont désormais non-éditables et grisés (champ + label), avec un tooltip explicatif au survol.

## Fixes

[IMPULS-5914](https://edifice-community.atlassian.net/browse/IMPULS-5914)

## Type of change

- [x] New feature (MINOR)

## Which packages changed?

- [x] admin

## Tests

1. Ouvrir la fiche d'un utilisateur ayant `hasFederatedIdentity: true` dans la console d'administration
2. Vérifier que les champs **login**, **loginAlias** et **code d'activation** sont désactivés (non éditables)
3. Vérifier que les labels de ces champs sont grisés (opacity 0.5)
4. Survoler un champ désactivé → un tooltip doit apparaître avec le message `user.connection.field.title.disabled.federatedUser`
5. Vérifier que le span « code d'activation » affiche bien le message i18n dédié lorsque le compte est fédéré
6. Ouvrir la fiche d'un utilisateur sans fédération → comportement inchangé

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley:


[IMPULS-5914]: https://edifice-community.atlassian.net/browse/IMPULS-5914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ