### PR TITLE
feat(class-admin): #IMPULS-5916, #IMPULS-5917, hide mass-mailing options and codes for federated users

### DIFF
--- a/directory/src/main/resources/i18n/fr.json
+++ b/directory/src/main/resources/i18n/fr.json
@@ -389,6 +389,7 @@
   "directory.favorite.name": "Nom de mon favori",
   "directory.favorite.share": "favoris de partage",
   "directory.favorites": "Favoris",
+  "directory.federated": "Fédéré",
   "directory.feeding": "Alimentation",
   "directory.filterResults": "Filtrer les résultats",
   "directory.filters": "Filtres",

--- a/directory/src/main/resources/public/template/admin/toaster.html
+++ b/directory/src/main/resources/public/template/admin/toaster.html
@@ -12,7 +12,7 @@
             <button workflow="directory.allowClassAdminDeleteUsers" ng-if="canRemoveSelection()" ng-click="openLightbox('admin/actions/delete')">
                 <i18n>remove</i18n>
             </button>
-            <button ng-click="goToExport(true)">
+            <button ng-click="goToExport(true)" ng-if="!allSelectedUsersAreFederated()">
                 <i18n>classAdmin.export.toaster</i18n>
             </button>
             <button workflow="directory.allowClassAdminUnlinkUsers" ng-click="onToasterUnlinkUsers()">

--- a/directory/src/main/resources/public/template/admin/user-infos.html
+++ b/directory/src/main/resources/public/template/admin/user-infos.html
@@ -143,8 +143,8 @@
 	<!--END FORM-->
 	<!--BUTTONS-->
 	<div class="row twelve bottom-spacing-three" ng-if="!isForbidden()">
-		<a workflow="directory.allowClassAdminResetPassword" ng-if="!selectedUser.activationCode" class="button" ng-click="resetPasswords(selectedUser)" translate content="classAdmin.userInfos.reset"></a>
-		<a class="button" ng-click="userInfoExport(selectedUser)" translate content="classAdmin.userInfos.connectInfos"></a>
+		<button workflow="directory.allowClassAdminResetPassword" ng-if="!selectedUser.activationCode" class="button" ng-click="resetPasswords(selectedUser)" translate content="classAdmin.userInfos.reset"></button>
+		<button ng-disabled="selectedUser.hasFederatedIdentity" ng-click="userInfoExport(selectedUser)" translate content="classAdmin.userInfos.connectInfos"></button>
 	</div>
 	<!--END BUTTON-->
 	<!--MOOD-->
@@ -195,7 +195,7 @@
 	<article class="row bottom-spacing-three" ng-if="userInfosDisplayRelative()">
 		<h2 content="userBook.profile.relatives"><span class="no-style" translate key="userBook.profile.relatives"></span></h2>
 		<div class="reduce-block-eight">
-			<div class="flex-row align-center top-spacing-twice">
+			<div ng-if="!selectedUser.hasFederatedIdentity" class="flex-row align-center top-spacing-twice">
 					<a class="cell-ellipsis small-text block left-text" ng-click="userInfoExportFamily(selectedUser)">
 						<i class="download-disk"></i> <i18n>classAdmin.report.family</i18n>
 					</a>

--- a/directory/src/main/resources/public/ts/admin/delegates/actions.ts
+++ b/directory/src/main/resources/public/ts/admin/delegates/actions.ts
@@ -9,6 +9,7 @@ export interface ActionsDelegateScope extends EventDelegateScope {
     selectedUsersAreNotActivated(): boolean;
     selectedUsersAreBlocked(): boolean;
     selectedUsersAreNotBlocked(): boolean;
+    allSelectedUsersAreFederated(): boolean;
     confirmRemove();
     canRemoveSelection(): boolean
     blockUsers(): void;
@@ -50,6 +51,9 @@ export function ActionsDelegate($scope: ActionsDelegateScope) {
     }
     $scope.selectedUsersAreBlocked = function () {
         return selection.findIndex((u) => !u.blocked) == -1;
+    }
+    $scope.allSelectedUsersAreFederated = function () {
+        return selection.some((u) => !u.hasFederatedIdentity);
     }
     $scope.canRemoveSelection = function () {
         return selection.filter((user) => {

--- a/directory/src/main/resources/public/ts/admin/delegates/userExport.ts
+++ b/directory/src/main/resources/public/ts/admin/delegates/userExport.ts
@@ -139,6 +139,7 @@ export function ExportDelegate($scope: ExportDelegateScope) {
                 return ($scope.userExport.profiles.indexOf(u.type) > -1);
             });
         }
+        _usersForMailing = _usersForMailing.filter(u => !u.hasFederatedIdentity);
         _usersWithoutMails = _usersForMailing.filter(s => !s.safeHasEmail);
         _usersWithMails = _usersForMailing.filter(s => s.safeHasEmail);
     }

--- a/directory/src/main/resources/public/ts/admin/delegates/userList.ts
+++ b/directory/src/main/resources/public/ts/admin/delegates/userList.ts
@@ -234,6 +234,8 @@ export async function UserListDelegate($scope: UserListDelegateScope) {
     $scope.displayCode = function (user) {
         if (user.blocked) {
             return lang.translate("directory.blocked.label");
+        } else if (user.hasFederatedIdentity) {
+            return lang.translate("directory.federated");
         } else if (user.activationCode) {
             return user.activationCode;
         } else if (user.resetCode) {
@@ -245,10 +247,12 @@ export async function UserListDelegate($scope: UserListDelegateScope) {
     $scope.displayCodeCss = function (user) {
         if (user.blocked) {
             return "blocked";
+        } else if (user.hasFederatedIdentity) {
+            return "italic-text";
         } else if (user.activationCode) {
             return "notactivated";
         } else if (user.resetCode) {
-            return "resetted"
+            return "resetted";
         } else {
             return "activated";
         }

--- a/directory/src/main/resources/public/ts/admin/model.ts
+++ b/directory/src/main/resources/public/ts/admin/model.ts
@@ -70,6 +70,7 @@ export class User extends Model {
     originalLogin: string;
     lastLogin: string;
     blocked: boolean;
+    hasFederatedIdentity: boolean;
     type: UserTypes;
     profile: UserTypes;
     resetCode: string;


### PR DESCRIPTION
# Description

Adds a “federated” status to the class-admin user list so that activation/reset codes are not displayed for users with a federated identity.

Buttons for mass-mailing are disabled for federated users.

## Fixes

https://edifice-community.atlassian.net/browse/IMPULS-5916

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [X] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: