### PR TITLE
feat(admin): #IMPULS-5903 add Screeb integration

### DIFF
--- a/admin/src/main/resources/template.j2
+++ b/admin/src/main/resources/template.j2
@@ -15,11 +15,15 @@
       "org.entcore.common.http.health.RedisProbe"
     ],
     "mass-messaging-enabled": {{ adminMassMessagingEnabled | default('false') }},
-    {% if hotjarId is defined %}
-      "publicConf": {
-        "hotjarId": {{ hotjarId }}
-      },
-    {% endif %}
+    "publicConf": {
+      {% if hotjarId is defined %}
+        "hotjarId": {{ hotjarId }},
+      {% endif %}
+      {% if adminScreebAllowedProfiles is defined %}
+        "screeb-allowed-profiles": {{ adminScreebAllowedProfiles }},
+      {% endif %}
+      "screeb-app-id": "{{ screebAppId | default('') }}"
+    },
     {% if adminDistributions is defined %}
       "distributions": {{ adminDistributions }},
     {% endif %}

--- a/admin/src/main/ts/package.json
+++ b/admin/src/main/ts/package.json
@@ -25,6 +25,8 @@
     "@angular/platform-browser": "^14.1.1",
     "@angular/platform-browser-dynamic": "^14.1.1",
     "@angular/router": "^14.1.1",
+    "@screeb/sdk-angular": "0.7.0",
+    "@screeb/sdk-browser": "0.7.0",
     "axios": "^0.19.0",
     "chardet": "^1.4.0",
     "dayjs": "^1.11.13",

--- a/admin/src/main/ts/proxy-development.conf.js
+++ b/admin/src/main/ts/proxy-development.conf.js
@@ -57,7 +57,22 @@ const parseEnvFile = (content) => {
 
 if (fs.existsSync("./.env")) {
   const env = parseEnvFile(fs.readFileSync("./.env", "utf-8"));
-  const {VITE_RECETTE, VITE_XSRF_TOKEN, VITE_ONE_SESSION_ID} = env;
+  const {VITE_RECETTE, VITE_XSRF_TOKEN, VITE_ONE_SESSION_ID, SCREEB_APP_ID_DEV} = env;
+
+  // Dev-only mock: the platform won't serve the Screeb key on /admin/conf/public
+  // until the backend template.j2 change is deployed. Set SCREEB_APP_ID_DEV in
+  // .env to test the Screeb integration locally.
+  if (SCREEB_APP_ID_DEV) {
+    console.log("Mocking /admin/conf/public with SCREEB_APP_ID_DEV");
+    PROXY_CONFIG.bypass = (req, res) => {
+      if (req.url && req.url.split("?")[0] === "/admin/conf/public") {
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ "screeb-app-id": SCREEB_APP_ID_DEV }));
+        return true; // response already sent, skip proxying
+      }
+      return null; // proxy normally
+    };
+  }
   if (VITE_RECETTE) {
     console.log("Using remote proxy configuration target: ", VITE_RECETTE);
     PROXY_CONFIG.target = VITE_RECETTE;

--- a/admin/src/main/ts/proxy-development.conf.js
+++ b/admin/src/main/ts/proxy-development.conf.js
@@ -57,22 +57,10 @@ const parseEnvFile = (content) => {
 
 if (fs.existsSync("./.env")) {
   const env = parseEnvFile(fs.readFileSync("./.env", "utf-8"));
-  const {VITE_RECETTE, VITE_XSRF_TOKEN, VITE_ONE_SESSION_ID, SCREEB_APP_ID_DEV} = env;
 
-  // Dev-only mock: the platform won't serve the Screeb key on /admin/conf/public
-  // until the backend template.j2 change is deployed. Set SCREEB_APP_ID_DEV in
-  // .env to test the Screeb integration locally.
-  if (SCREEB_APP_ID_DEV) {
-    console.log("Mocking /admin/conf/public with SCREEB_APP_ID_DEV");
-    PROXY_CONFIG.bypass = (req, res) => {
-      if (req.url && req.url.split("?")[0] === "/admin/conf/public") {
-        res.setHeader("Content-Type", "application/json");
-        res.end(JSON.stringify({ "screeb-app-id": SCREEB_APP_ID_DEV }));
-        return true; // response already sent, skip proxying
-      }
-      return null; // proxy normally
-    };
-  }
+  const {VITE_RECETTE, VITE_XSRF_TOKEN, VITE_ONE_SESSION_ID} = env;
+
+  // If VITE_RECETTE is set, we override the target of the proxy configuration to point to the remote server.
   if (VITE_RECETTE) {
     console.log("Using remote proxy configuration target: ", VITE_RECETTE);
     PROXY_CONFIG.target = VITE_RECETTE;
@@ -88,6 +76,22 @@ if (fs.existsSync("./.env")) {
         ];
       };
     }
+  }
+
+  // Dev-only mock: the platform won't serve the Screeb key on /admin/conf/public
+  // until the backend template.j2 change is deployed. Set SCREEB_APP_ID_DEV in
+  // .env to test the Screeb integration locally.
+  const {SCREEB_APP_ID_DEV} = env;
+  if (SCREEB_APP_ID_DEV) {
+    console.log("Mocking /admin/conf/public with SCREEB_APP_ID_DEV");
+    PROXY_CONFIG.bypass = (req, res) => {
+      if (req.url?.split("?")[0] === "/admin/conf/public") {
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ "screeb-app-id": SCREEB_APP_ID_DEV }));
+        return true; // response already sent, skip proxying
+      }
+      return null; // proxy normally
+    };
   }
 }
 

--- a/admin/src/main/ts/src/app/app-root.component.ts
+++ b/admin/src/main/ts/src/app/app-root.component.ts
@@ -1,6 +1,7 @@
 import { Component, Injector } from '@angular/core';
 import { Data } from '@angular/router';
 import { OdeComponent } from 'ngx-ode-core';
+import { ScreebService } from './core/services/screeb.service';
 import { globalStore } from './core/store/global.store';
 import { SessionModel } from './core/store/models/session.model';
 import { StructureModel } from './core/store/models/structure.model';
@@ -50,8 +51,8 @@ export class AppRootComponent extends OdeComponent {
     public enableMassMessaging: boolean;
     private hasSubscribeChildRoute: boolean = false;
 
-    constructor(injector: Injector) {
-        super(injector);  
+    constructor(injector: Injector, private screebService: ScreebService) {
+        super(injector);
     }
 
     async ngOnInit() {
@@ -95,6 +96,10 @@ export class AppRootComponent extends OdeComponent {
         }
         // Add Zendesk Guide Widget
         this.addZendeskGuideWedget(session);
+        // Initialize Screeb (user feedback tool), enabled per platform via publicConf
+        this.screebService.initFromPlatformConf(session).catch(err => {
+            console.error('Failed to initialize Screeb:', err);
+        });
     }
     public onSelectStructure(structure: StructureModel) {
         this.router.navigateByUrl(this.getNewPath(structure.id));

--- a/admin/src/main/ts/src/app/app-root.component.ts
+++ b/admin/src/main/ts/src/app/app-root.component.ts
@@ -1,13 +1,13 @@
+import { JsonObject } from '@angular/compiler-cli/ngcc/src/utils';
 import { Component, Injector } from '@angular/core';
 import { Data } from '@angular/router';
+import http from 'axios';
 import { OdeComponent } from 'ngx-ode-core';
 import { ScreebService } from './core/services/screeb.service';
 import { globalStore } from './core/store/global.store';
+import { Session } from './core/store/mappings/session';
 import { SessionModel } from './core/store/models/session.model';
 import { StructureModel } from './core/store/models/structure.model';
-import http from 'axios';
-import {JsonObject} from '@angular/compiler-cli/ngcc/src/utils';
-import { Session } from './core/store/mappings/session';
 
 
 @Component({
@@ -51,7 +51,7 @@ export class AppRootComponent extends OdeComponent {
     public enableMassMessaging: boolean;
     private hasSubscribeChildRoute: boolean = false;
 
-    constructor(injector: Injector, private screebService: ScreebService) {
+    constructor(injector: Injector, private readonly screebService: ScreebService) {
         super(injector);
     }
 

--- a/admin/src/main/ts/src/app/app.module.ts
+++ b/admin/src/main/ts/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import {AppRoutingModule} from './app-routing.module';
 import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
+import {ScreebModule} from '@screeb/sdk-angular';
 import {NgxOdeSijilModule} from 'ngx-ode-sijil';
 
 import {CoreModule} from './core/core.module';
@@ -38,7 +39,14 @@ registerLocaleData(localePt);
             provide: LabelsService,
             useExisting: SijilLabelsService
         }),
-        BrowserAnimationsModule
+        BrowserAnimationsModule,
+        // Screeb is loaded and initialized manually (see ScreebService): the app id is
+        // only known at runtime, from the platform publicConf, and no script must be
+        // loaded at all when Screeb is not enabled for the platform.
+        ScreebModule.forRoot({
+            autoInit: false,
+            shouldLoad: false
+        })
     ],
     declarations: [
         AppComponent,

--- a/admin/src/main/ts/src/app/core/core.module.ts
+++ b/admin/src/main/ts/src/app/core/core.module.ts
@@ -11,6 +11,7 @@ import { I18nResolver } from './resolvers/i18n.resolver';
 import { SessionResolver } from './resolvers/session.resolver';
 import { StructuresResolver } from './resolvers/structures.resolver';
 import { NotifyService } from './services/notify.service';
+import { ScreebService } from './services/screeb.service';
 import { SijilLabelsService } from './services/sijil.labels.service';
 import { TimezoneService } from './services/timezone.service';
 import { UserPositionService } from './services/user-position.service';
@@ -40,7 +41,8 @@ import { WidgetService } from './services/widgets.service';
         UserService,
         UserPositionService,
         TimezoneService,
-        FavIconResolver
+        FavIconResolver,
+        ScreebService
     ],
 })
 export class CoreModule {

--- a/admin/src/main/ts/src/app/core/services/screeb.service.ts
+++ b/admin/src/main/ts/src/app/core/services/screeb.service.ts
@@ -1,0 +1,92 @@
+import { Injectable } from '@angular/core';
+import { Screeb } from '@screeb/sdk-angular';
+import {
+    HooksMessageStart,
+    HooksSurveyStart,
+    PropertyRecord,
+} from '@screeb/sdk-browser';
+import http from 'axios';
+import { Session } from '../store/mappings/session';
+
+type ScreebPublicConf = {
+    'screeb-app-id'?: string;
+    'screeb-allowed-profiles'?: string[];
+};
+
+/**
+ * Bridge to the Screeb SDK (user feedback and surveys).
+ * Never call the Screeb SDK directly from components: always go through this service.
+ *
+ * Screeb is enabled per platform via the `screeb-app-id` key of the admin
+ * module `publicConf` (served by GET /admin/conf/public). When the key is
+ * absent or empty, no Screeb script is loaded and no network call is made.
+ */
+@Injectable()
+export class ScreebService {
+
+    constructor(private screeb: Screeb) {
+    }
+
+    /**
+     * Reads the platform configuration and initializes Screeb when enabled
+     * for this platform and allowed for the user's profile.
+     */
+    public async initFromPlatformConf(session: Session): Promise<void> {
+        const conf = (await http.get<ScreebPublicConf>('/admin/conf/public')).data;
+        const appId = conf && conf['screeb-app-id'];
+        if (!appId) {
+            return;
+        }
+        const allowedProfiles = conf['screeb-allowed-profiles'];
+        if (allowedProfiles && allowedProfiles.length > 0 && allowedProfiles.indexOf(session.type) === -1) {
+            return;
+        }
+        await this.init(appId, session);
+    }
+
+    /**
+     * Loads the Screeb tag and identifies the user in a single init call
+     * (no anonymous entry created). The user identifier sent to Screeb is
+     * hashed: the real userId is never transmitted.
+     */
+    public async init(appId: string, session: Session): Promise<void> {
+        await this.screeb.load();
+        const hashedId = await this.hashUserId(session.userId);
+        await this.screeb.init(appId, hashedId, {profile: session.type});
+    }
+
+    public trackEvent(name: string, properties?: PropertyRecord): void {
+        this.screeb.eventTrack(name, properties);
+    }
+
+    public triggerSurvey(surveyId: string, hooks?: HooksSurveyStart, hiddenFields?: PropertyRecord): void {
+        // distributionId and allowMultipleResponses are wrongly declared as required by the Angular SDK:
+        // the underlying browser SDK treats them as optional.
+        this.screeb.surveyStart(surveyId, undefined as unknown as string, undefined as unknown as boolean, hiddenFields, hooks);
+    }
+
+    public triggerMessage(messageId: string, hooks?: HooksMessageStart): void {
+        this.screeb.messageStart(messageId, undefined, undefined, hooks);
+    }
+
+    public closeSurvey(): void {
+        this.screeb.surveyClose();
+    }
+
+    public setIdentityProperties(properties: PropertyRecord): void {
+        this.screeb.identityProperties(properties);
+    }
+
+    public reset(): void {
+        this.screeb.identityReset();
+    }
+
+    /** SHA-256 hash truncated to 16 hexadecimal characters (privacy rule shared with the React apps). */
+    private async hashUserId(userId: string): Promise<string> {
+        const hashBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(userId));
+        return Array.from(new Uint8Array(hashBuffer))
+            .map(b => b.toString(16).padStart(2, '0'))
+            .join('')
+            .slice(0, 16);
+    }
+}

--- a/admin/src/main/ts/src/app/core/services/screeb.service.ts
+++ b/admin/src/main/ts/src/app/core/services/screeb.service.ts
@@ -1,10 +1,5 @@
 import { Injectable } from '@angular/core';
 import { Screeb } from '@screeb/sdk-angular';
-import {
-    HooksMessageStart,
-    HooksSurveyStart,
-    PropertyRecord,
-} from '@screeb/sdk-browser';
 import http from 'axios';
 import { Session } from '../store/mappings/session';
 
@@ -19,7 +14,7 @@ type ScreebPublicConf = {
  *
  * Screeb is enabled per platform via the `screeb-app-id` key of the admin
  * module `publicConf` (served by GET /admin/conf/public). When the key is
- * absent or empty, no Screeb script is loaded and no network call is made.
+ * absent or empty, no Screeb script is loaded and no network call is made to Screeb.
  */
 @Injectable()
 export class ScreebService {
@@ -33,12 +28,12 @@ export class ScreebService {
      */
     public async initFromPlatformConf(session: Session): Promise<void> {
         const conf = (await http.get<ScreebPublicConf>('/admin/conf/public')).data;
-        const appId = conf && conf['screeb-app-id'];
+        const appId = conf?.['screeb-app-id'];
         if (!appId) {
             return;
         }
         const allowedProfiles = conf['screeb-allowed-profiles'];
-        if (allowedProfiles && allowedProfiles.length > 0 && allowedProfiles.indexOf(session.type) === -1) {
+        if (allowedProfiles && allowedProfiles.length > 0 && !allowedProfiles.includes(session.type)) {
             return;
         }
         await this.init(appId, session);
@@ -53,32 +48,6 @@ export class ScreebService {
         await this.screeb.load();
         const hashedId = await this.hashUserId(session.userId);
         await this.screeb.init(appId, hashedId, {profile: session.type});
-    }
-
-    public trackEvent(name: string, properties?: PropertyRecord): void {
-        this.screeb.eventTrack(name, properties);
-    }
-
-    public triggerSurvey(surveyId: string, hooks?: HooksSurveyStart, hiddenFields?: PropertyRecord): void {
-        // distributionId and allowMultipleResponses are wrongly declared as required by the Angular SDK:
-        // the underlying browser SDK treats them as optional.
-        this.screeb.surveyStart(surveyId, undefined as unknown as string, undefined as unknown as boolean, hiddenFields, hooks);
-    }
-
-    public triggerMessage(messageId: string, hooks?: HooksMessageStart): void {
-        this.screeb.messageStart(messageId, undefined, undefined, hooks);
-    }
-
-    public closeSurvey(): void {
-        this.screeb.surveyClose();
-    }
-
-    public setIdentityProperties(properties: PropertyRecord): void {
-        this.screeb.identityProperties(properties);
-    }
-
-    public reset(): void {
-        this.screeb.identityReset();
     }
 
     /** SHA-256 hash truncated to 16 hexadecimal characters (privacy rule shared with the React apps). */


### PR DESCRIPTION
# Description

Intègre le SDK Screeb (outil de feedback/enquêtes utilisateurs) dans le module admin (Angular 14), sur le même modèle que l'intégration déjà en place côté conversation.

- Ajout de `@screeb/sdk-angular` et `@screeb/sdk-browser` (0.7.0) au module admin.
- `ScreebModule` chargé avec `autoInit: false, shouldLoad: false` : aucun script Screeb n'est chargé au bootstrap. Le `ScreebService` pilote manuellement `load()`/`init()` une fois la conf de la plateforme connue.
- Activation par plateforme via `publicConf` (`screeb-app-id`, `screeb-allowed-profiles` optionnel) exposée par `GET /admin/conf/public`, ajoutée dans `template.j2`.
- Identité envoyée à Screeb = SHA-256(userId) tronqué à 16 caractères hexadécimaux (règle de confidentialité commune aux intégrations Screeb Edifice) — aucun identifiant réel transmis.
- Mock de dev dans `proxy-development.conf.js` (clé `SCREEB_APP_ID_DEV` du `.env`) : la recette ne servira la clé sur `/admin/conf/public` qu'une fois ce `template.j2` déployé.

## Fixes

[IMPULS-5903](https://edifice-community.atlassian.net/browse/IMPULS-5903)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [x] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Renseigner `SCREEB_APP_ID_DEV` dans `admin/src/main/ts/.env`, lancer `ng serve` avec le proxy de développement.
2. Vérifier dans les DevTools que le tag Screeb ne se charge que lorsque `screeb-app-id` est présent dans la réponse mockée de `/admin/conf/public`.
3. Vérifier qu'aucun appel réseau vers Screeb n'a lieu quand la clé est absente/vide.
4. Vérifier, si `screeb-allowed-profiles` est renseigné, que l'init est bien filtrée selon le profil de session.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley:

[IMPULS-5903]: https://edifice-community.atlassian.net/browse/IMPULS-5903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ