### PR TITLE
chore(feeder): #IMPULS-6018, copie PS au .attach()

### DIFF
--- a/feeder/src/main/java/org/entcore/feeder/ManualFeeder.java
+++ b/feeder/src/main/java/org/entcore/feeder/ManualFeeder.java
@@ -349,12 +349,12 @@ public class ManualFeeder extends BusModBase {
 		String query =
 				"MATCH (s:Structure { id : {structureId}})<-[:DEPENDS]-" +
 				"(pg:ProfileGroup)-[:HAS_PROFILE]->(p:Profile { name : {profile}}) " +
-				"CREATE (u:User {props}) " +
+				"CREATE UNIQUE pg<-[:IN]-(u:User {props}) " +
+				"SET u.structures = [s.externalId] " +
 				related +
 				"RETURN DISTINCT u.id as id, u.login AS login";
 		tx.add(query, params);
-		new org.entcore.common.schema.users.User(user.getString("id")).attach(tx,
-		        new Id<org.entcore.common.schema.structures.Structure, String>(structureId));
+		org.entcore.common.schema.structures.Structure.applyStructureManagedPreferences(tx, user.getString("id"), structureId);
 		if (classesNames != null && !classesNames.isEmpty()) {
 			final String classesQuery =
 					"MATCH (s:Structure {id:{structureId}})<-[:BELONGS]-(c:Class)<-[:DEPENDS]-(cpg:ProfileGroup {filter: {profile}}), " +
@@ -640,8 +640,8 @@ public class ManualFeeder extends BusModBase {
 		String query =
 				"MATCH (s:Class { id : {classId}})<-[:DEPENDS]-(cpg:ProfileGroup)-[:DEPENDS]->" +
 				"(pg:ProfileGroup)-[:HAS_PROFILE]->(p:Profile { name : {profile}}), s-[:BELONGS]->(struct:Structure) " +
-				"CREATE (u:User {props}), cpg<-[:IN]-u " +
-				"SET u.classes = [s.externalId] " +
+				"CREATE UNIQUE pg<-[:IN]-(u:User {props}), cpg<-[:IN]-u " +
+				"SET u.classes = [s.externalId], u.structures = [struct.externalId] " +
 				related +
 				"RETURN DISTINCT u.id as id, u.login AS login";
 		final String structureQuery = "MATCH (c:Class {id:{classId}})-[:BELONGS]->(s:Structure) RETURN s.id as structureId";
@@ -654,8 +654,7 @@ public class ManualFeeder extends BusModBase {
 				final TransactionHelper tx = new TransactionHelper(neo4j, Source.MANUAL, transactionId);
 				tx.add(query, params);
 				if (structureId != null) {
-					new org.entcore.common.schema.users.User(user.getString("id")).attach(tx,
-							new Id<org.entcore.common.schema.structures.Structure, String>(structureId));
+					org.entcore.common.schema.structures.Structure.applyStructureManagedPreferences(tx, user.getString("id"), structureId);
 				}
 				final Promise<Void> promise = Promise.promise();
 				if (userPositionIds == null) {
@@ -725,8 +724,7 @@ public class ManualFeeder extends BusModBase {
 				final TransactionHelper tx = new TransactionHelper(neo4j, Source.MANUAL, transactionId);
 				tx.add(query, params);
 				if (structureId != null) {
-					new org.entcore.common.schema.users.User(userId).attach(tx,
-							new Id<org.entcore.common.schema.structures.Structure, String>(structureId));
+					org.entcore.common.schema.structures.Structure.attach(tx, userId, structureId);
 				}
 				final Handler<Message<JsonObject>> replyHandler = new Handler<Message<JsonObject>>() {
 					@Override
@@ -774,8 +772,7 @@ public class ManualFeeder extends BusModBase {
 									"RETURN DISTINCT u.id as id";
 					tx.add(query, params);
 					if (structureId != null) {
-						new org.entcore.common.schema.users.User(uid).attach(tx,
-								new Id<org.entcore.common.schema.structures.Structure, String>(structureId));
+						org.entcore.common.schema.structures.Structure.attach(tx, uid, structureId);
 					}
 				}
 				tx.commit(new Handler<Message<JsonObject>>() {

--- a/feeder/src/main/java/org/entcore/feeder/ManualFeeder.java
+++ b/feeder/src/main/java/org/entcore/feeder/ManualFeeder.java
@@ -384,19 +384,16 @@ public class ManualFeeder extends BusModBase {
 			.onFailure(promise::fail);
 		}
 		promise.future().onSuccess(e -> {
-			final Handler<Message<JsonObject>> replyHandler = new Handler<Message<JsonObject>>() {
-				@Override
-				public void handle(Message<JsonObject> event) {
-					final JsonArray results = event.body().getJsonArray("results");
-					if ("ok".equals(event.body().getString("status")) && results != null && results.size() > 0) {
-						message.reply(event.body().put("result", results.getJsonArray(0)));
-						if (commit) {
-							eventStore.createAndStoreEvent(Feeder.FeederEvent.CREATE_USER.name(),
-								(UserInfos) null, new JsonObject().put("new-user", user.getString("id")));
-						}
-					} else {
-						message.reply(event.body());
+			final Handler<Message<JsonObject>> replyHandler = event -> {
+				final JsonArray results = event.body().getJsonArray("results");
+				if ("ok".equals(event.body().getString("status")) && results != null && results.size() > 0) {
+					message.reply(event.body().put("result", results.getJsonArray(0)));
+					if (commit) {
+						eventStore.createAndStoreEvent(Feeder.FeederEvent.CREATE_USER.name(),
+							(UserInfos) null, new JsonObject().put("new-user", user.getString("id")));
 					}
+				} else {
+					message.reply(event.body());
 				}
 			};
 			if (Boolean.TRUE.equals(commit)) {
@@ -645,56 +642,50 @@ public class ManualFeeder extends BusModBase {
 				related +
 				"RETURN DISTINCT u.id as id, u.login AS login";
 		final String structureQuery = "MATCH (c:Class {id:{classId}})-[:BELONGS]->(s:Structure) RETURN s.id as structureId";
-		neo4j.execute(structureQuery, new JsonObject().put("classId", classId), new Handler<Message<JsonObject>>() {
-			@Override
-			public void handle(Message<JsonObject> structRes) {
-				final JsonArray sr = structRes.body().getJsonArray("result");
-				final String structureId = ("ok".equals(structRes.body().getString("status")) && sr != null && sr.size() > 0)
-						? sr.getJsonObject(0).getString("structureId") : null;
-				final TransactionHelper tx = new TransactionHelper(neo4j, Source.MANUAL, transactionId);
-				tx.add(query, params);
-				if (structureId != null) {
-					org.entcore.common.schema.structures.Structure.applyStructureManagedPreferences(tx, user.getString("id"), structureId);
-				}
-				final Promise<Void> promise = Promise.promise();
-				if (userPositionIds == null) {
-					promise.complete();
-				} else {
-					userPositionService.getUserPositionSettingQueryAndParam(
-						userPositionIds.stream().map(id -> (String) id).collect(Collectors.toSet()),
-						user.getString("id"),
-						message.body().getString("callerId"))
-					.onSuccess(queryAndParams -> {
-						tx.add(queryAndParams.getQuery(), queryAndParams.getParams());
-						promise.complete();
-					}).onFailure(promise::fail);
-				}
-				promise.future().onSuccess(e -> {
-					final Handler<Message<JsonObject>> replyHandler = new Handler<Message<JsonObject>>() {
-						@Override
-						public void handle(Message<JsonObject> event) {
-							final JsonArray results = event.body().getJsonArray("results");
-							if ("ok".equals(event.body().getString("status")) && results != null && results.size() > 0) {
-								message.reply(event.body().put("result", results.getJsonArray(0)));
-								if (commit) {
-									eventStore.createAndStoreEvent(Feeder.FeederEvent.CREATE_USER.name(),
-										(UserInfos) null, new JsonObject().put("new-user", user.getString("id")));
-								}
-							} else {
-								message.reply(event.body());
-							}
-						}
-					};
-					if (Boolean.TRUE.equals(commit)) {
-						tx.commit(replyHandler);
-					} else {
-						tx.flush(replyHandler);
-					}
-				}).onFailure(th -> {
-					logger.warn("An error occurred while creating user position update query", th);
-					sendError(message, "Unknown error");
-				});
+		neo4j.execute(structureQuery, new JsonObject().put("classId", classId), structRes -> {
+			final JsonArray sr = structRes.body().getJsonArray("result");
+			final String structureId = ("ok".equals(structRes.body().getString("status")) && sr != null && sr.size() > 0)
+					? sr.getJsonObject(0).getString("structureId") : null;
+			final TransactionHelper tx = new TransactionHelper(neo4j, Source.MANUAL, transactionId);
+			tx.add(query, params);
+			if (structureId != null) {
+				org.entcore.common.schema.structures.Structure.applyStructureManagedPreferences(tx, user.getString("id"), structureId);
 			}
+			final Promise<Void> promise = Promise.promise();
+			if (userPositionIds == null) {
+				promise.complete();
+			} else {
+				userPositionService.getUserPositionSettingQueryAndParam(
+					userPositionIds.stream().map(id -> (String) id).collect(Collectors.toSet()),
+					user.getString("id"),
+					message.body().getString("callerId"))
+				.onSuccess(queryAndParams -> {
+					tx.add(queryAndParams.getQuery(), queryAndParams.getParams());
+					promise.complete();
+				}).onFailure(promise::fail);
+			}
+			promise.future().onSuccess(e -> {
+				final Handler<Message<JsonObject>> replyHandler = event -> {
+					final JsonArray results = event.body().getJsonArray("results");
+					if ("ok".equals(event.body().getString("status")) && results != null && results.size() > 0) {
+						message.reply(event.body().put("result", results.getJsonArray(0)));
+						if (commit) {
+							eventStore.createAndStoreEvent(Feeder.FeederEvent.CREATE_USER.name(),
+								(UserInfos) null, new JsonObject().put("new-user", user.getString("id")));
+						}
+					} else {
+						message.reply(event.body());
+					}
+				};
+				if (Boolean.TRUE.equals(commit)) {
+					tx.commit(replyHandler);
+				} else {
+					tx.flush(replyHandler);
+				}
+			}).onFailure(th -> {
+				logger.warn("An error occurred while creating user position update query", th);
+				sendError(message, "Unknown error");
+			});
 		});
 	}
 
@@ -715,33 +706,27 @@ public class ManualFeeder extends BusModBase {
 						"u.classes ELSE coalesce(u.classes, []) + s.externalId END " +
 						"RETURN DISTINCT u.id as id";
 		final String structureQuery = "MATCH (c:Class {id:{classId}})-[:BELONGS]->(s:Structure) RETURN s.id as structureId";
-		neo4j.execute(structureQuery, new JsonObject().put("classId", classId), new Handler<Message<JsonObject>>() {
-			@Override
-			public void handle(Message<JsonObject> structRes) {
-				final JsonArray sr = structRes.body().getJsonArray("result");
-				final String structureId = ("ok".equals(structRes.body().getString("status")) && sr != null && sr.size() > 0)
-						? sr.getJsonObject(0).getString("structureId") : null;
-				final TransactionHelper tx = new TransactionHelper(neo4j, Source.MANUAL, transactionId);
-				tx.add(query, params);
-				if (structureId != null) {
-					org.entcore.common.schema.structures.Structure.attach(tx, userId, structureId);
-				}
-				final Handler<Message<JsonObject>> replyHandler = new Handler<Message<JsonObject>>() {
-					@Override
-					public void handle(Message<JsonObject> event) {
-						final JsonArray results = event.body().getJsonArray("results");
-						if ("ok".equals(event.body().getString("status")) && results != null && results.size() > 0) {
-							message.reply(event.body().put("result", results.getJsonArray(0)));
-						} else {
-							message.reply(event.body());
-						}
-					}
-				};
-				if (Boolean.TRUE.equals(commit)) {
-					tx.commit(replyHandler);
+		neo4j.execute(structureQuery, new JsonObject().put("classId", classId), structRes -> {
+			final JsonArray sr = structRes.body().getJsonArray("result");
+			final String structureId = ("ok".equals(structRes.body().getString("status")) && sr != null && sr.size() > 0)
+					? sr.getJsonObject(0).getString("structureId") : null;
+			final TransactionHelper tx = new TransactionHelper(neo4j, Source.MANUAL, transactionId);
+			tx.add(query, params);
+			if (structureId != null) {
+				org.entcore.common.schema.structures.Structure.attach(tx, userId, structureId);
+			}
+			final Handler<Message<JsonObject>> replyHandler = event -> {
+				final JsonArray results = event.body().getJsonArray("results");
+				if ("ok".equals(event.body().getString("status")) && results != null && results.size() > 0) {
+					message.reply(event.body().put("result", results.getJsonArray(0)));
 				} else {
-					tx.flush(replyHandler);
+					message.reply(event.body());
 				}
+			};
+			if (Boolean.TRUE.equals(commit)) {
+				tx.commit(replyHandler);
+			} else {
+				tx.flush(replyHandler);
 			}
 		});
 	}
@@ -749,39 +734,31 @@ public class ManualFeeder extends BusModBase {
 	private void addUsersInClass(final Message<JsonObject> message,
 								JsonArray userIds, String classId) {
 		final String structureQuery = "MATCH (c:Class {id:{classId}})-[:BELONGS]->(s:Structure) RETURN s.id as structureId";
-		neo4j.execute(structureQuery, new JsonObject().put("classId", classId), new Handler<Message<JsonObject>>() {
-			@Override
-			public void handle(Message<JsonObject> structRes) {
-				final JsonArray sr = structRes.body().getJsonArray("result");
-				final String structureId = ("ok".equals(structRes.body().getString("status")) && sr != null && sr.size() > 0)
-						? sr.getJsonObject(0).getString("structureId") : null;
-				final TransactionHelper tx = new TransactionHelper(neo4j, Source.MANUAL);
-				for (Object userId : userIds.getList()) {
-					String uid = userId.toString();
-					JsonObject params = new JsonObject()
-							.put("classId", classId)
-							.put("userId", uid);
-					String query =
-							"MATCH (u:User { id : {userId}})-[:IN]->(opg:ProfileGroup)-[:HAS_PROFILE]->(p:Profile) " +
-									"WITH u, p " +
-									"MATCH (s:Class { id : {classId}})<-[:DEPENDS]-(cpg:ProfileGroup)-[:DEPENDS]->" +
-									"(pg:ProfileGroup)-[:HAS_PROFILE]->(p) " +
-									"MERGE cpg<-[:IN {source:'MANUAL'}]-u " +
-									"SET u.classes = CASE WHEN s.externalId IN u.classes THEN " +
-									"u.classes ELSE coalesce(u.classes, []) + s.externalId END " +
-									"RETURN DISTINCT u.id as id";
-					tx.add(query, params);
-					if (structureId != null) {
-						org.entcore.common.schema.structures.Structure.attach(tx, uid, structureId);
-					}
+		neo4j.execute(structureQuery, new JsonObject().put("classId", classId), structRes -> {
+			final JsonArray sr = structRes.body().getJsonArray("result");
+			final String structureId = ("ok".equals(structRes.body().getString("status")) && sr != null && sr.size() > 0)
+					? sr.getJsonObject(0).getString("structureId") : null;
+			final TransactionHelper tx = new TransactionHelper(neo4j, Source.MANUAL);
+			for (Object userId : userIds.getList()) {
+				String uid = userId.toString();
+				JsonObject params = new JsonObject()
+						.put("classId", classId)
+						.put("userId", uid);
+				String query =
+						"MATCH (u:User { id : {userId}})-[:IN]->(opg:ProfileGroup)-[:HAS_PROFILE]->(p:Profile) " +
+								"WITH u, p " +
+								"MATCH (s:Class { id : {classId}})<-[:DEPENDS]-(cpg:ProfileGroup)-[:DEPENDS]->" +
+								"(pg:ProfileGroup)-[:HAS_PROFILE]->(p) " +
+								"MERGE cpg<-[:IN {source:'MANUAL'}]-u " +
+								"SET u.classes = CASE WHEN s.externalId IN u.classes THEN " +
+								"u.classes ELSE coalesce(u.classes, []) + s.externalId END " +
+								"RETURN DISTINCT u.id as id";
+				tx.add(query, params);
+				if (structureId != null) {
+					org.entcore.common.schema.structures.Structure.attach(tx, uid, structureId);
 				}
-				tx.commit(new Handler<Message<JsonObject>>() {
-					@Override
-					public void handle(Message<JsonObject> res) {
-						message.reply(res.body());
-					}
-				});
 			}
+			tx.commit(res -> message.reply(res.body()));
 		});
 	}
 

--- a/feeder/src/main/java/org/entcore/feeder/ManualFeeder.java
+++ b/feeder/src/main/java/org/entcore/feeder/ManualFeeder.java
@@ -331,7 +331,7 @@ public class ManualFeeder extends BusModBase {
 			JsonArray classesNames, JsonArray userPositionIds) {
 		final Integer transactionId = message.body().getInteger("transactionId");
 		final Boolean commit = message.body().getBoolean("commit", true);
-		StatementsBuilder statementsBuilder = new StatementsBuilder();
+		final TransactionHelper tx = new TransactionHelper(neo4j, Source.MANUAL, transactionId);
 		String related = "";
 		JsonObject params = new JsonObject()
 				.put("structureId", structureId)
@@ -349,11 +349,12 @@ public class ManualFeeder extends BusModBase {
 		String query =
 				"MATCH (s:Structure { id : {structureId}})<-[:DEPENDS]-" +
 				"(pg:ProfileGroup)-[:HAS_PROFILE]->(p:Profile { name : {profile}}) " +
-				"CREATE UNIQUE pg<-[:IN]-(u:User {props}) " +
-				"SET u.structures = [s.externalId] " +
+				"CREATE (u:User {props}) " +
 				related +
 				"RETURN DISTINCT u.id as id, u.login AS login";
-		statementsBuilder.add(query, params);
+		tx.add(query, params);
+		new org.entcore.common.schema.users.User(user.getString("id")).attach(tx,
+		        new Id<org.entcore.common.schema.structures.Structure, String>(structureId));
 		if (classesNames != null && !classesNames.isEmpty()) {
 			final String classesQuery =
 					"MATCH (s:Structure {id:{structureId}})<-[:BELONGS]-(c:Class)<-[:DEPENDS]-(cpg:ProfileGroup {filter: {profile}}), " +
@@ -366,7 +367,7 @@ public class ManualFeeder extends BusModBase {
 					.put("userId", user.getString("id"))
 					.put("classesNames", classesNames)
 					.put("source", user.getString("source"));
-			statementsBuilder.add(classesQuery, classesParams);
+			tx.add(classesQuery, classesParams);
 		}
 		final Promise<Void> promise = Promise.promise();
 		if (userPositionIds == null) {
@@ -377,13 +378,13 @@ public class ManualFeeder extends BusModBase {
 				user.getString("id"),
 				message.body().getString("callerId"))
 			.onSuccess(queryAndParams -> {
-				statementsBuilder.add(queryAndParams.getQuery(), queryAndParams.getParams());
+				tx.add(queryAndParams.getQuery(), queryAndParams.getParams());
 				promise.complete();
 			})
 			.onFailure(promise::fail);
 		}
 		promise.future().onSuccess(e -> {
-			neo4j.executeTransaction(statementsBuilder.build(), transactionId, commit, new Handler<Message<JsonObject>>() {
+			final Handler<Message<JsonObject>> replyHandler = new Handler<Message<JsonObject>>() {
 				@Override
 				public void handle(Message<JsonObject> event) {
 					final JsonArray results = event.body().getJsonArray("results");
@@ -397,7 +398,12 @@ public class ManualFeeder extends BusModBase {
 						message.reply(event.body());
 					}
 				}
-			});
+			};
+			if (Boolean.TRUE.equals(commit)) {
+				tx.commit(replyHandler);
+			} else {
+				tx.flush(replyHandler);
+			}
 		}).onFailure(th -> {
 			logger.warn("An error occurred when trying to create user positions update metho", th);
 			message.reply("Unknown error");
@@ -617,7 +623,6 @@ public class ManualFeeder extends BusModBase {
 		final Boolean commit = message.body().getBoolean("commit", true);
 		// Retrieve user position ids and remove them from user properties before creating user node
 		final JsonArray userPositionIds = (JsonArray) user.remove("userPositionIds");
-		StatementsBuilder statementsBuilder = new StatementsBuilder();
 		String related = "";
 		JsonObject params = new JsonObject()
 				.put("classId", classId)
@@ -635,77 +640,109 @@ public class ManualFeeder extends BusModBase {
 		String query =
 				"MATCH (s:Class { id : {classId}})<-[:DEPENDS]-(cpg:ProfileGroup)-[:DEPENDS]->" +
 				"(pg:ProfileGroup)-[:HAS_PROFILE]->(p:Profile { name : {profile}}), s-[:BELONGS]->(struct:Structure) " +
-				"CREATE UNIQUE pg<-[:IN]-(u:User {props}), cpg<-[:IN]-u " +
-				"SET u.classes = [s.externalId], u.structures = [struct.externalId] " +
+				"CREATE (u:User {props}), cpg<-[:IN]-u " +
+				"SET u.classes = [s.externalId] " +
 				related +
 				"RETURN DISTINCT u.id as id, u.login AS login";
-		statementsBuilder.add(query, params);
-		final Promise<Void> promise = Promise.promise();
-		if(userPositionIds == null) {
-			promise.complete();
-		} else {
-			userPositionService.getUserPositionSettingQueryAndParam(
-				userPositionIds.stream().map(id -> (String) id).collect(Collectors.toSet()),
-				user.getString("id"),
-				message.body().getString("callerId"))
-			.onSuccess(queryAndParams -> {
-				statementsBuilder.add(queryAndParams.getQuery(), queryAndParams.getParams());
-				promise.complete();
-			}).onFailure(promise::fail);
-		}
-		promise.future().onSuccess(e -> {
-			neo4j.executeTransaction(statementsBuilder.build(), transactionId, commit.booleanValue(), new Handler<Message<JsonObject>>() {
-				@Override
-				public void handle(Message<JsonObject> event) {
-					final JsonArray results = event.body().getJsonArray("results");
-					if ("ok".equals(event.body().getString("status")) && results != null && results.size() > 0) {
-						message.reply(event.body().put("result", results.getJsonArray(0)));
-						if (commit) {
-							eventStore.createAndStoreEvent(Feeder.FeederEvent.CREATE_USER.name(),
-								(UserInfos) null, new JsonObject().put("new-user", user.getString("id")));
-						}
-					} else {
-						message.reply(event.body());
-					}
+		final String structureQuery = "MATCH (c:Class {id:{classId}})-[:BELONGS]->(s:Structure) RETURN s.id as structureId";
+		neo4j.execute(structureQuery, new JsonObject().put("classId", classId), new Handler<Message<JsonObject>>() {
+			@Override
+			public void handle(Message<JsonObject> structRes) {
+				final JsonArray sr = structRes.body().getJsonArray("result");
+				final String structureId = ("ok".equals(structRes.body().getString("status")) && sr != null && sr.size() > 0)
+						? sr.getJsonObject(0).getString("structureId") : null;
+				final TransactionHelper tx = new TransactionHelper(neo4j, Source.MANUAL, transactionId);
+				tx.add(query, params);
+				if (structureId != null) {
+					new org.entcore.common.schema.users.User(user.getString("id")).attach(tx,
+							new Id<org.entcore.common.schema.structures.Structure, String>(structureId));
 				}
-			});
-			}).onFailure(th -> {
-				logger.warn("An error occurred while creating user position update query", th);
-				sendError(message, "Unknown error");
-			});
-
+				final Promise<Void> promise = Promise.promise();
+				if (userPositionIds == null) {
+					promise.complete();
+				} else {
+					userPositionService.getUserPositionSettingQueryAndParam(
+						userPositionIds.stream().map(id -> (String) id).collect(Collectors.toSet()),
+						user.getString("id"),
+						message.body().getString("callerId"))
+					.onSuccess(queryAndParams -> {
+						tx.add(queryAndParams.getQuery(), queryAndParams.getParams());
+						promise.complete();
+					}).onFailure(promise::fail);
+				}
+				promise.future().onSuccess(e -> {
+					final Handler<Message<JsonObject>> replyHandler = new Handler<Message<JsonObject>>() {
+						@Override
+						public void handle(Message<JsonObject> event) {
+							final JsonArray results = event.body().getJsonArray("results");
+							if ("ok".equals(event.body().getString("status")) && results != null && results.size() > 0) {
+								message.reply(event.body().put("result", results.getJsonArray(0)));
+								if (commit) {
+									eventStore.createAndStoreEvent(Feeder.FeederEvent.CREATE_USER.name(),
+										(UserInfos) null, new JsonObject().put("new-user", user.getString("id")));
+								}
+							} else {
+								message.reply(event.body());
+							}
+						}
+					};
+					if (Boolean.TRUE.equals(commit)) {
+						tx.commit(replyHandler);
+					} else {
+						tx.flush(replyHandler);
+					}
+				}).onFailure(th -> {
+					logger.warn("An error occurred while creating user position update query", th);
+					sendError(message, "Unknown error");
+				});
+			}
+		});
 	}
 
 	private void addUserInClass(final Message<JsonObject> message,
 								String userId, String classId) {
 		final Integer transactionId = message.body().getInteger("transactionId");
 		final Boolean commit = message.body().getBoolean("commit", true);
-		StatementsBuilder statementsBuilder = new StatementsBuilder();
-		JsonObject params = new JsonObject()
+		final JsonObject params = new JsonObject()
 				.put("classId", classId)
 				.put("userId", userId);
-		String query =
+		final String query =
 				"MATCH (u:User { id : {userId}})-[:IN]->(opg:ProfileGroup)-[:HAS_PROFILE]->(p:Profile) " +
 						"WITH u, p " +
 						"MATCH (s:Class { id : {classId}})<-[:DEPENDS]-(cpg:ProfileGroup)-[:DEPENDS]->" +
-						"(pg:ProfileGroup)-[:HAS_PROFILE]->p, s-[:BELONGS]->(struct:Structure) " +
-						"MERGE (pg)<-[inProfileGroup:IN]-(u) " +
+						"(pg:ProfileGroup)-[:HAS_PROFILE]->p " +
 						"CREATE UNIQUE (cpg)<-[:IN {source:'MANUAL'}]-(u) " +
 						"SET u.classes = CASE WHEN s.externalId IN u.classes THEN " +
-						"u.classes ELSE coalesce(u.classes, []) + s.externalId END, " +
-						"u.structures = CASE WHEN struct.externalId IN u.structures THEN " +
-						"u.structures ELSE coalesce(u.structures, []) + struct.externalId END, " +
-						"inProfileGroup.source = CASE WHEN inProfileGroup.source = 'MANUAL' THEN 'MANUAL' ELSE null END " +
+						"u.classes ELSE coalesce(u.classes, []) + s.externalId END " +
 						"RETURN DISTINCT u.id as id";
-		statementsBuilder.add(query, params);
-		neo4j.executeTransaction(statementsBuilder.build(), transactionId, commit.booleanValue(), new Handler<Message<JsonObject>>() {
+		final String structureQuery = "MATCH (c:Class {id:{classId}})-[:BELONGS]->(s:Structure) RETURN s.id as structureId";
+		neo4j.execute(structureQuery, new JsonObject().put("classId", classId), new Handler<Message<JsonObject>>() {
 			@Override
-			public void handle(Message<JsonObject> event) {
-				final JsonArray results = event.body().getJsonArray("results");
-				if ("ok".equals(event.body().getString("status")) && results != null && results.size() > 0) {
-					message.reply(event.body().put("result", results.getJsonArray(0)));
+			public void handle(Message<JsonObject> structRes) {
+				final JsonArray sr = structRes.body().getJsonArray("result");
+				final String structureId = ("ok".equals(structRes.body().getString("status")) && sr != null && sr.size() > 0)
+						? sr.getJsonObject(0).getString("structureId") : null;
+				final TransactionHelper tx = new TransactionHelper(neo4j, Source.MANUAL, transactionId);
+				tx.add(query, params);
+				if (structureId != null) {
+					new org.entcore.common.schema.users.User(userId).attach(tx,
+							new Id<org.entcore.common.schema.structures.Structure, String>(structureId));
+				}
+				final Handler<Message<JsonObject>> replyHandler = new Handler<Message<JsonObject>>() {
+					@Override
+					public void handle(Message<JsonObject> event) {
+						final JsonArray results = event.body().getJsonArray("results");
+						if ("ok".equals(event.body().getString("status")) && results != null && results.size() > 0) {
+							message.reply(event.body().put("result", results.getJsonArray(0)));
+						} else {
+							message.reply(event.body());
+						}
+					}
+				};
+				if (Boolean.TRUE.equals(commit)) {
+					tx.commit(replyHandler);
 				} else {
-					message.reply(event.body());
+					tx.flush(replyHandler);
 				}
 			}
 		});
@@ -713,27 +750,41 @@ public class ManualFeeder extends BusModBase {
 
 	private void addUsersInClass(final Message<JsonObject> message,
 								JsonArray userIds, String classId) {
-		StatementsBuilder statementsBuilder = new StatementsBuilder();
-		for(Object userId : userIds.getList()) {
-			JsonObject params = new JsonObject()
-					.put("classId", classId)
-					.put("userId", userId);
-			String query =
-					"MATCH (u:User { id : {userId}})-[:IN]->(opg:ProfileGroup)-[:HAS_PROFILE]->(p:Profile) " +
-							"WITH u, p " +
-							"MATCH (s:Class { id : {classId}})<-[:DEPENDS]-(cpg:ProfileGroup)-[:DEPENDS]->" +
-							"(pg:ProfileGroup)-[:HAS_PROFILE]->(p), (s)-[:BELONGS]->(struct:Structure) " +
-							"MERGE pg<-[:IN {source:'MANUAL'}]-u " +
-							"MERGE cpg<-[:IN {source:'MANUAL'}]-u " +
-							"SET u.classes = CASE WHEN s.externalId IN u.classes THEN " +
-							"u.classes ELSE coalesce(u.classes, []) + s.externalId END, " +
-							"u.structures = CASE WHEN struct.externalId IN u.structures THEN " +
-							"u.structures ELSE coalesce(u.structures, []) + struct.externalId END " +
-							"RETURN DISTINCT u.id as id";
-			statementsBuilder.add(query, params);
-		}
-		neo4j.executeTransaction(statementsBuilder.build(), null,true, res-> {
-				message.reply(res.body());
+		final String structureQuery = "MATCH (c:Class {id:{classId}})-[:BELONGS]->(s:Structure) RETURN s.id as structureId";
+		neo4j.execute(structureQuery, new JsonObject().put("classId", classId), new Handler<Message<JsonObject>>() {
+			@Override
+			public void handle(Message<JsonObject> structRes) {
+				final JsonArray sr = structRes.body().getJsonArray("result");
+				final String structureId = ("ok".equals(structRes.body().getString("status")) && sr != null && sr.size() > 0)
+						? sr.getJsonObject(0).getString("structureId") : null;
+				final TransactionHelper tx = new TransactionHelper(neo4j, Source.MANUAL);
+				for (Object userId : userIds.getList()) {
+					String uid = userId.toString();
+					JsonObject params = new JsonObject()
+							.put("classId", classId)
+							.put("userId", uid);
+					String query =
+							"MATCH (u:User { id : {userId}})-[:IN]->(opg:ProfileGroup)-[:HAS_PROFILE]->(p:Profile) " +
+									"WITH u, p " +
+									"MATCH (s:Class { id : {classId}})<-[:DEPENDS]-(cpg:ProfileGroup)-[:DEPENDS]->" +
+									"(pg:ProfileGroup)-[:HAS_PROFILE]->(p) " +
+									"MERGE cpg<-[:IN {source:'MANUAL'}]-u " +
+									"SET u.classes = CASE WHEN s.externalId IN u.classes THEN " +
+									"u.classes ELSE coalesce(u.classes, []) + s.externalId END " +
+									"RETURN DISTINCT u.id as id";
+					tx.add(query, params);
+					if (structureId != null) {
+						new org.entcore.common.schema.users.User(uid).attach(tx,
+								new Id<org.entcore.common.schema.structures.Structure, String>(structureId));
+					}
+				}
+				tx.commit(new Handler<Message<JsonObject>>() {
+					@Override
+					public void handle(Message<JsonObject> res) {
+						message.reply(res.body());
+					}
+				});
+			}
 		});
 	}
 


### PR DESCRIPTION
# Description

Modification de `createUserInStructure`, `createUserInClass` et `addUserInClass` pour qu'ils passent par `attach`.
La copie des PS se fait dans cette dernière méthode (cf. `edifice-entcore-libs`).

## Fixes

[#IMPULS-6018](https://edifice-community.atlassian.net/browse/IMPULS-6018)

## Type of change

Please check options that are relevant.

- [x] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [x] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: