### PR TITLE
feat(conversation): #IMPULS-6147 transmet le fuseau de l'expéditeur dans la charge utile d'envoi

### DIFF
--- a/conversation/frontend/src/services/api/messageService.test.ts
+++ b/conversation/frontend/src/services/api/messageService.test.ts
@@ -71,6 +71,21 @@ describe('Conversation Message Mutation Methods', () => {
     expect(response).toHaveProperty('sent');
   });
 
+  test('includes the sender timezone in the send payload', async () => {
+    const postMock = vi.spyOn(odeServices.http(), 'post');
+
+    await messageService.send('message_draft', { body: 'New content' });
+
+    expect(postMock).toHaveBeenCalledWith(
+      expect.stringContaining('/send?id=message_draft'),
+      expect.objectContaining({
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      }),
+    );
+
+    postMock.mockRestore();
+  });
+
   test('makes a PUT request to move messages to trash', async () => {
     const messageIds = ['f43d3783', '4d14920b'];
 

--- a/conversation/frontend/src/services/api/messageService.ts
+++ b/conversation/frontend/src/services/api/messageService.ts
@@ -130,7 +130,12 @@ export const createMessageService = (baseURL: string) => ({
     if (inReplyToId) {
       postUrl += '&In-Reply-To=' + inReplyToId;
     }
-    return odeServices.http().post<MessageSentResponse>(postUrl, payload);
+    // Transport-only field: reference timezone for the back's absence auto-reply
+    // daily guard. Optional server-side, with a server-side fallback when absent.
+    return odeServices.http().post<MessageSentResponse>(postUrl, {
+      ...payload,
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    });
   },
 
   recall(messageId: string) {


### PR DESCRIPTION
# Description

Ajoute le fuseau horaire du navigateur de l'expéditeur (`Intl.DateTimeFormat().resolvedOptions().timeZone`) à la charge utile de l'appel d'envoi de message (`POST /conversation/send`), dans `messageService.send()`. Ce champ sert de référentiel au garde-fou back « une réponse par jour et par expéditeur » du message d'absence (US-2, IMPULS-6109) : sans lui, la journée de référence est celle du serveur.

- Champ optionnel côté back, avec repli sur le fuseau serveur — aucune rupture pour les clients mobiles qui ne l'envoient pas.
- Calculé automatiquement dans le service d'envoi ; aucun changement requis dans les appelants (`useSendDraft`).
- Handler MSW `send` inchangé : il échoue déjà le payload reçu tel quel, donc reflète automatiquement le nouveau champ.

## Fixes

[IMPULS-6147](https://edifice-community.atlassian.net/browse/IMPULS-6147)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [x] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. `cd conversation/frontend && pnpm test src/services` — couvre `messageService.send`, dont le nouveau test vérifiant l'inclusion du fuseau dans le payload POST.
2. `pnpm typecheck` et `pnpm lint` — aucune nouvelle erreur (l'unique erreur lint restante, sur `moveToFolder`, est préexistante et sans lien avec ce changement).

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley:

[IMPULS-6147]: https://edifice-community.atlassian.net/browse/IMPULS-6147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ