### PR TITLE
fix(admin):#IMPULS-6050-refactor mock server to avoid PUT 403

### DIFF
--- a/admin/src/main/ts/package.json
+++ b/admin/src/main/ts/package.json
@@ -26,7 +26,6 @@
     "@angular/platform-browser-dynamic": "^14.1.1",
     "@angular/router": "^14.1.1",
     "@screeb/sdk-angular": "0.7.0",
-    "@screeb/sdk-browser": "0.7.0",
     "axios": "^0.19.0",
     "chardet": "^1.4.0",
     "dayjs": "^1.11.13",

--- a/admin/src/main/ts/proxy-development.conf.js
+++ b/admin/src/main/ts/proxy-development.conf.js
@@ -1,7 +1,10 @@
-const fs = require("node:fs");
-const { applyRemoteTarget } = require("./proxy-remote-target");
-const { createLocalI18nFrMock } = require("./proxy-mocks/local-i18n-fr.mock");
-const { createScreebAppIdMock } = require("./proxy-mocks/screeb-app-id.mock");
+const { on } = require("events");
+const fs = require("fs");
+
+const { applyRemoteTarget } = require("./proxy-mocks/proxy-remote-target");
+const { PROXY_ADMIN_I18N, registerLocalI18nFrMock } = require("./proxy-mocks/local-i18n-fr.mock");
+const { PROXY_ADMIN_CONF_PUBLIC, registerScreebAppIdMock } = require("./proxy-mocks/screeb-app-id.mock");
+const { startMockServer } = require("./proxy-mocks/mock-server");
 
 const PROXY_CONFIG = {
   context: [
@@ -13,9 +16,7 @@ const PROXY_CONFIG = {
     "/timeline",
     "/workspace",
     "/cas",
-    "/admin/conf/public",
     "/admin/public/dist/assets/trumbowyg",
-    "/admin/i18n",
     "/i18n",
     "/languages",
     "/zendeskGuide",
@@ -34,6 +35,13 @@ const PROXY_FAVICO = {
   logLevel: "debug",
   changeOrigin: true,
 };
+
+// Each mock module owns its proxy entry (instead of sharing PROXY_CONFIG's
+// context), so that only the entry whose mock is actually enabled gets its
+// `target` redirected to the local mock server (see
+// proxy-mocks/mock-server.js) — the bulk of routes (e.g. /directory) stay
+// untouched.
+const ALL_PROXIES = [PROXY_CONFIG, PROXY_FAVICO, PROXY_ADMIN_CONF_PUBLIC, PROXY_ADMIN_I18N];
 
 // This function parses a .env file and returns an object with key-value pairs.
 // This is used to uniformize the parsing of the .env file and to avoid using a third-party library.
@@ -57,34 +65,13 @@ const parseEnvFile = (content) => {
   return result;
 };
 
-// Combines several proxy bypass handlers: tries each in order, the first to
-// return a truthy result wins, otherwise the request proxies normally.
-const composeBypass = (handlers) => (req, res) => {
-  for (const handler of handlers) {
-    const result = handler(req, res);
-    if (result) {
-      return result;
-    }
-  }
-  return null;
-};
-
-// Each mock below contributes at most one bypass handler.
-const bypassHandlers = [createLocalI18nFrMock()].filter(Boolean);
-
 if (fs.existsSync("./.env")) {
   const env = parseEnvFile(fs.readFileSync("./.env", "utf-8"));
-
-  applyRemoteTarget(env, PROXY_CONFIG, PROXY_FAVICO);
-
-  const screebAppIdMock = createScreebAppIdMock(env);
-  if (screebAppIdMock) {
-    bypassHandlers.push(screebAppIdMock);
-  }
+  applyRemoteTarget(env, ALL_PROXIES);
+  registerScreebAppIdMock(env.SCREEB_APP_ID_DEV);
 }
 
-if (bypassHandlers.length > 0) {
-  PROXY_CONFIG.bypass = composeBypass(bypassHandlers);
-}
+registerLocalI18nFrMock();
+startMockServer();
 
-module.exports = [PROXY_CONFIG, PROXY_FAVICO];
+module.exports = ALL_PROXIES;

--- a/admin/src/main/ts/proxy-development.conf.js
+++ b/admin/src/main/ts/proxy-development.conf.js
@@ -1,4 +1,3 @@
-const { on } = require("events");
 const fs = require("fs");
 
 const { applyRemoteTarget } = require("./proxy-mocks/proxy-remote-target");

--- a/admin/src/main/ts/proxy-mocks/local-i18n-fr.mock.js
+++ b/admin/src/main/ts/proxy-mocks/local-i18n-fr.mock.js
@@ -1,30 +1,36 @@
 const fs = require("node:fs");
 const path = require("node:path");
+const { registerMockRoute, MOCK_SERVER_TARGET } = require("./mock-server");
 
 const LOCAL_FR_I18N_PATH = path.resolve(__dirname, "../../resources/i18n/fr.json");
+
+const PROXY_ADMIN_I18N = {
+  context: "/admin/i18n",
+  target: "http://localhost:8090",
+  secure: false,
+  logLevel: "debug",
+  changeOrigin: true,
+};
 
 // Dev-only mock: serve the local i18n/fr.json file directly instead of
 // proxying to the backend, so translation edits are reflected immediately
 // without rebuilding/redeploying the backend.
-const createLocalI18nFrMock = () => {
+const registerLocalI18nFrMock = () => {
   if (!fs.existsSync(LOCAL_FR_I18N_PATH)) {
-    return null;
+    return;
   }
   console.log("Mocking /admin/i18n with local i18n/fr.json");
-  return (req, res) => {
-    if (req.url?.split("?")[0] === "/admin/i18n") {
-      res.setHeader("Content-Type", "application/json; charset=utf-8");
-      try {
-        res.end(fs.readFileSync(LOCAL_FR_I18N_PATH, "utf-8"));
-      } catch (e) {
-        console.error("Failed to read local i18n file:", e);
-        res.statusCode = 500;
-        res.end(JSON.stringify({ error: "Failed to read local i18n file" }));
-      }
-      return true; // response already sent, skip proxying
+  registerMockRoute("/admin/i18n", (req, res) => {
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    try {
+      res.end(fs.readFileSync(LOCAL_FR_I18N_PATH, "utf-8"));
+    } catch (e) {
+      console.error("Failed to read local i18n file:", e);
+      res.statusCode = 500;
+      res.end(JSON.stringify({ error: "Failed to read local i18n file" }));
     }
-    return null; // proxy normally
-  };
+  });
+  PROXY_ADMIN_I18N.target = MOCK_SERVER_TARGET;
 };
 
-module.exports = { createLocalI18nFrMock };
+module.exports = { PROXY_ADMIN_I18N, registerLocalI18nFrMock };

--- a/admin/src/main/ts/proxy-mocks/mock-server.js
+++ b/admin/src/main/ts/proxy-mocks/mock-server.js
@@ -30,19 +30,28 @@ const startMockServer = () => {
   if (routes.size === 0) {
     return;
   }
-  http
-    .createServer((req, res) => {
-      const handler = routes.get(req.url?.split("?")[0]);
-      if (handler) {
-        return handler(req, res);
-      }
-      res.statusCode = 404;
-      res.end();
-    })
-    .listen(MOCK_SERVER_PORT);
+  const server = http.createServer((req, res) => {
+    const handler = routes.get(req.url?.split("?")[0]);
+    if (handler) {
+      return handler(req, res);
+    }
+    res.statusCode = 404;
+    res.end();
+  });
+
+  server.on("error", (err) => {
+    if (err && err.code === "EADDRINUSE") {
+      console.warn(
+        `Dev mock server port ${MOCK_SERVER_PORT} already in use; skipping start.`,
+      );
+      return;
+    }
+    throw err;
+  });
+
+  server.listen(MOCK_SERVER_PORT);
   console.log(
     `Dev mock server listening on ${MOCK_SERVER_TARGET} for: ${[...routes.keys()].join(", ")}`,
   );
-};
 
 module.exports = { registerMockRoute, startMockServer, MOCK_SERVER_TARGET };

--- a/admin/src/main/ts/proxy-mocks/mock-server.js
+++ b/admin/src/main/ts/proxy-mocks/mock-server.js
@@ -1,0 +1,48 @@
+const http = require("node:http");
+
+// Dev-only mock routing: path -> (req, res) => void, served by a tiny local
+// HTTP server instead of webpack-dev-server's proxy `bypass` option.
+//
+// `bypass` looked like the natural tool for per-route mocks, but
+// webpack-dev-server has a bug (lib/Server.js, the per-proxy-entry
+// `handler`): whenever a proxy entry's `bypass` returns a falsy-but-not-null
+// value, that entry's own `proxyMiddleware` still gets invoked on the
+// current request even if the request's URL doesn't match that entry's
+// `context`. So merely having a `bypass` defined anywhere in the proxy
+// array causes stray createProxyMiddleware invocations on *every* request,
+// which corrupts body streaming for unrelated PUT/POST/PATCH requests (e.g.
+// to /directory). Pointing a proxy's `target` at this local server instead
+// avoids that code path entirely — it's a plain proxy pass-through, same as
+// any other target.
+
+// Fixed rather than ephemeral so mocks can build their target URL
+// synchronously, before ng serve finishes reading the proxy config.
+const MOCK_SERVER_PORT = 4299;
+const MOCK_SERVER_TARGET = `http://localhost:${MOCK_SERVER_PORT}`;
+
+const routes = new Map();
+
+const registerMockRoute = (urlPath, handler) => {
+  routes.set(urlPath, handler);
+};
+
+const startMockServer = () => {
+  if (routes.size === 0) {
+    return;
+  }
+  http
+    .createServer((req, res) => {
+      const handler = routes.get(req.url?.split("?")[0]);
+      if (handler) {
+        return handler(req, res);
+      }
+      res.statusCode = 404;
+      res.end();
+    })
+    .listen(MOCK_SERVER_PORT);
+  console.log(
+    `Dev mock server listening on ${MOCK_SERVER_TARGET} for: ${[...routes.keys()].join(", ")}`,
+  );
+};
+
+module.exports = { registerMockRoute, startMockServer, MOCK_SERVER_TARGET };

--- a/admin/src/main/ts/proxy-mocks/mock-server.js
+++ b/admin/src/main/ts/proxy-mocks/mock-server.js
@@ -27,31 +27,32 @@ const registerMockRoute = (urlPath, handler) => {
 };
 
 const startMockServer = () => {
-  if (routes.size === 0) {
-    return;
-  }
-  const server = http.createServer((req, res) => {
-    const handler = routes.get(req.url?.split("?")[0]);
-    if (handler) {
-      return handler(req, res);
-    }
-    res.statusCode = 404;
-    res.end();
-  });
-
-  server.on("error", (err) => {
-    if (err && err.code === "EADDRINUSE") {
-      console.warn(
-        `Dev mock server port ${MOCK_SERVER_PORT} already in use; skipping start.`,
-      );
+    if (routes.size === 0) {
       return;
     }
-    throw err;
-  });
+    const server = http.createServer((req, res) => {
+      const handler = routes.get(req.url?.split("?")[0]);
+      if (handler) {
+        return handler(req, res);
+      }
+      res.statusCode = 404;
+      res.end();
+    });
 
-  server.listen(MOCK_SERVER_PORT);
-  console.log(
-    `Dev mock server listening on ${MOCK_SERVER_TARGET} for: ${[...routes.keys()].join(", ")}`,
-  );
+    server.on("error", (err) => {
+      if (err && err.code === "EADDRINUSE") {
+        console.warn(
+          `Dev mock server port ${MOCK_SERVER_PORT} already in use; skipping start.`,
+        );
+        return;
+      }
+      throw err;
+    });
+
+    server.listen(MOCK_SERVER_PORT);
+    console.log(
+      `Dev mock server listening on ${MOCK_SERVER_TARGET} for: ${[...routes.keys()].join(", ")}`,
+    );
+  };
 
 module.exports = { registerMockRoute, startMockServer, MOCK_SERVER_TARGET };

--- a/admin/src/main/ts/proxy-mocks/proxy-remote-target.js
+++ b/admin/src/main/ts/proxy-mocks/proxy-remote-target.js
@@ -1,26 +1,29 @@
 // If VITE_RECETTE is set, override the proxy target to point at a remote
 // server instead of localhost:8090, forwarding the recette session/XSRF
 // cookies so authenticated requests work against that environment.
-const applyRemoteTarget = (env, PROXY_CONFIG, PROXY_FAVICO) => {
+const applyRemoteTarget = (env, proxies) => {
   const { VITE_RECETTE, VITE_XSRF_TOKEN, VITE_ONE_SESSION_ID } = env;
   if (!VITE_RECETTE) {
     return;
   }
 
   console.log("Using remote proxy configuration target: ", VITE_RECETTE);
-  PROXY_CONFIG.target = VITE_RECETTE;
-  PROXY_FAVICO.target = VITE_RECETTE;
+  proxies.forEach((proxy) => {
+    proxy.target = VITE_RECETTE;
+  });
 
   if (VITE_ONE_SESSION_ID && VITE_XSRF_TOKEN) {
-    PROXY_CONFIG.headers = {
-      cookie: `oneSessionId=${VITE_ONE_SESSION_ID}; authenticated=true; XSRF-TOKEN=${VITE_XSRF_TOKEN}`,
-    };
-    PROXY_CONFIG.onProxyRes = (proxyRes, req, res) => {
+    const cookie = `oneSessionId=${VITE_ONE_SESSION_ID}; authenticated=true; XSRF-TOKEN=${VITE_XSRF_TOKEN}`;
+    const onProxyRes = (proxyRes, req, res) => {
       proxyRes.headers["set-cookie"] = [
         `oneSessionId=${VITE_ONE_SESSION_ID}`,
         `XSRF-TOKEN=${VITE_XSRF_TOKEN}`,
       ];
     };
+    proxies.forEach((proxy) => {
+      proxy.headers = { cookie };
+      proxy.onProxyRes = onProxyRes;
+    });
   }
 };
 

--- a/admin/src/main/ts/proxy-mocks/screeb-app-id.mock.js
+++ b/admin/src/main/ts/proxy-mocks/screeb-app-id.mock.js
@@ -1,20 +1,26 @@
+const { registerMockRoute, MOCK_SERVER_TARGET } = require("./mock-server");
+
+const PROXY_ADMIN_CONF_PUBLIC = {
+  context: "/admin/conf/public",
+  target: "http://localhost:8090",
+  secure: false,
+  logLevel: "debug",
+  changeOrigin: true,
+};
+
 // Dev-only mock: the platform won't serve the Screeb key on /admin/conf/public
 // until the backend template.j2 change is deployed. Set SCREEB_APP_ID_DEV in
 // .env to test the Screeb integration locally.
-const createScreebAppIdMock = (env) => {
-  const { SCREEB_APP_ID_DEV } = env;
-  if (!SCREEB_APP_ID_DEV) {
-    return null;
+const registerScreebAppIdMock = (screebAppIdDev) => {
+  if (!screebAppIdDev) {
+    return;
   }
   console.log("Mocking /admin/conf/public with SCREEB_APP_ID_DEV");
-  return (req, res) => {
-    if (req.url?.split("?")[0] === "/admin/conf/public") {
-      res.setHeader("Content-Type", "application/json");
-      res.end(JSON.stringify({ "screeb-app-id": SCREEB_APP_ID_DEV }));
-      return true; // response already sent, skip proxying
-    }
-    return null; // proxy normally
-  };
+  registerMockRoute("/admin/conf/public", (req, res) => {
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({ "screeb-app-id": screebAppIdDev }));
+  });
+  PROXY_ADMIN_CONF_PUBLIC.target = MOCK_SERVER_TARGET;
 };
 
-module.exports = { createScreebAppIdMock };
+module.exports = { PROXY_ADMIN_CONF_PUBLIC, registerScreebAppIdMock };


### PR DESCRIPTION
# Description

Le mock dev `/admin/i18n` ajouté dans #1081 utilisait l'option `bypass` du proxy webpack-dev-server (`ng serve`). Cette option a un bug côté `webpack-dev-server` (`lib/Server.js`) : dès qu'une entrée de proxy définit un `bypass`, son `proxyMiddleware` est ré-invoqué sur **toutes** les requêtes, y compris celles qui ne matchent pas son `context` — ce qui corrompt le streaming du body des requêtes PUT/POST/PATCH sur des routes sans rapport (ex. `/directory/structure/.../default-auth-config`).

Cette PR remplace `bypass` par un mini serveur HTTP local (`proxy-mocks/mock-server.js`, port 4299) : chaque mock enregistre sa route dessus et redirige uniquement son propre `target` de proxy vers ce serveur — un simple pass-through, sans toucher au code path bugué de `bypass`. Elle en profite pour isoler chaque mock (i18n, Screeb) dans son propre fichier sous `proxy-mocks/`, chacun possédant sa config de proxy (`PROXY_ADMIN_I18N`, `PROXY_ADMIN_CONF_PUBLIC`), afin que `proxy-development.conf.js` ne connaisse plus les détails internes de chaque mock (single responsibility).

Détail des changements :

- **`proxy-mocks/mock-server.js`** (nouveau) : mini serveur HTTP local sur le port 4299 (`registerMockRoute(path, handler)` + `startMockServer()`), démarré seulement si au moins un mock est actif. Contient le commentaire expliquant le bug `bypass` évité.
- **`proxy-mocks/local-i18n-fr.mock.js`** : `createLocalI18nFrMock()` (retournait une fonction `bypass`) devient `registerLocalI18nFrMock()` qui enregistre la route sur le mock-server. Le fichier possède désormais aussi sa propre config de proxy `PROXY_ADMIN_I18N` (exportée), avec `target` redirigé vers le mock-server si le fichier `fr.json` local existe.
- **`proxy-mocks/screeb-app-id.mock.js`** : même transformation — `createScreebAppIdMock(env)` devient `registerScreebAppIdMock(screebAppIdDev)`, et le fichier possède désormais sa propre config `PROXY_ADMIN_CONF_PUBLIC` (exportée).
- **`proxy-remote-target.js` → `proxy-mocks/proxy-remote-target.js`** : déplacé pour rester à côté des autres mocks. `applyRemoteTarget(env, PROXY_CONFIG, PROXY_FAVICO)` (2 params positionnels) devient `applyRemoteTarget(env, proxies)` (tableau), pour pouvoir s'appliquer aux 4 configs de proxy désormais exportées, y compris celles des mocks.
- **`proxy-development.conf.js`** : supprime `composeBypass`/`bypassHandlers`/`PROXY_CONFIG.bypass`. Retire `/admin/conf/public` et `/admin/i18n` du `context` partagé de `PROXY_CONFIG` (ces deux routes ont maintenant leur propre config, importée depuis leur mock). Exporte désormais un tableau de 4 proxys au lieu de 2 (`PROXY_CONFIG`, `PROXY_FAVICO`, `PROXY_ADMIN_CONF_PUBLIC`, `PROXY_ADMIN_I18N`).

## Fixes

IMPULS-6050

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [x] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. `ng serve` avec ce fichier, sans `.env` particulier : PUT sur `/directory/structure/<id>/default-auth-config` (ou toute autre route sous `/directory`) répond normalement (plus de 403 / échec silencieux).
2. Avec `admin/src/main/resources/i18n/fr.json` présent : GET `/admin/i18n` sert bien le fichier local (log "Mocking /admin/i18n with local i18n/fr.json" au démarrage).
3. Avec `SCREEB_APP_ID_DEV` défini dans `.env` : GET `/admin/conf/public` renvoie bien `{"screeb-app-id": ...}`.
4. Avec `VITE_RECETTE` défini : les 4 entrées de proxy (y compris les deux mocks non actifs) pointent bien vers la recette et portent les cookies/XSRF attendus.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley:
