### PR TITLE
fix(workspace): #IMPULS-5827, clé de trad manquante, notif push

### DIFF
--- a/workspace/src/main/resources/i18n/fr.json
+++ b/workspace/src/main/resources/i18n/fr.json
@@ -148,6 +148,7 @@
   "size": "Poids",
   "terabyte": "Téra-octet(s)",
   "terminate": "Terminer",
+  "timeline.workspace.contrib.folder": "a contribué dans le dossier",
   "to": "Destinataire",
   "trash": "Corbeille",
   "tuto.action.open": "Double-cliquez",


### PR DESCRIPTION
# Description

Clé de trad présente au mauvais endroit. `i18n/timeline/*` uniquement utilisé par le module timeline. Workspace ne pouvait pas la résoudre.

## Fixes

[#IMPULS-5827](https://edifice-community.atlassian.net/browse/IMPULS-5827)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [x] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: