### PR TITLE
fix(admin): #IMPULS-6050 profils fédérés dynamiques dans l'info publipostage

### DIFF
--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -860,7 +860,7 @@
   "massmail.filename": "publipostage_pdf",
   "massmail.filters": "Filtrer la liste à publiposter",
   "massmail.firstsort": "Par",
-  "massmail.info.authMode": "Dans votre établissement, certains comptes sont paramétrés pour passer par une authentification externe à l'ENT (par exemple : ÉduConnect, Arena, LiÀ, FranceConnect…). Les utilisateurs concernés ne figureront pas dans la liste ci-dessous car il n’est pas prévu que vous leur donniez un identifiant/mot de passe ENT pour se connecter. Les utilisateurs concernés sont les comptes chargés automatiquements (AAF, csv) pour les profils suivant : {{profiles}}.",
+  "massmail.info.authMode": "Dans votre établissement, certains comptes sont paramétrés pour passer par une authentification externe à l'ENT (par exemple : ÉduConnect, Arena, LiÀ, FranceConnect…). Les utilisateurs concernés ne figureront pas dans la liste ci-dessous car il n’est pas prévu que vous leur donniez un identifiant/mot de passe ENT pour se connecter. Les utilisateurs concernés sont les comptes chargés automatiquement (AAF, csv) pour les profils suivants : {{profiles}}.",
   "massmail.link.user": "Accéder à la fiche utilisateur",
   "massmail.mail": "Envoyer par mail",
   "massmail.mail.done": "Publipostage mail effectué ",

--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -860,7 +860,7 @@
   "massmail.filename": "publipostage_pdf",
   "massmail.filters": "Filtrer la liste à publiposter",
   "massmail.firstsort": "Par",
-  "massmail.info.authMode": "Dans votre établissement, certains comptes sont paramétrés pour passer par une authentification externe à l'ENT (par exemple : ÉduConnect, Arena, LiÀ, FranceConnect…). Les utilisateurs concernés ne figureront pas dans la liste ci-dessous car il n’est pas prévu que vous leur donniez un identifiant/mot de passe ENT pour se connecter. Les utilisateurs concernés sont les comptes chargés automatiquements (AAF, csv) pour les profils suivant : Parents, Enseignants.",
+  "massmail.info.authMode": "Dans votre établissement, certains comptes sont paramétrés pour passer par une authentification externe à l'ENT (par exemple : ÉduConnect, Arena, LiÀ, FranceConnect…). Les utilisateurs concernés ne figureront pas dans la liste ci-dessous car il n’est pas prévu que vous leur donniez un identifiant/mot de passe ENT pour se connecter. Les utilisateurs concernés sont les comptes chargés automatiquements (AAF, csv) pour les profils suivant : {{profiles}}.",
   "massmail.link.user": "Accéder à la fiche utilisateur",
   "massmail.mail": "Envoyer par mail",
   "massmail.mail.done": "Publipostage mail effectué ",

--- a/admin/src/main/ts/src/app/imports-exports/mailing/mass-mail/mass-mail.component.html
+++ b/admin/src/main/ts/src/app/imports-exports/mailing/mass-mail/mass-mail.component.html
@@ -7,7 +7,7 @@
       <use [attr.href]="'/admin/public/icons/icons.svg#alert-triangle'"></use>
     </svg>
     <div class="flash-content">
-      <p><s5l>massmail.info.authMode</s5l></p>
+      <p><s5l [s5l-params]="{profiles: federatedProfilesLabel}">massmail.info.authMode</s5l></p>
     </div>
   
   </div>

--- a/admin/src/main/ts/src/app/imports-exports/mailing/mass-mail/mass-mail.component.ts
+++ b/admin/src/main/ts/src/app/imports-exports/mailing/mass-mail/mass-mail.component.ts
@@ -8,6 +8,7 @@ import { UserModel } from 'src/app/core/store/models/user.model';
 import { NotifyService } from '../../../core/services/notify.service';
 import { routing } from '../../../core/services/routing.service';
 import { UserlistFiltersService } from '../../../core/services/userlist.filters.service';
+import { Profile } from '../../import/user.model';
 import { MassMailService } from '../mass-mail.service';
 
 @Component({
@@ -31,6 +32,7 @@ export class MassMailComponent extends OdeComponent implements OnInit, OnDestroy
     countUsers = 0;
     countUsersWithoutMail = 0;
     countUsersInactiveAndFederated = 0;
+    federatedProfilesLabel = '';
     userOrder: string;
     structureId: string;
     show = false;
@@ -70,13 +72,17 @@ export class MassMailComponent extends OdeComponent implements OnInit, OnDestroy
         this.subscriptions.add(routing.observe(this.route, 'data').subscribe(async (data: Data) => {
             if (data.structure) {
                 const structure: StructureModel = data.structure;
-                this.spinner.perform('portal-content', MassMailService.getUsers(structure._id)
-                    .then((data) => {
-                        this.users = data;
+                this.spinner.perform('portal-content', Promise.all([
+                        MassMailService.getUsers(structure._id),
+                        structure.syncAuthMode()
+                    ])
+                    .then(([users]) => {
+                        this.users = users;
                         this.structureId = structure._id;
                         this.dateFormat = Intl.DateTimeFormat(this.bundles.currentLanguage);
                         this.initFilters(structure);
                         this.filters = this.userlistFiltersService.getFormattedFilters();
+                        this.federatedProfilesLabel = this.getFederatedProfilesLabel(structure);
                         this.getFilteredUsers();
                         this.changeDetector.detectChanges();
                     }).catch(err => {
@@ -91,6 +97,14 @@ export class MassMailComponent extends OdeComponent implements OnInit, OnDestroy
                 this.changeDetector.markForCheck();
             }
         }));
+    }
+
+    private getFederatedProfilesLabel(structure: StructureModel): string {
+        const authModes = structure.getAuthConfig().defaultAuthModes;
+        return (Object.keys(authModes) as Profile[])
+            .filter(profile => authModes[profile] === 'FEDERATED')
+            .map(profile => this.translate(profile))
+            .join(', ');
     }
 
     private initFilters(structure: StructureModel): void {


### PR DESCRIPTION
# Description

Le message d'information affiché dans le publipostage (mass-mail) indiquait toujours "Parents, Enseignants" comme profils exclus car fédérés, alors que la liste réelle dépend de la configuration d'authentification (`authModes`) propre à chaque établissement (cf. `auth-mode.component.ts` / `structure.getAuthConfig()`).

Cette PR calcule dynamiquement, pour l'établissement courant, la liste des profils configurés en mode `FEDERATED` et l'injecte dans le message traduit via `s5l-params`, au lieu du texte codé en dur dans `fr.json`.

## Fixes

IMPULS-6050

## Type of change

- [x] Bug fix (PATCH)

## Which packages changed?

- [x] admin

## Tests

1. Se connecter en ADMC/ADML sur un établissement recette dont au moins un profil (ex. Enseignant) est configuré en mode d'authentification fédéré (page "Mode d'authentification" de l'établissement).
2. Aller sur Admin > Publipostage pour cet établissement, avec au moins un utilisateur fédéré sans identifiant (compte AAF/csv sans code).
3. Vérifier que le message d'alerte affiche bien la liste des profils réellement configurés en fédéré (et non plus systématiquement "Parents, Enseignants").
4. Modifier la configuration d'authentification de l'établissement (ex. ajouter "Élève" en fédéré) et vérifier que le message se met à jour en conséquence.

# Reminder

- Security flaws: N/A
- Performance impacts (think bulk !): N/A, calcul limité à une liste de 5 profils par appel
- Unit tests were replayed
- Unit tests were added and/or changed: N/A (pas de suite de tests existante sur ce composant)
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: