### PR TITLE
Fix enabling 986 single xml validation scheme

### DIFF
--- a/directory/src/main/resources/template.j2
+++ b/directory/src/main/resources/template.j2
@@ -1,5 +1,6 @@
 {
   "name": "org.entcore~directory",
+  "waitDeploy": true,
   "config": {
     "main": "org.entcore.directory.Directory",
     "auto-redeploy": false,

--- a/feeder/src/main/java/org/entcore/feeder/aaf/BaseImportProcessing.java
+++ b/feeder/src/main/java/org/entcore/feeder/aaf/BaseImportProcessing.java
@@ -61,10 +61,12 @@ public abstract class BaseImportProcessing implements ImportProcessing {
 			);
 	private static final int MAX_DEADLOCK_RETRIES = 1;
 	private static final Pattern DEADLOCK_PATTERN = Pattern.compile("(deadlock|EntityNotFound)", Pattern.CASE_INSENSITIVE);
+	private final String validationFilePath;
 
 	protected BaseImportProcessing(String path, Vertx vertx) {
 		this.path = path;
 		this.vertx = vertx;
+		this.validationFilePath = vertx.getOrCreateContext().config().getString("validation-file-path", null);
 		log = new FeederLogger(e-> getTag(), e-> "academy: "+ academyPrefix);
 	}
 
@@ -117,7 +119,12 @@ public abstract class BaseImportProcessing implements ImportProcessing {
 								@Override
 								public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
 									if (systemId.equals("ficAlimMENESR.dtd")) {
-										Reader reader = new FileReader(path + File.separator + "ficAlimMENESR.dtd");
+										Reader reader;
+										if (validationFilePath != null && !validationFilePath.isEmpty()) {
+											reader = new FileReader(validationFilePath);
+										} else {
+											reader = new FileReader(path + File.separator + "ficAlimMENESR.dtd");
+										}
 										return new InputSource(reader);
 									} else {
 										return null;

--- a/feeder/src/main/resources/template.j2
+++ b/feeder/src/main/resources/template.j2
@@ -115,6 +115,7 @@
     "exporter": "ELIOT",
     "export-path": "/tmp",
     "delete-export" : {{ feederEliotDeleteExport | default('false') }},
-    "export-destination": ""
+    "export-destination": "",
+    "validation-file-path": "{{ feederValidationFilePath }}"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     </modules>
 
     <properties>
-        <revision>6.15-SNAPSHOT</revision>
+        <revision>6.15-ENABLING-986-SNAPSHOT</revision>
         <entCoreLibsVersion>6.15-SNAPSHOT</entCoreLibsVersion>
         <junitVersion>4.13.2</junitVersion>
         <testContainerVersion>1.19.3</testContainerVersion>


### PR DESCRIPTION
# Description

Enable usage of a single xml validation file, and make directory start before feeder to have shared conf map fully loaded

## Fixes

https://edifice-community.atlassian.net/browse/ENABLING-986

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [x] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

AAF import triggered in preprod-essonne

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: