### PR TITLE
Fix timeline impuls 6026 flash notif doublon mail daily weekly

### DIFF
--- a/timeline/src/main/java/org/entcore/timeline/events/TimelineEventStore.java
+++ b/timeline/src/main/java/org/entcore/timeline/events/TimelineEventStore.java
@@ -37,7 +37,7 @@ public interface TimelineEventStore {
 	}
 
 	List<String> FIELDS = Arrays.asList("resource", "sender", "message", "params", "type",
-			"recipients", "comments", "add-comment", "sub-resource", "event-type", "date", "pushNotif", "preview");
+			"recipients", "comments", "add-comment", "sub-resource", "event-type", "date", "pushNotif", "disableMailNotification", "preview");
 
 	List<String> REQUIRED_FIELDS = Arrays.asList("params", "recipients", "type");
 

--- a/timeline/src/main/java/org/entcore/timeline/services/impl/PeriodicTimelineMailerService.java
+++ b/timeline/src/main/java/org/entcore/timeline/services/impl/PeriodicTimelineMailerService.java
@@ -905,7 +905,8 @@ public class PeriodicTimelineMailerService implements CronMailerService {
                         .add(new JsonObject().put("recipients.userId", new JsonObject()
                                 .put("$in", userIds)))
                         .add(new JsonObject().put("date", new JsonObject().put("$gte", new JsonObject().put("$date", formatUtcDateTime(from)))))
-                        .add(new JsonObject().put("date", new JsonObject().put("$lt", new JsonObject().put("$date", formatUtcDateTime(to))))));
+                        .add(new JsonObject().put("date", new JsonObject().put("$lt", new JsonObject().put("$date", formatUtcDateTime(to))))))
+                .put("disableMailNotification", new JsonObject().put("$ne", true));
 
         JsonObject transformer = new JsonObject("{ \"type\": 1, \"event-type\": 1, \"recipients\": { \"$filter\": { \"input\": \"$recipients\", \"as\": \"r\", \"cond\" : { \"$in\" : " +
                 "  [\"$$r.userId\", " + userIds.encode() + "]} }}}");
@@ -959,7 +960,8 @@ public class PeriodicTimelineMailerService implements CronMailerService {
                         .add(new JsonObject().put("recipients.userId", new JsonObject()
                                 .put("$in", userIds)))
                         .add(new JsonObject().put("date", new JsonObject().put("$gte", new JsonObject().put("$date", formatUtcDateTime(from)))))
-                        .add(new JsonObject().put("date", new JsonObject().put("$lt", new JsonObject().put("$date", formatUtcDateTime(to))))));
+                        .add(new JsonObject().put("date", new JsonObject().put("$lt", new JsonObject().put("$date", formatUtcDateTime(to))))))
+                .put("disableMailNotification", new JsonObject().put("$ne", true));
 
         final JsonObject matcherPostUnwind = new JsonObject().put("recipients.userId", new JsonObject().put("$in", userIds));
 


### PR DESCRIPTION
# Description

Un message flash publié avec **notif mail ET mobile** cochées apparaît **deux fois** dans le mail quotidien. Visible quand l'usager est en plage silencieuse (les notifs immédiates sont alors différées vers le digest).

## Fixes

[#IMPULS-6026](https://edifice-community.atlassian.net/browse/IMPULS-6026)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [x] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: