### PR TITLE
build(admin):#IMPULS-6050-add-mock-i18n

### DIFF
--- a/admin/src/main/ts/proxy-development.conf.js
+++ b/admin/src/main/ts/proxy-development.conf.js
@@ -1,4 +1,4 @@
-const fs = require("fs");
+const fs = require("node:fs");
 const { applyRemoteTarget } = require("./proxy-remote-target");
 const { createLocalI18nFrMock } = require("./proxy-mocks/local-i18n-fr.mock");
 const { createScreebAppIdMock } = require("./proxy-mocks/screeb-app-id.mock");

--- a/admin/src/main/ts/proxy-development.conf.js
+++ b/admin/src/main/ts/proxy-development.conf.js
@@ -1,5 +1,8 @@
 const { on } = require("events");
 const fs = require("fs");
+const { applyRemoteTarget } = require("./proxy-remote-target");
+const { createLocalI18nFrMock } = require("./proxy-mocks/local-i18n-fr.mock");
+const { createScreebAppIdMock } = require("./proxy-mocks/screeb-app-id.mock");
 
 const PROXY_CONFIG = {
   context: [
@@ -55,44 +58,34 @@ const parseEnvFile = (content) => {
   return result;
 };
 
+// Combines several proxy bypass handlers: tries each in order, the first to
+// return a truthy result wins, otherwise the request proxies normally.
+const composeBypass = (handlers) => (req, res) => {
+  for (const handler of handlers) {
+    const result = handler(req, res);
+    if (result) {
+      return result;
+    }
+  }
+  return null;
+};
+
+// Each mock below contributes at most one bypass handler.
+const bypassHandlers = [createLocalI18nFrMock()].filter(Boolean);
+
 if (fs.existsSync("./.env")) {
   const env = parseEnvFile(fs.readFileSync("./.env", "utf-8"));
 
-  const {VITE_RECETTE, VITE_XSRF_TOKEN, VITE_ONE_SESSION_ID} = env;
+  applyRemoteTarget(env, PROXY_CONFIG, PROXY_FAVICO);
 
-  // If VITE_RECETTE is set, we override the target of the proxy configuration to point to the remote server.
-  if (VITE_RECETTE) {
-    console.log("Using remote proxy configuration target: ", VITE_RECETTE);
-    PROXY_CONFIG.target = VITE_RECETTE;
-    PROXY_FAVICO.target = VITE_RECETTE;
-    if (VITE_ONE_SESSION_ID && VITE_XSRF_TOKEN) {
-      PROXY_CONFIG.headers = {
-        cookie: `oneSessionId=${VITE_ONE_SESSION_ID}; authenticated=true; XSRF-TOKEN=${VITE_XSRF_TOKEN}`,
-      };
-      PROXY_CONFIG.onProxyRes = (proxyRes, req, res) => {
-        proxyRes.headers["set-cookie"] = [
-          `oneSessionId=${VITE_ONE_SESSION_ID}`,
-          `XSRF-TOKEN=${VITE_XSRF_TOKEN}`,
-        ];
-      };
-    }
+  const screebAppIdMock = createScreebAppIdMock(env);
+  if (screebAppIdMock) {
+    bypassHandlers.push(screebAppIdMock);
   }
+}
 
-  // Dev-only mock: the platform won't serve the Screeb key on /admin/conf/public
-  // until the backend template.j2 change is deployed. Set SCREEB_APP_ID_DEV in
-  // .env to test the Screeb integration locally.
-  const {SCREEB_APP_ID_DEV} = env;
-  if (SCREEB_APP_ID_DEV) {
-    console.log("Mocking /admin/conf/public with SCREEB_APP_ID_DEV");
-    PROXY_CONFIG.bypass = (req, res) => {
-      if (req.url?.split("?")[0] === "/admin/conf/public") {
-        res.setHeader("Content-Type", "application/json");
-        res.end(JSON.stringify({ "screeb-app-id": SCREEB_APP_ID_DEV }));
-        return true; // response already sent, skip proxying
-      }
-      return null; // proxy normally
-    };
-  }
+if (bypassHandlers.length > 0) {
+  PROXY_CONFIG.bypass = composeBypass(bypassHandlers);
 }
 
 module.exports = [PROXY_CONFIG, PROXY_FAVICO];

--- a/admin/src/main/ts/proxy-development.conf.js
+++ b/admin/src/main/ts/proxy-development.conf.js
@@ -1,4 +1,3 @@
-const { on } = require("events");
 const fs = require("fs");
 const { applyRemoteTarget } = require("./proxy-remote-target");
 const { createLocalI18nFrMock } = require("./proxy-mocks/local-i18n-fr.mock");

--- a/admin/src/main/ts/proxy-mocks/local-i18n-fr.mock.js
+++ b/admin/src/main/ts/proxy-mocks/local-i18n-fr.mock.js
@@ -1,5 +1,5 @@
-const fs = require("fs");
-const path = require("path");
+const fs = require("node:fs");
+const path = require("node:path");
 
 const LOCAL_FR_I18N_PATH = path.resolve(__dirname, "../../resources/i18n/fr.json");
 
@@ -17,6 +17,7 @@ const createLocalI18nFrMock = () => {
       try {
         res.end(fs.readFileSync(LOCAL_FR_I18N_PATH, "utf-8"));
       } catch (e) {
+        console.error("Failed to read local i18n file:", e);
         res.statusCode = 500;
         res.end(JSON.stringify({ error: "Failed to read local i18n file" }));
       }

--- a/admin/src/main/ts/proxy-mocks/local-i18n-fr.mock.js
+++ b/admin/src/main/ts/proxy-mocks/local-i18n-fr.mock.js
@@ -13,8 +13,13 @@ const createLocalI18nFrMock = () => {
   console.log("Mocking /admin/i18n with local i18n/fr.json");
   return (req, res) => {
     if (req.url?.split("?")[0] === "/admin/i18n") {
-      res.setHeader("Content-Type", "application/json");
-      res.end(fs.readFileSync(LOCAL_FR_I18N_PATH, "utf-8"));
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+      try {
+        res.end(fs.readFileSync(LOCAL_FR_I18N_PATH, "utf-8"));
+      } catch (e) {
+        res.statusCode = 500;
+        res.end(JSON.stringify({ error: "Failed to read local i18n file" }));
+      }
       return true; // response already sent, skip proxying
     }
     return null; // proxy normally

--- a/admin/src/main/ts/proxy-mocks/local-i18n-fr.mock.js
+++ b/admin/src/main/ts/proxy-mocks/local-i18n-fr.mock.js
@@ -1,0 +1,24 @@
+const fs = require("fs");
+const path = require("path");
+
+const LOCAL_FR_I18N_PATH = path.resolve(__dirname, "../../resources/i18n/fr.json");
+
+// Dev-only mock: serve the local i18n/fr.json file directly instead of
+// proxying to the backend, so translation edits are reflected immediately
+// without rebuilding/redeploying the backend.
+const createLocalI18nFrMock = () => {
+  if (!fs.existsSync(LOCAL_FR_I18N_PATH)) {
+    return null;
+  }
+  console.log("Mocking /admin/i18n with local i18n/fr.json");
+  return (req, res) => {
+    if (req.url?.split("?")[0] === "/admin/i18n") {
+      res.setHeader("Content-Type", "application/json");
+      res.end(fs.readFileSync(LOCAL_FR_I18N_PATH, "utf-8"));
+      return true; // response already sent, skip proxying
+    }
+    return null; // proxy normally
+  };
+};
+
+module.exports = { createLocalI18nFrMock };

--- a/admin/src/main/ts/proxy-mocks/screeb-app-id.mock.js
+++ b/admin/src/main/ts/proxy-mocks/screeb-app-id.mock.js
@@ -1,0 +1,20 @@
+// Dev-only mock: the platform won't serve the Screeb key on /admin/conf/public
+// until the backend template.j2 change is deployed. Set SCREEB_APP_ID_DEV in
+// .env to test the Screeb integration locally.
+const createScreebAppIdMock = (env) => {
+  const { SCREEB_APP_ID_DEV } = env;
+  if (!SCREEB_APP_ID_DEV) {
+    return null;
+  }
+  console.log("Mocking /admin/conf/public with SCREEB_APP_ID_DEV");
+  return (req, res) => {
+    if (req.url?.split("?")[0] === "/admin/conf/public") {
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ "screeb-app-id": SCREEB_APP_ID_DEV }));
+      return true; // response already sent, skip proxying
+    }
+    return null; // proxy normally
+  };
+};
+
+module.exports = { createScreebAppIdMock };

--- a/admin/src/main/ts/proxy-remote-target.js
+++ b/admin/src/main/ts/proxy-remote-target.js
@@ -1,0 +1,27 @@
+// If VITE_RECETTE is set, override the proxy target to point at a remote
+// server instead of localhost:8090, forwarding the recette session/XSRF
+// cookies so authenticated requests work against that environment.
+const applyRemoteTarget = (env, PROXY_CONFIG, PROXY_FAVICO) => {
+  const { VITE_RECETTE, VITE_XSRF_TOKEN, VITE_ONE_SESSION_ID } = env;
+  if (!VITE_RECETTE) {
+    return;
+  }
+
+  console.log("Using remote proxy configuration target: ", VITE_RECETTE);
+  PROXY_CONFIG.target = VITE_RECETTE;
+  PROXY_FAVICO.target = VITE_RECETTE;
+
+  if (VITE_ONE_SESSION_ID && VITE_XSRF_TOKEN) {
+    PROXY_CONFIG.headers = {
+      cookie: `oneSessionId=${VITE_ONE_SESSION_ID}; authenticated=true; XSRF-TOKEN=${VITE_XSRF_TOKEN}`,
+    };
+    PROXY_CONFIG.onProxyRes = (proxyRes, req, res) => {
+      proxyRes.headers["set-cookie"] = [
+        `oneSessionId=${VITE_ONE_SESSION_ID}`,
+        `XSRF-TOKEN=${VITE_XSRF_TOKEN}`,
+      ];
+    };
+  }
+};
+
+module.exports = { applyRemoteTarget };

--- a/admin/src/main/ts/src/app/core/services/screeb.service.ts
+++ b/admin/src/main/ts/src/app/core/services/screeb.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { Screeb } from '@screeb/sdk-angular';
-import http from 'axios';
 import { Session } from '../store/mappings/session';
 
 type ScreebPublicConf = {
@@ -26,7 +25,11 @@ export class ScreebService {
      * for this platform and allowed for the user's profile.
      */
     public async initFromPlatformConf(session: Session): Promise<void> {
-        const conf = (await http.get<ScreebPublicConf>('/admin/conf/public')).data;
+        const response = await fetch('/admin/conf/public');
+        if (!response.ok) {
+            return;
+        }
+        const conf: ScreebPublicConf = await response.json();
         const appId = conf?.['screeb-app-id'];
         if (!appId) {
             return;


### PR DESCRIPTION
# Description

Le fichier `proxy-development.conf.js` accumulait plusieurs comportements de dev (mock i18n, mock Screeb, cible distante) directement inline, rendant le fichier difficile à maintenir. Cette PR extrait chaque mock dans son propre module sous `proxy-mocks/`, et ajoute un nouveau mock i18n :

- `proxy-mocks/local-i18n-fr.mock.js` (nouveau) : sert directement `resources/i18n/fr.json` sur `/admin/i18n` quand le fichier existe, pour voir les traductions modifiées localement sans rebuild/redeploy du backend.
- `proxy-mocks/screeb-app-id.mock.js` : extraction du mock existant de `/admin/conf/public` (piloté par `SCREEB_APP_ID_DEV`).
- `proxy-remote-target.js` : extraction de la logique de bascule du proxy vers un serveur distant (`VITE_RECETTE`).
- `proxy-development.conf.js` : compose désormais les handlers de bypass via `composeBypass`, pour permettre à plusieurs mocks de coexister.

## Fixes

[IMPULS-6050](https://edifice-community.atlassian.net/browse/IMPULS-6050)

## Type of change

- [x] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

- [x] admin

## Tests

1. Lancer le serveur de dev (`ng serve` / vite) avec un `.env` local
2. Modifier une clé dans `resources/i18n/fr.json`
3. Vérifier que `/admin/i18n` reflète le changement immédiatement, sans rebuild backend
4. Vérifier que les mocks Screeb (`SCREEB_APP_ID_DEV`) et cible distante (`VITE_RECETTE`) fonctionnent toujours comme avant




[IMPULS-6050]: https://edifice-community.atlassian.net/browse/IMPULS-6050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ