### PR TITLE
feat(admin):#IMPULS-5856 exclude-federated-users-from-massmail

### DIFF
--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -852,6 +852,7 @@
   "massmail.confirm": "Êtes-vous sûr de vouloir envoyer leur identifiant par mail à {{nbUsers}} utilisateur(s) ?",
   "massmail.error": "Erreur lors du publipostage",
   "massmail.filename": "publipostage_pdf",
+  "massmail.info.authMode": "Dans votre établissement, certains comptes sont paramétrés pour passer par une authentification externe à l'ENT (par exemple : ÉduConnect, Arena, LiÀ, FranceConnect…). Les utilisateurs concernés ne figureront pas dans la liste ci-dessous car il n’est pas prévu que vous leur donniez un identifiant/mot de passe ENT pour se connecter. Les utilisateurs concernés sont les comptes chargés automatiquements (AAF, csv) pour les profils suivant : Parents, Enseignants.",
   "massmail.filters": "Filtrer la liste à publiposter",
   "massmail.firstsort": "Par",
   "massmail.link.user": "Accéder à la fiche utilisateur",

--- a/admin/src/main/ts/src/app/core/store/models/user.model.ts
+++ b/admin/src/main/ts/src/app/core/store/models/user.model.ts
@@ -46,6 +46,7 @@ export class UserModel extends Model<UserModel> {
     duplicates: { id: string, firstName: string, lastName: string, code: string, score: number, structures: { id: string, name: string }[] }[] = [];
     deleteDate?: number;
     disappearanceDate?: number;
+    hasFederatedIdentity?: boolean;
 
     userDetails: UserDetailsModel;
 

--- a/admin/src/main/ts/src/app/imports-exports/mailing/mass-mail/mass-mail.component.html
+++ b/admin/src/main/ts/src/app/imports-exports/mailing/mass-mail/mass-mail.component.html
@@ -1,6 +1,17 @@
 <div class="container has-shadow">
   <h2>{{ 'massmail.accounts' | translate }}</h2>
 
+
+  <div class="cell flashmsg blue" *ngIf="countUsersInactiveAndFederated > 0">
+      <svg class="icon-svg flash-icon" width="20" height="20" viewBox="0 0 24 24">
+      <use [attr.href]="'/admin/public/icons/icons.svg#alert-triangle'"></use>
+    </svg>
+    <div class="flash-content">
+      <p><s5l>massmail.info.authMode</s5l></p>
+    </div>
+  
+  </div>
+
   <div class="has-vertical-padding-10 is-pulled-left">
     <button (click)="toggleVisibility()"
             class="button is-primary"

--- a/admin/src/main/ts/src/app/imports-exports/mailing/mass-mail/mass-mail.component.html
+++ b/admin/src/main/ts/src/app/imports-exports/mailing/mass-mail/mass-mail.component.html
@@ -97,7 +97,7 @@
           [lightboxTitle]="'warning'"
           (onConfirm)="processMassMail('mail')"
           (onCancel)="showConfirmation = false">
-          <s5l [s5l-params]="{nbUsers: countUsers - countUsersWithoutMail}">massmail.confirm</s5l>
+          <s5l [s5l-params]="{nbUsers: countUsersWithMail}">massmail.confirm</s5l>
         </ode-lightbox-confirm>
       </div>
     </div>

--- a/admin/src/main/ts/src/app/imports-exports/mailing/mass-mail/mass-mail.component.ts
+++ b/admin/src/main/ts/src/app/imports-exports/mailing/mass-mail/mass-mail.component.ts
@@ -30,6 +30,7 @@ export class MassMailComponent extends OdeComponent implements OnInit, OnDestroy
     inputFilters = {lastName: '', firstName: '', classesStr: ''};
     countUsers = 0;
     countUsersWithoutMail = 0;
+    countUsersInactiveAndFederated = 0;
     userOrder: string;
     structureId: string;
     show = false;
@@ -96,17 +97,24 @@ export class MassMailComponent extends OdeComponent implements OnInit, OnDestroy
         this.userlistFiltersService.setClassesComboModel(structure.classes);
         this.userlistFiltersService.setProfilesComboModel(structure.profiles.map(p => p.name));
     }
-
+    
     getFilteredUsers(): UserModel[] {
         const users = FilterPipe.prototype.transform(this.users, this.filters) || [];
+        console.log('users:', users)
         this.countUsers = 0;
         this.countUsersWithoutMail = 0;
+        this.countUsersInactiveAndFederated = 0;
         users.forEach(user => {
             this.countUsers++;
             if (!user.email) {
                 this.countUsersWithoutMail++;
             }
+            if (user.hasFederatedIdentity && (!user.code || user.code.length === 0)) {
+                console.log('user:', user)
+                this.countUsersInactiveAndFederated++;
+            }
         });
+        console.log('this.countUsersInactiveAndFederated:', this.countUsersInactiveAndFederated)
         return users;
     }
 

--- a/admin/src/main/ts/src/app/imports-exports/mailing/mass-mail/mass-mail.component.ts
+++ b/admin/src/main/ts/src/app/imports-exports/mailing/mass-mail/mass-mail.component.ts
@@ -61,6 +61,10 @@ export class MassMailComponent extends OdeComponent implements OnInit, OnDestroy
         super(injector);
     }
 
+    get countUsersWithMail(): number {
+        return this.countUsers - this.countUsersWithoutMail;
+    }
+
     ngOnInit(): void {
         super.ngOnInit();
         this.subscriptions.add(routing.observe(this.route, 'data').subscribe(async (data: Data) => {
@@ -88,8 +92,6 @@ export class MassMailComponent extends OdeComponent implements OnInit, OnDestroy
             }
         }));
     }
-
-
 
     private initFilters(structure: StructureModel): void {
         this.userlistFiltersService.resetFilters();

--- a/admin/src/main/ts/src/app/imports-exports/mailing/mass-mail/mass-mail.component.ts
+++ b/admin/src/main/ts/src/app/imports-exports/mailing/mass-mail/mass-mail.component.ts
@@ -100,22 +100,22 @@ export class MassMailComponent extends OdeComponent implements OnInit, OnDestroy
     
     getFilteredUsers(): UserModel[] {
         const users = FilterPipe.prototype.transform(this.users, this.filters) || [];
-        console.log('users:', users)
         this.countUsers = 0;
         this.countUsersWithoutMail = 0;
         this.countUsersInactiveAndFederated = 0;
+        const visibleUsers: UserModel[] = [];
         users.forEach(user => {
+            if (user.hasFederatedIdentity && (!user.code || user.code.length === 0)) {
+                this.countUsersInactiveAndFederated++;
+                return;
+            }
+            visibleUsers.push(user);
             this.countUsers++;
             if (!user.email) {
                 this.countUsersWithoutMail++;
             }
-            if (user.hasFederatedIdentity && (!user.code || user.code.length === 0)) {
-                console.log('user:', user)
-                this.countUsersInactiveAndFederated++;
-            }
         });
-        console.log('this.countUsersInactiveAndFederated:', this.countUsersInactiveAndFederated)
-        return users;
+        return visibleUsers;
     }
 
     async processMassMail(type: string): Promise<void> {


### PR DESCRIPTION
# Description

Dans l'écran de publipostage (mass-mail), les utilisateurs dont l'authentification est déléguée
à un fournisseur externe (hasFederatedIdentity = true) et qui n'ont pas de code d'activation ENT
n'ont pas vocation à recevoir un identifiant/mot de passe ENT. Les afficher dans la liste pouvait
induire les admins en erreur.

Ce changement les retire de la liste affichée et ajoute un bandeau d'information expliquant
pourquoi ces comptes sont absents.

## Fixes

[IMPULS-5856](https://edifice-community.atlassian.net/browse/IMPULS-5856)

## Type of change

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

- [x] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Aller dans Admin > Établissement > Publipostage
2. Vérifier qu'un utilisateur ayant `hasFederatedIdentity = true` et sans code d'activation **n'apparaît pas** dans la liste
3. Vérifier que le **bandeau bleu d'information** s'affiche si au moins un tel utilisateur existe dans l'établissement
4. Vérifier que les compteurs (total utilisateurs, sans mail) ne comptent **pas** ces utilisateurs exclus
5. Vérifier qu'un utilisateur fédéré **avec** un code d'activation reste visible dans la liste

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley:

[IMPULS-5856]: https://edifice-community.atlassian.net/browse/IMPULS-5856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ