### PR TITLE
fix(admin): #IMPULS-5996 ajout d'une modale de confirmation avant le déverrouillage des champs fédérés

### DIFF
--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -1699,6 +1699,8 @@
   "users.details.section.connection.federatedInfo.unlock": "Débloquer l’accès au code d’activation :",
   "users.details.section.connection.federatedFields.toggle.locked": "Bloqué",
   "users.details.section.connection.federatedFields.toggle.unlocked": "Débloqué",
+  "users.details.section.connection.federatedFields.unlock.confirm.title": "Débloquer le code d'activation",
+  "users.details.section.connection.federatedFields.unlock.confirm.content": "Vous êtes sur le point de débloquer l'accès aux informations de connexion de ce compte. Si vous distribuez ces identifiants, pensez à bien indiquer à l'utilisateur de passer par la fenêtre de connexion de l'ENT (généralement pour les profils invités).",
   "users.details.section.connection.activationCode.unlock": "Débloquer pour voir le code d’activation",
   "users.details.section.connection.field.title.disabled.federatedUser": "Champs verrouillé car l'utilisateur est en authentification externe (voir message ci-dessus)",
   "users.details.section.detached": "non rattaché",

--- a/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.html
+++ b/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.html
@@ -17,7 +17,7 @@
     </div>
     <p><b><s5l>users.details.section.connection.federatedInfo.unlock</s5l></b>
     <label>
-      <input type="checkbox" [(ngModel)]="isFederatedUserFieldsUnlocked" />
+      <input type="checkbox" [ngModel]="isFederatedUserFieldsUnlocked" (ngModelChange)="onFederatedUnlockChange($event)" name="federatedUnlock" />
       <s5l *ngIf="!isFederatedUserFieldsUnlocked">users.details.section.connection.federatedFields.toggle.locked</s5l>
       <s5l *ngIf="isFederatedUserFieldsUnlocked">users.details.section.connection.federatedFields.toggle.unlocked</s5l>
     </label>
@@ -480,3 +480,13 @@
     </fieldset>
   </form>
 </ode-panel-section>
+
+<ode-lightbox-confirm
+  lightboxTitle="users.details.section.connection.federatedFields.unlock.confirm.title"
+  [show]="showUnlockConfirmModal"
+  (onCancel)="showUnlockConfirmModal = false"
+  (onConfirm)="confirmFederatedUnlock()">
+  <p>
+    <s5l>users.details.section.connection.federatedFields.unlock.confirm.content</s5l>
+  </p>
+</ode-lightbox-confirm>

--- a/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.ts
+++ b/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.ts
@@ -76,6 +76,7 @@ export class UserConnectionSectionComponent
   @Input() set inUser(user: UserModel) {
       this._inUser = user;
       this.user = user;
+      this.showUnlockConfirmModal = false;
   }
 
   @Input() config: Config;

--- a/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.ts
+++ b/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.ts
@@ -123,13 +123,11 @@ export class UserConnectionSectionComponent
     } else {
       this.isFederatedUserFieldsUnlocked = false;
     }
-    this.cdRef.markForCheck();
   }
 
   confirmFederatedUnlock() {
     this.isFederatedUserFieldsUnlocked = true;
     this.showUnlockConfirmModal = false;
-    this.cdRef.markForCheck();
   }
 
   get isFederatedIdentityFieldsLocked(): boolean {

--- a/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.ts
+++ b/admin/src/main/ts/src/app/users/details/sections/connection/user-connection-section.component.ts
@@ -61,6 +61,7 @@ export class UserConnectionSectionComponent
   showTotpVerify: boolean = false;
   tempTotpCode: string = "";
   isFederatedUserFieldsUnlocked = false;
+  showUnlockConfirmModal: boolean = false;
   // Base32 alphabet: A-Z and 2-7, with optional padding
   readonly totpBase32Pattern = /^[A-Za-z2-7]+(={0,6})?$/;
   // TOTP code: exactly 6 digits
@@ -113,6 +114,21 @@ export class UserConnectionSectionComponent
       this.details.activationCode && this.details.activationCode.length > 0
     );
     return this.details?.hasFederatedIdentity && !isUserActive;
+  }
+
+  onFederatedUnlockChange(value: boolean) {
+    if (value) {
+      this.showUnlockConfirmModal = true;
+    } else {
+      this.isFederatedUserFieldsUnlocked = false;
+    }
+    this.cdRef.markForCheck();
+  }
+
+  confirmFederatedUnlock() {
+    this.isFederatedUserFieldsUnlocked = true;
+    this.showUnlockConfirmModal = false;
+    this.cdRef.markForCheck();
   }
 
   get isFederatedIdentityFieldsLocked(): boolean {


### PR DESCRIPTION
# Description

Ajout d'une modale de confirmation avant le déverrouillage des champs de connexion pour les utilisateurs fédérés. Auparavant, cliquer sur le toggle de déverrouillage révélait immédiatement les champs sans avertissement. La modale informe désormais l'administrateur des implications avant de procéder.

## Fixes

[IMPULS-5996](https://edifice-community.atlassian.net/browse/IMPULS-5996)

## Type of change

- [x] Bug fix (PATCH)

## Which packages changed?

- [x] admin

## Tests

1. Ouvrir la fiche d'un **utilisateur fédéré inactif** (avec `hasFederatedIdentity = true` et non actif)
2. Dans la section **Connexion**, cliquer sur le toggle "Débloquer l'accès au code d'activation"
3. Résultat attendu : une modale de confirmation s'affiche avec le titre _"Débloquer le code d'activation"_ et un message d'avertissement sur la distribution des identifiants
4. Cliquer **Annuler** → la modale se ferme, les champs restent verrouillés (`isFederatedUserFieldsUnlocked = false`)
5. Refaire l'étape 2, puis cliquer **Confirmer** → la modale se ferme, les champs sont déverrouillés
6. Vérifier que le toggle affiche "Débloqué" et que les champs de connexion sont accessibles

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley:

[IMPULS-5996]: https://edifice-community.atlassian.net/browse/IMPULS-5996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ