### PR TITLE
fix(timeline): #IMPULS-5968 use user preference for include or  notifications in recap  mail

### DIFF
--- a/timeline/src/main/java/org/entcore/timeline/services/impl/PeriodicTimelineMailerService.java
+++ b/timeline/src/main/java/org/entcore/timeline/services/impl/PeriodicTimelineMailerService.java
@@ -799,15 +799,15 @@ public class PeriodicTimelineMailerService implements CronMailerService {
             if (notificationPreference == null){
                 continue;
             }
-            notificationPreference.getJsonObject("preferences", new JsonObject())
+            JsonObject userNotificationPref = notificationPreference.getJsonObject("preferences", new JsonObject())
                     .getJsonObject("config", new JsonObject())
                     .getJsonObject(notificationName, new JsonObject());
             if (TimelineNotificationsLoader.Frequencies.DAILY.name().equals(
-                    notificationPrefsMixin("defaultFrequency", notificationPreference, notificationsDefaults.getJsonObject(notificationName))) &&
+                    notificationPrefsMixin("defaultFrequency", userNotificationPref, notificationsDefaults.getJsonObject(notificationName))) &&
                     !TimelineNotificationsLoader.Restrictions.INTERNAL.name().equals(
-                            notificationPrefsMixin("restriction", notificationPreference, notificationsDefaults.getJsonObject(notificationName))) &&
+                            notificationPrefsMixin("restriction", userNotificationPref, notificationsDefaults.getJsonObject(notificationName))) &&
                     !TimelineNotificationsLoader.Restrictions.HIDDEN.name().equals(
-                            notificationPrefsMixin("restriction", notificationPreference, notificationsDefaults.getJsonObject(notificationName)))) {
+                            notificationPrefsMixin("restriction", userNotificationPref, notificationsDefaults.getJsonObject(notificationName)))) {
 
                 notification.put("template", notificationsDefaults.getJsonObject(notificationName, new JsonObject()).getString("template", ""));
 


### PR DESCRIPTION
# Description

Use user preference for include or  notifications in recap  mail

## Fixes

https://edifice-community.atlassian.net/browse/IMPULS-5968

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [X ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: