### PR TITLE
Fix impuls 5965 filter login on user dendpoints

### DIFF
--- a/directory/src/main/java/org/entcore/directory/controllers/UserController.java
+++ b/directory/src/main/java/org/entcore/directory/controllers/UserController.java
@@ -344,7 +344,7 @@ public class UserController extends BaseController {
 					.add("city").add("otherNames").add("title").add("surname").add("functions").add("headTeacher")
 					.add("relativeAddress").add("classCategories").add("subjectTaught").add("needRevalidateTerms")
 					.add("joinKey").add("isTeacher").add("structures").add("type").add("children").add("parents")
-					.add("functionalGroups").add("startDateStruct").add("endDateStruct")
+					.add("functionalGroups").add("startDateStruct").add("endDateStruct").add("login")
 					.add("administrativeStructures").add("subjectCodes").add("fieldOfStudyLabels").add("startDateClasses")
 					.add("scholarshipHolder").add("attachmentId").add("fieldOfStudy").add("module").add("transport")
 					.add("accommodation").add("status").add("relative").add("moduleName").add("sector").add("level");

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserBookService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserBookService.java
@@ -508,6 +508,7 @@ public class DefaultUserBookService implements UserBookService {
 						if(!visibleInfos.contains("SHOW_MOBILE")) result.put("mobile", "");
 						if(!visibleInfos.contains("SHOW_BIRTHDATE")) result.put("birthdate", "");
 						if(!visibleInfos.contains("SHOW_HEALTH")) result.put("health", "");
+						result.put("login", "");
 					}
 				}
 				handler.handle(new Either.Right<>(results));

--- a/directory/src/test/java/org/entcore/directory/services/impl/DefaultUserBookServiceTest.java
+++ b/directory/src/test/java/org/entcore/directory/services/impl/DefaultUserBookServiceTest.java
@@ -131,6 +131,7 @@ public class DefaultUserBookServiceTest {
                 testContext.assertEquals(user.getString("displayName"), parent.getDisplayName() , "Field must be equals");
                 testContext.assertEquals(user.getString("email"), parent.getEmail() , "Field must be equals");
                 testContext.assertEquals(user.getString("birthdate"), parent.getBirthdate() , "Field must be equals");
+                testContext.assertTrue(isEmpty(user.getString("login")), "Login must be hidden on public access even without visibility filter");
                 async.complete();
             });
 
@@ -154,6 +155,7 @@ public class DefaultUserBookServiceTest {
                 testContext.assertNotNull(user.getString("displayName") , "Field must be not null");
                 testContext.assertNull(user.getString("email"), "Field must be null");
                 testContext.assertNull(user.getString("birthdate") , "Field must be null");
+                testContext.assertTrue(isEmpty(user.getString("login")), "Login must be hidden with public filter");
                 async.complete();
             });
 


### PR DESCRIPTION
# Description

For security reason, not admin user should not see login of other users, filter login from two endpoint use in  Annuaire

## Fixes

https://edifice-community.atlassian.net/browse/IMPULS-5965

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: