### PR TITLE
feat(directory): #IMPULS-5955 add duplicate default auth of a structue to a list of structure

### DIFF
--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultSchoolService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultSchoolService.java
@@ -639,7 +639,8 @@ public class DefaultSchoolService implements SchoolService {
 				setWidget = options.getBoolean("setWidgets", true),
 				setDistribution = options.getBoolean("setDistribution", true),
 				setEducation = options.getBoolean("setEducation", true),
-				setHasApp = options.getBoolean("setHasApp", true);
+				setHasApp = options.getBoolean("setHasApp", true),
+				setDefaultAuth = options.getBoolean("setDefaultAuth", false);
 		if (setApplications) {
 			buildDuplicateQuery(structureId, targetUAIs, builder, "Role", "ProfileGroup");
 			buildDuplicateQuery(structureId, targetUAIs, builder, "Role", "FunctionGroup");
@@ -647,6 +648,9 @@ public class DefaultSchoolService implements SchoolService {
 		if (setWidget) {
 			buildDuplicateQuery(structureId, targetUAIs, builder, "Widget", "ProfileGroup");
 			buildDuplicateQuery(structureId, targetUAIs, builder, "Widget", "FunctionGroup");
+		}
+		if (setDefaultAuth) {
+			buildDuplicateDefaultAuthQuery(structureId, targetUAIs, builder);
 		}
 		if (setDistribution || setEducation || setHasApp) {
 			String structureUpdateQuery = "MATCH (s:Structure {id:{structureId}}), (s2:Structure) " +
@@ -681,6 +685,18 @@ public class DefaultSchoolService implements SchoolService {
 				"AND s2.UAI IN {uais} AND g2.name ENDS WITH LAST(SPLIT(g1.name, '-')) AND g1.id <> g2.id " +
 				"MERGE (g2)-[a2:AUTHORIZED]->(r)" +
 				"ON CREATE SET a2.mandatory = a.mandatory";
+		builder.add(duplicateQuery, params);
+	}
+
+	private void buildDuplicateDefaultAuthQuery(String structureId, JsonArray targetUAIs, StatementsBuilder builder) {
+		final JsonObject params = new JsonObject().put("structureId", structureId).put("uais", targetUAIs);
+		final String deleteExistingQuery = "MATCH (s2:Structure)-[:HAS_AUTH_DEFAULT]->(d:AuthDefault) " +
+				"WHERE s2.UAI IN {uais} " +
+				"DETACH DELETE d";
+		builder.add(deleteExistingQuery, params);
+		final String duplicateQuery = "MATCH (s:Structure {id:{structureId}})-[:HAS_AUTH_DEFAULT]->(d:AuthDefault), (s2:Structure) " +
+				"WHERE s2.UAI IN {uais} " +
+				"MERGE (s2)-[:HAS_AUTH_DEFAULT]->(:AuthDefault { profile: d.profile, auth: d.auth })";
 		builder.add(duplicateQuery, params);
 	}
 

--- a/directory/src/test/java/org/entcore/directory/services/impl/DefaultSchoolServiceTest.java
+++ b/directory/src/test/java/org/entcore/directory/services/impl/DefaultSchoolServiceTest.java
@@ -6,6 +6,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.entcore.directory.pojo.structure.DefaultAuthModeConfig;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -104,6 +105,12 @@ public class DefaultSchoolServiceTest {
                 .withUser(parent)
                 .withUser(adml)
                     .adml(adml.getId(), "my-structure-01")
+                // Structures dedicated to the defaultAuth duplication tests.
+                // Sources are matched by id, targets by UAI.
+                .withStructure(new StructureTest("auth-src-fed", "auth source federated", true))
+                .withStructure(new StructureTest("auth-src-ent", "auth source ent"))
+                .withStructure(new StructureTest("auth-target-copy", "auth target copy", false, "UAI-AUTH-COPY"))
+                .withStructure(new StructureTest("auth-target-replace", "auth target replace", true, "UAI-AUTH-REPLACE"))
                 .execute();
     }
 
@@ -304,6 +311,70 @@ public class DefaultSchoolServiceTest {
                     // validate() returns false when enabled=true and schedule.length==0
                     context.assertTrue(ar.failed(), "enabled=true with empty schedule should be rejected");
                     context.assertEquals("invalid.preference.data", ar.cause().getMessage());
+                    async.complete();
+                });
+    }
+
+    // -----------------------------------------------------------------------
+    //  Default auth duplication tests (setDefaultAuth option)
+    // -----------------------------------------------------------------------
+
+    private Future<Void> duplicateDefaultAuth(final String sourceStructureId, final String targetUai) {
+        final Promise<Void> promise = Promise.promise();
+        // Only the defaultAuth config is duplicated, to isolate the behaviour under test.
+        final JsonObject options = new JsonObject()
+                .put("setApplications", false)
+                .put("setWidgets", false)
+                .put("setDistribution", false)
+                .put("setEducation", false)
+                .put("setHasApp", false)
+                .put("setDefaultAuth", true);
+        defaultSchoolService.duplicateStructureSettings(sourceStructureId, new JsonArray().add(targetUai), options, result -> {
+            if (result.isRight()) {
+                promise.complete();
+            } else {
+                promise.fail(result.left().getValue());
+            }
+        });
+        return promise.future();
+    }
+
+    @Test
+    public void testDuplicateDefaultAuth_copiesFederatedConfigToTarget(final TestContext context) {
+        final Async async = context.async();
+        // Source "auth-src-fed" is FEDERATED for every profile, target starts with no config.
+        duplicateDefaultAuth("auth-src-fed", "UAI-AUTH-COPY")
+                .compose(ignored -> defaultSchoolService.getDefaultAuth("auth-target-copy"))
+                .onComplete(ar -> {
+                    if (ar.succeeded()) {
+                        final DefaultAuthModeConfig config = ar.result();
+                        context.assertEquals(DefaultAuthModeConfig.Profile.values().length,
+                                config.getDefaultAuthModes().size(), "every profile should be configured");
+                        config.getDefaultAuthModes().forEach((profile, mode) ->
+                                context.assertEquals(DefaultAuthModeConfig.DefaultAuthMode.FEDERATED, mode,
+                                        "profile " + profile + " should be FEDERATED after duplication"));
+                    } else {
+                        context.fail(ar.cause());
+                    }
+                    async.complete();
+                });
+    }
+
+    @Test
+    public void testDuplicateDefaultAuth_replacesExistingConfigWhenSourceHasNone(final TestContext context) {
+        final Async async = context.async();
+        // Source "auth-src-ent" has no AuthDefault, target starts FEDERATED: duplication must clear it back to ENT.
+        duplicateDefaultAuth("auth-src-ent", "UAI-AUTH-REPLACE")
+                .compose(ignored -> defaultSchoolService.getDefaultAuth("auth-target-replace"))
+                .onComplete(ar -> {
+                    if (ar.succeeded()) {
+                        final DefaultAuthModeConfig config = ar.result();
+                        config.getDefaultAuthModes().forEach((profile, mode) ->
+                                context.assertEquals(DefaultAuthModeConfig.DefaultAuthMode.ENT, mode,
+                                        "profile " + profile + " should fall back to ENT after duplication"));
+                    } else {
+                        context.fail(ar.cause());
+                    }
                     async.complete();
                 });
     }


### PR DESCRIPTION
# Description

Add service and test to duplicate default auth of a structue to a list of structure for the admin

## Fixes

https://edifice-community.atlassian.net/browse/IMPULS-5955

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ X] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ X] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: