### PR TITLE
fix(timeline): #IMPULS-6046, extend max schedule range

### DIFF
--- a/timeline/src/main/java/org/entcore/timeline/controllers/helper/QuietHoursHelper.java
+++ b/timeline/src/main/java/org/entcore/timeline/controllers/helper/QuietHoursHelper.java
@@ -55,20 +55,17 @@ public final class QuietHoursHelper {
      *
      * <p>Base send time is the processing hour itself (run at 07:00 local -> mail at 07:00 local, i.e. sent
      * immediately). If quiet hours are active at the base time, the send time is pushed to the first non-quiet slot.
-     * The mail must be sent before the next daily run of the user's timezone (next local processing hour, i.e. +1
-     * calendar day — calendar arithmetic so DST transition days stay correct): past that point a fresher digest takes
-     * over, so the mail is dropped instead.</p>
+     * When the whole day is quiet (e.g. a fully-silent weekend), that slot falls on the next open day and the digest
+     * is deferred there rather than dropped, so weekend content is not lost (IMPULS-6046). Daily windows are disjoint,
+     * so a deferred digest never overlaps the content of a later one.</p>
      *
-     * @return the send instant, or null if no valid slot exists before the next run (mail must be skipped)
+     * @return the send instant, or null only when the schedule leaves no non-quiet slot at all (mail must be skipped)
      */
     public static Instant computeDailyMailScheduleAt(Instant runTime, QuietHoursPreference userPrefQuietHours, ZoneId zone) {
         if (zone == null) return null;
         final ZonedDateTime localRun = runTime.atZone(zone).truncatedTo(ChronoUnit.HOURS);
         final Instant base = localRun.toInstant();
-        final Instant nextRun = localRun.plusDays(1).toInstant();
-        final Instant scheduleAt = computeNextSendTime(base, userPrefQuietHours, zone);
-        if (scheduleAt == null || !scheduleAt.isBefore(nextRun)) return null;
-        return scheduleAt;
+        return computeNextSendTime(base, userPrefQuietHours, zone);
     }
 
     /**

--- a/timeline/src/main/java/org/entcore/timeline/services/impl/PeriodicTimelineMailerService.java
+++ b/timeline/src/main/java/org/entcore/timeline/services/impl/PeriodicTimelineMailerService.java
@@ -392,7 +392,7 @@ public class PeriodicTimelineMailerService implements CronMailerService {
                 .compose( preferences -> getUsersNotifications(preferences, from, to, page))
                 .map( notificationContext -> trimNotificationsToUserWindow(notificationContext, runTime))
                 .compose( notificationContext -> applyDailyRuleToNotification(notificationContext, notificationsDefaults, page))
-                .compose( notificationContext -> processDailyTimelineTemplate(notificationContext, page))
+                .compose( notificationContext -> processDailyTimelineTemplate(notificationContext, page, runTime))
                 .compose( notificationContext -> sendMassMail(notificationContext, page));
     }
 
@@ -577,7 +577,7 @@ public class PeriodicTimelineMailerService implements CronMailerService {
                 .compose( filteredUser -> getUserPreferences(filteredUser, page)))
                 .compose( preferences -> getUsersNotifications(preferences, from, to, page))
                 .compose( notificationContext -> applyDailyRuleToNotification(notificationContext, notificationsDefaults, page))
-                .compose( notificationContext -> processDailyTimelineTemplate(notificationContext, page))
+                .compose( notificationContext -> processDailyTimelineTemplate(notificationContext, page, from.toInstant()))
                 .compose( notificationContext -> sendMassMail(notificationContext, page));
     }
 
@@ -636,7 +636,7 @@ public class PeriodicTimelineMailerService implements CronMailerService {
     }
 
 
-    private Future<NotificationContext> processDailyTimelineTemplate(NotificationContext notificationContext, int page) {
+    private Future<NotificationContext> processDailyTimelineTemplate(NotificationContext notificationContext, int page, Instant digestDay) {
         List<Future<?>> futures = new ArrayList<>();
 
         StopWatch step6 = new StopWatch();
@@ -661,8 +661,12 @@ public class PeriodicTimelineMailerService implements CronMailerService {
             }
             final String userLanguage = mutableUserLanguage;
             final String userDisplayName = getOrElse(userPrefs.getString("displayName"), "", true);
+            final ZoneId userZone = ZoneId.of(userPrefs.getString("zoneId", DEFAULT_TIMEZONE.getId()));
             SimpleDateFormat formatter = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss", Locale.forLanguageTag(userLanguage));
-            formatter.setTimeZone(TimeZone.getTimeZone(ZoneId.of(userPrefs.getString("zoneId", DEFAULT_TIMEZONE.getId()))));
+            formatter.setTimeZone(TimeZone.getTimeZone(userZone));
+            final SimpleDateFormat dayFormatter = new SimpleDateFormat("EEEE", Locale.forLanguageTag(userLanguage));
+            dayFormatter.setTimeZone(TimeZone.getTimeZone(userZone));
+            final String dayName = dayFormatter.format(Date.from(digestDay));
 
             final HttpServerRequest request = new JsonHttpServerRequest(new JsonObject()
                     .put("headers", new JsonObject()
@@ -675,7 +679,8 @@ public class PeriodicTimelineMailerService implements CronMailerService {
                                                                 .map(JsonObject.class::cast)
                                                                 .map( notification -> formatter.format(MongoDb.parseIsoDate(notification.getJsonObject("date"))))
                                                                 .collect(Collectors.toList()))
-                                                        .put("displayName", userDisplayName);
+                                                        .put("displayName", userDisplayName)
+                                                        .put("day", dayName);
 
             futures.add(processTimelineTemplate(templateParams,  "notifications/daily-mail.html", request)
                     .onSuccess( template -> {
@@ -688,7 +693,8 @@ public class PeriodicTimelineMailerService implements CronMailerService {
             JsonArray keys = new JsonArray()
                     .add("timeline.daily.mail.subject.header");
             futures.add(translateTimeline(keys, request, userLanguage)
-                    .onSuccess( translations -> { notificationContext.subjects.put(userId, translations.getString(0));}));
+                    .onSuccess( translations -> notificationContext.subjects.put(userId,
+                            Mustache.compiler().compile(translations.getString(0)).execute(templateParams.getMap()))));
         }
 
         return Future.join(futures).map( v -> {

--- a/timeline/src/main/java/org/entcore/timeline/services/impl/PeriodicTimelineMailerService.java
+++ b/timeline/src/main/java/org/entcore/timeline/services/impl/PeriodicTimelineMailerService.java
@@ -37,11 +37,11 @@ import org.entcore.timeline.controllers.helper.QuietHoursHelper;
 import org.entcore.timeline.services.CronMailerService;
 import org.entcore.timeline.services.TimelineConfigService;
 
-import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -662,11 +662,9 @@ public class PeriodicTimelineMailerService implements CronMailerService {
             final String userLanguage = mutableUserLanguage;
             final String userDisplayName = getOrElse(userPrefs.getString("displayName"), "", true);
             final ZoneId userZone = ZoneId.of(userPrefs.getString("zoneId", DEFAULT_TIMEZONE.getId()));
-            SimpleDateFormat formatter = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss", Locale.forLanguageTag(userLanguage));
-            formatter.setTimeZone(TimeZone.getTimeZone(userZone));
-            final SimpleDateFormat dayFormatter = new SimpleDateFormat("EEEE", Locale.forLanguageTag(userLanguage));
-            dayFormatter.setTimeZone(TimeZone.getTimeZone(userZone));
-            final String dayName = dayFormatter.format(Date.from(digestDay));
+            final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, d MMM yyyy HH:mm:ss", Locale.forLanguageTag(userLanguage)).withZone(userZone);
+            final DateTimeFormatter dayFormatter = DateTimeFormatter.ofPattern("EEEE", Locale.forLanguageTag(userLanguage)).withZone(userZone);
+            final String dayName = dayFormatter.format(digestDay);
 
             final HttpServerRequest request = new JsonHttpServerRequest(new JsonObject()
                     .put("headers", new JsonObject()
@@ -677,7 +675,7 @@ public class PeriodicTimelineMailerService implements CronMailerService {
             JsonObject templateParams = new JsonObject().put("nestedTemplatesArray", notificationEntry.getValue())
                                                         .put("notificationDates", notificationEntry.getValue().stream()
                                                                 .map(JsonObject.class::cast)
-                                                                .map( notification -> formatter.format(MongoDb.parseIsoDate(notification.getJsonObject("date"))))
+                                                                .map( notification -> formatter.format(MongoDb.parseIsoDate(notification.getJsonObject("date")).toInstant()))
                                                                 .collect(Collectors.toList()))
                                                         .put("displayName", userDisplayName)
                                                         .put("day", dayName);

--- a/timeline/src/main/resources/i18n/fr.json
+++ b/timeline/src/main/resources/i18n/fr.json
@@ -207,7 +207,7 @@
   "timeline.daily.mail.action.text": "Voir les nouveautés",
   "timeline.daily.mail.subject.bold": "du nouveau depuis hier",
   "timeline.daily.mail.subject.end": "dans votre ENT",
-  "timeline.daily.mail.subject.header": "Quoi de neuf aujourd'hui ?",
+  "timeline.daily.mail.subject.header": "Quoi de neuf ce {{day}} ?",
   "timeline.daily.mail.subject.start": "Bonjour {{displayName}}, il y a",
   "timeline.defaultFrequency": "Fréquence de mail par défaut",
   "timeline.empty": "Votre réseau proche n'a partagé aucune information avec vous pour le moment !",

--- a/timeline/src/test/java/org/entcore/timeline/controllers/helper/NotificationHelperTest.java
+++ b/timeline/src/test/java/org/entcore/timeline/controllers/helper/NotificationHelperTest.java
@@ -347,13 +347,30 @@ public class NotificationHelperTest {
     }
 
     @Test
-    public void testComputeDailyMailScheduleAt_SlotAtNextRun_Skipped() {
-        // Monday quiet from 6h, Tuesday quiet 0h-5h -> first free slot Tuesday 06:00 = next run -> mail skipped (null)
+    public void testComputeDailyMailScheduleAt_SlotAtNextRun_Deferred() {
+        // Monday quiet from 6h, Tuesday quiet 0h-5h -> first free slot Tuesday 06:00 (what used to be the next run):
+        // no longer dropped, the digest is deferred to that slot (IMPULS-6046)
         int[][] schedule = new int[7][];
         schedule[0] = new int[]{6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
         schedule[1] = new int[]{0, 1, 2, 3, 4, 5};
         for (int i = 2; i < 7; i++) schedule[i] = new int[]{};
-        assertNull(QuietHoursHelper.computeDailyMailScheduleAt(mondayRun(), enabledPref(schedule), PARIS));
+        Instant expected = ZonedDateTime.of(2026, 6, 2, 6, 0, 0, 0, PARIS).toInstant();
+        assertEquals(expected, QuietHoursHelper.computeDailyMailScheduleAt(mondayRun(), enabledPref(schedule), PARIS));
+    }
+
+    @Test
+    public void testComputeDailyMailScheduleAt_FullyQuietWeekend_DeferredToMonday() {
+        // Weekend 100% quiet, weekdays quiet 20h-6h: the Saturday run has no free slot before Sunday's run, but the
+        // digest is now deferred to the first open slot (Monday 07:00) instead of being dropped (IMPULS-6046)
+        int[] allDay = new int[24];
+        for (int h = 0; h < 24; h++) allDay[h] = h;
+        int[][] schedule = new int[7][];
+        for (int i = 0; i <= 4; i++) schedule[i] = new int[]{0, 1, 2, 3, 4, 5, 6, 20, 21, 22, 23}; // Mon-Fri
+        schedule[5] = allDay; // Saturday
+        schedule[6] = allDay; // Sunday
+        Instant saturdayRun = ZonedDateTime.of(2026, 6, 6, 6, 0, 0, 0, PARIS).toInstant();
+        Instant expected = ZonedDateTime.of(2026, 6, 8, 7, 0, 0, 0, PARIS).toInstant(); // next Monday 07:00
+        assertEquals(expected, QuietHoursHelper.computeDailyMailScheduleAt(saturdayRun, enabledPref(schedule), PARIS));
     }
 
     @Test


### PR DESCRIPTION
# Description

On agrandi la plage max retourné par `computeDailyMailScheduleAt` de 24h à 168h (une semaine).
Ça permet en autre aux mails daily du samedi et dimanche d'être schedule pour envoi le lundi matin.

## Fixes

[#IMPULS-6046](https://edifice-community.atlassian.net/browse/IMPULS-6046)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [x] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: