### PR TITLE
Fix impuls 6042 downcasting error on sb local

### DIFF
--- a/timeline/src/main/java/org/entcore/timeline/services/impl/PeriodicTimelineMailerService.java
+++ b/timeline/src/main/java/org/entcore/timeline/services/impl/PeriodicTimelineMailerService.java
@@ -21,8 +21,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.entcore.common.email.EmailFactory;
+import org.entcore.common.email.MassEmailSender;
 import org.entcore.common.email.impl.PostgresEmailDto;
-import org.entcore.common.email.impl.PostgresEmailSender;
 import org.entcore.common.http.request.JsonHttpServerRequest;
 import org.entcore.common.neo4j.Neo4j;
 import org.entcore.common.neo4j.Neo4jResult;
@@ -60,7 +60,7 @@ public class PeriodicTimelineMailerService implements CronMailerService {
     private TimelineConfigService configService;
     private Map<String, String> eventsI18n;
     private HashMap<String, JsonObject> lazyEventsI18n;
-    private final PostgresEmailSender emailSender;
+    private final MassEmailSender emailSender;
     private final int USERS_LIMIT;
     private final long QUERY_TIMEOUT;
     private final MongoDb mongo = MongoDb.getInstance();
@@ -74,7 +74,7 @@ public class PeriodicTimelineMailerService implements CronMailerService {
     public PeriodicTimelineMailerService(Vertx vertx, JsonObject config) {
         eb = Server.getEventBus(vertx);
         EmailFactory emailFactory = EmailFactory.getInstance();
-        emailSender = (PostgresEmailSender) emailFactory.getSenderWithPriority(EmailFactory.PRIORITY_VERY_LOW);
+        emailSender = emailFactory.getSenderWithPriority(EmailFactory.PRIORITY_VERY_LOW);
         USERS_LIMIT = config.getInteger("users-loop-limit", 200);
         QUERY_TIMEOUT = config.getLong("query-timeout", 300000L);
         init(vertx, config);


### PR DESCRIPTION
# Description

In PeriodicTimelineMailerService we down cast emailSender to postgresqlEmailsender, it is correct on production / recette env, but not on local SB => refactor to use an interface and add default implementation on mass mailing

## Fixes

https://edifice-community.atlassian.net/browse/IMPULS-6042

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ X] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [X ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: