### PR TITLE
feat(conversation): #IMPULS-6140 affiche la modale de message d'absence via le menu déroulant

### DIFF
--- a/conversation/backend/src/main/resources/i18n/fr.json
+++ b/conversation/backend/src/main/resources/i18n/fr.json
@@ -31,6 +31,7 @@
   "conversation.absence.invalid.body": "Le contenu du message d'absence est absent ou mal formé",
   "conversation.absence.invalid.dates": "Les dates du message d'absence sont absentes ou mal formées",
   "conversation.absence.invalid.payload": "La requête de paramétrage du message d'absence est invalide",
+  "conversation.absence.menu.label": "Message d'absence",
   "conversation.absence.reply.subject": "Réponse automatique : {0}",
   "conversation.absence.modal.cancel": "Annuler",
   "conversation.absence.modal.dateFormat": "DD/MM/YYYY",

--- a/conversation/frontend/src/components/PortalModal.tsx
+++ b/conversation/frontend/src/components/PortalModal.tsx
@@ -1,0 +1,26 @@
+import { Modal, ModalElement, ModalProps } from '@edifice.io/react';
+import { Ref, forwardRef } from 'react';
+import { createPortal } from 'react-dom';
+
+/**
+ * `Modal` rendered into the `#portal` DOM node instead of wherever it is
+ * mounted in the React tree. Lets a modal be triggered from several,
+ * unrelated places (e.g. a menu item and a banner button) by mounting one
+ * lightweight, independent instance per trigger — each with its own local
+ * `isOpen` state — instead of lifting shared state to a common ancestor.
+ */
+export const PortalModal = forwardRef(
+  ({ children, ...otherProps }: ModalProps, ref: Ref<ModalElement>) => {
+    const portal =
+      (document.getElementById('portal') as HTMLElement) || document.body;
+
+    return createPortal(
+      <Modal ref={ref} {...otherProps}>
+        {children}
+      </Modal>,
+      portal,
+    );
+  },
+);
+
+PortalModal.displayName = 'PortalModal';

--- a/conversation/frontend/src/components/index.ts
+++ b/conversation/frontend/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './FolderActionDropdown';
 export * from './MessageBody';
 export * from './OriginalFormatModal';
+export * from './PortalModal';
 export * from './ProgressBar';

--- a/conversation/frontend/src/features/absence/AbsenceModal.tsx
+++ b/conversation/frontend/src/features/absence/AbsenceModal.tsx
@@ -1,4 +1,5 @@
 import { Modal } from '@edifice.io/react';
+import { PortalModal } from '~/components';
 import { useI18n } from '~/hooks/useI18n';
 import { AbsenceModalForm } from './AbsenceModalForm';
 import { AbsenceModalSkeleton } from './AbsenceModalSkeletonBody';
@@ -15,7 +16,7 @@ export function AbsenceModal({ isOpen, onModalClose }: AbsenceModalProps) {
     useAbsenceModalData();
 
   return (
-    <Modal
+    <PortalModal
       size="lg"
       id="modalAbsence"
       isOpen={isOpen}
@@ -35,6 +36,6 @@ export function AbsenceModal({ isOpen, onModalClose }: AbsenceModalProps) {
           onSave={handleSave}
         />
       )}
-    </Modal>
+    </PortalModal>
   );
 }

--- a/conversation/frontend/src/features/app/Action/AppActionHeader.test.tsx
+++ b/conversation/frontend/src/features/app/Action/AppActionHeader.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '~/mocks/setup';
+import { AppActionHeader } from './AppActionHeader';
+
+const mocks = vi.hoisted(() => ({
+  useEdificeClient: vi.fn(),
+}));
+
+vi.mock('@edifice.io/react', async () => {
+  const actual = await vi.importActual('@edifice.io/react');
+  return {
+    ...actual,
+    useEdificeClient: mocks.useEdificeClient,
+  };
+});
+
+describe('AppActionHeader', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each(['ENSEIGNANT', 'PERSEDUCNAT'])(
+    'shows the absence menu item for a %s profile',
+    async (profile) => {
+      mocks.useEdificeClient.mockReturnValue({ user: { type: profile } });
+
+      const { user } = render(<AppActionHeader />);
+      await user.click(screen.getByTestId('dropdown').querySelector('button')!);
+
+      expect(
+        screen.getByText('conversation.absence.menu.label'),
+      ).toBeInTheDocument();
+    },
+  );
+
+  it.each(['ELEVE', 'PERSRELELEVE', 'SUPERADMIN'])(
+    'hides the absence menu item for a %s profile',
+    async (profile) => {
+      mocks.useEdificeClient.mockReturnValue({ user: { type: profile } });
+
+      const { user } = render(<AppActionHeader />);
+      await user.click(screen.getByTestId('dropdown').querySelector('button')!);
+
+      expect(
+        screen.queryByText('conversation.absence.menu.label'),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  it('opens the absence modal by portal when the menu item is clicked', async () => {
+    mocks.useEdificeClient.mockReturnValue({ user: { type: 'ENSEIGNANT' } });
+
+    const { user } = render(<AppActionHeader />);
+    await user.click(screen.getByTestId('dropdown').querySelector('button')!);
+    await user.click(screen.getByText('conversation.absence.menu.label'));
+
+    expect(document.getElementById('modalAbsence')).toBeInTheDocument();
+  });
+});

--- a/conversation/frontend/src/features/app/Action/AppActionHeader.tsx
+++ b/conversation/frontend/src/features/app/Action/AppActionHeader.tsx
@@ -1,19 +1,37 @@
-import { Dropdown, IconButton, IconButtonProps } from '@edifice.io/react';
-import { IconSettings, IconSignature } from '@edifice.io/react/icons';
-import { Fragment, RefAttributes } from 'react';
+import {
+  Dropdown,
+  IconButton,
+  IconButtonProps,
+  useEdificeClient,
+} from '@edifice.io/react';
+import {
+  IconCalendar,
+  IconSettings,
+  IconSignature,
+} from '@edifice.io/react/icons';
+import { Fragment, RefAttributes, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { NewMessageButton } from '~/components/NewMessageButton';
+import { AbsenceModal } from '~/features';
 import { useI18n } from '~/hooks/useI18n';
 import { useActionsStore } from '~/store/actions';
 import { AppActionMenuOptions } from './AppActionMenuOptions';
 
+const ABSENCE_ALLOWED_PROFILES = ['ENSEIGNANT', 'PERSEDUCNAT'];
+
 export function AppActionHeader() {
   const { t, common_t } = useI18n();
+  const { user } = useEdificeClient();
   const setOpenedModal = useActionsStore.use.setOpenedModal();
   const location = useLocation();
   const draftRoute = '/draft/create';
 
   const isDraft = location.pathname === draftRoute;
+
+  const [isAbsenceModalOpen, setIsAbsenceModalOpen] = useState(false);
+
+  const canManageAbsence =
+    !!user?.type && ABSENCE_ALLOWED_PROFILES.includes(user.type);
 
   const dropdownOptions: AppActionMenuOptions[] = [
     {
@@ -22,6 +40,13 @@ export function AppActionHeader() {
       icon: <IconSignature />,
       action: () => setOpenedModal('signature'),
       visibility: true,
+    },
+    {
+      id: 'absence',
+      label: t('conversation.absence.menu.label'),
+      icon: <IconCalendar />,
+      action: () => setIsAbsenceModalOpen(true),
+      visibility: canManageAbsence,
     },
   ];
 
@@ -69,6 +94,13 @@ export function AppActionHeader() {
             )}
           </Dropdown>
         </div>
+      )}
+
+      {isAbsenceModalOpen && (
+        <AbsenceModal
+          isOpen={isAbsenceModalOpen}
+          onModalClose={() => setIsAbsenceModalOpen(false)}
+        />
       )}
     </>
   );

--- a/conversation/frontend/src/routes/root/index.tsx
+++ b/conversation/frontend/src/routes/root/index.tsx
@@ -7,11 +7,9 @@ import {
   useEdificeClient,
 } from '@edifice.io/react';
 import { QueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
 import { useLoaderData, useLocation, useParams } from 'react-router-dom';
 import { Config, existingActions } from '~/config';
 import {
-  AbsenceModal,
   CreateFolderModal,
   DesktopMenu,
   MobileMenu,
@@ -78,9 +76,6 @@ export function Component() {
 
   const openedModal = useActionsStore.use.openedModal();
 
-  // TODO(IMPULS-6139 QA): temporary, remove before commit. Real entry point is IMPULS-6140.
-  const [isAbsenceModalOpenForQA, setIsAbsenceModalOpenForQA] = useState(true);
-
   if (!init || !currentApp) return <LoadingScreen position={false} />;
 
   if (!actions || !config) {
@@ -125,14 +120,6 @@ export function Component() {
         {openedModal === 'trash' && <TrashFolderModal />}
         {openedModal === 'move-message' && <MoveMessageToFolderModal />}
         {openedModal === 'signature' && <SignatureModal />}
-
-        {/* TODO(IMPULS-6139 QA): temporary, remove before commit. Opens automatically on launch to ease manual testing. */}
-        {isAbsenceModalOpenForQA && (
-          <AbsenceModal
-            isOpen={true}
-            onModalClose={() => setIsAbsenceModalOpenForQA(false)}
-          />
-        )}
       </Layout>
     </div>
   );


### PR DESCRIPTION
# Description

Ajoute le point d'entrée réel de la modale de paramétrage du message d'absence (IMPULS-6138/6139) : un item « Message d'absence » dans le menu déroulant du header (`AppActionHeader`), visible uniquement pour les profils `ENSEIGNANT` et `PERSEDUCNAT`.

Introduit `PortalModal`, un wrapper de `Modal` qui rend via `createPortal` dans le nœud `#portal` plutôt que dans l'arbre React où il est monté. Cela permet de déclencher la modale depuis un point isolé (l'item de menu) avec un état `isOpen` local à l'instance, sans remonter un état partagé vers un ancêtre commun.

Retire l'ouverture automatique temporaire de la modale ajoutée pour les tests QA d'IMPULS-6139 (`isAbsenceModalOpenForQA` dans `routes/root/index.tsx`), qui était explicitement marquée comme à supprimer avant ce commit.

## Fixes

[IMPULS-6140](https://edifice-community.atlassian.net/browse/IMPULS-6140)

## Type of change

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

- [x] conversation

## Tests

1. `cd conversation/frontend && pnpm test` — nouveaux tests dans `AppActionHeader.test.tsx` : visibilité de l'item selon le profil (`ENSEIGNANT`/`PERSEDUCNAT` vs `ELEVE`/`PERSRELELEVE`/`SUPERADMIN`) et ouverture de la modale par portail au clic.
2. Manuel (`pnpm dev:mock`) : se connecter avec un profil enseignant, ouvrir le menu du header, cliquer sur « Message d'absence » → la modale de paramétrage s'ouvre. Avec un profil élève, l'item n'apparaît pas dans le menu.

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley:

[IMPULS-6140]: https://edifice-community.atlassian.net/browse/IMPULS-6140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ