### PR TITLE
fix: #IMPULS_5596 message already sent

### DIFF
--- a/conversation/backend/src/main/resources/i18n/fr.json
+++ b/conversation/backend/src/main/resources/i18n/fr.json
@@ -49,7 +49,7 @@
   "conversation.error.reply.not.allowed": "Vous ne pouvez pas répondre à ce message",
   "conversation.error.send.visible": "Votre message n'a pas été envoyé car il ne respecte pas vos droits de communication",
   "conversation.error.trash.folder": "Le dossier n'a pas pu être supprimé",
-  "conversation.error.alreadysend": "Ce méssage a déjà été envoyé",
+  "conversation.error.alreadysend": "Ce message a déjà été envoyé",
   "conversation.notfound.or.unauthorized": "Le message demandé n'existe pas, a été supprimé, ou vous n'avez pas la possibilité d'y accéder.",
   "conversation.recall.mail": "Les destinataires ne pourront plus voir le contenu du message, mais ils verront que vous l'avez rappelé. Êtes-vous sûr de vouloir rappeler ce message ?",
   "conversation.recall.mail.content": "L’expéditeur a rappelé ce message, son contenu n’est donc plus visible.",

--- a/conversation/frontend/src/services/queries/message.ts
+++ b/conversation/frontend/src/services/queries/message.ts
@@ -560,7 +560,18 @@ export const useSendDraft = () => {
       inReplyToId?: string;
     }) => {
       setMessageNeedToSave(false);
-      return messageService.send(draftId, payload, inReplyToId);
+      return messageService
+        .send(draftId, payload, inReplyToId)
+        .catch((error: any) => {
+          if (error.error) {
+            toast.error(t(error.error));
+            throw error;
+          }
+          invalidateQueriesWithFirstPage(queryClient, {
+            queryKey: folderQueryKeys.messages('draft'),
+          });
+          return Promise.reject(error);
+        });
     },
     onSuccess: (_response, { payload, draftId }) => {
       toast.success(t('message.sent'));


### PR DESCRIPTION
# Description

nouveau code d’erreur lorsqu’on essaie d’envoyer un message qui à déjà été envoyé : 

 *   affiche le message d’erreur (conversation.error.alreadysend)
*    met à jours la liste des brouillons et messages envoyés.

## Fixes

https://edifice-community.atlassian.net/browse/IMPULS-5596

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: