### PR TITLE
feat(conversation):#IMPULS-6133-add-absence-banner

### DIFF
--- a/conversation/backend/src/main/resources/i18n/fr.json
+++ b/conversation/backend/src/main/resources/i18n/fr.json
@@ -25,6 +25,8 @@
   "confirm": "Confirmer",
   "confirm.empty.trash": "Attention ! Vous allez supprimer définitivement l'ensemble des messages et dossiers présents dans votre corbeille",
   "content": "Objet",
+  "conversation.absence.banner.edit": "Modifier",
+  "conversation.absence.banner.text": "Votre message d'absence est actif jusqu'au [[endDate]].",
   "conversation.absence.empty.body": "Saisissez un message avant d'activer votre message d'absence",
   "conversation.absence.end.before.start": "La date de fin doit être postérieure ou égale à la date de début",
   "conversation.absence.forbidden.profile": "Votre profil ne permet pas de paramétrer un message d'absence",

--- a/conversation/frontend/src/features/absence/AbsenceReminderBanner.test.tsx
+++ b/conversation/frontend/src/features/absence/AbsenceReminderBanner.test.tsx
@@ -1,0 +1,45 @@
+import { mockAbsenceSettings } from '~/mocks';
+import { render, screen, waitFor } from '~/mocks/setup';
+import { queryClient } from '~/providers';
+import { absenceService } from '~/services';
+import { AbsenceReminderBanner } from './AbsenceReminderBanner';
+
+// The tiptap `Editor` rendered deep inside `AbsenceModal` isn't worth
+// driving through jsdom for a test that only covers the banner's own
+// rendering and wiring; `AbsenceModal.test.tsx` covers the modal itself.
+vi.mock('./AbsenceModal', () => ({
+  AbsenceModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="absence-modal-stub" /> : null,
+}));
+
+describe('AbsenceReminderBanner', () => {
+  beforeEach(() => {
+    queryClient.clear();
+  });
+
+  it('is not rendered while there is no active absence', async () => {
+    vi.spyOn(absenceService, 'getSettings').mockResolvedValueOnce({
+      ...mockAbsenceSettings,
+      enabled: false,
+    });
+
+    render(<AbsenceReminderBanner />);
+
+    await waitFor(() =>
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('shows the banner and opens the settings modal from its edit button', async () => {
+    const { user } = render(<AbsenceReminderBanner />);
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.queryByTestId('absence-modal-stub')).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByTestId('conversation-absence-banner-button-edit'),
+    );
+
+    expect(screen.getByTestId('absence-modal-stub')).toBeInTheDocument();
+  });
+});

--- a/conversation/frontend/src/features/absence/AbsenceReminderBanner.tsx
+++ b/conversation/frontend/src/features/absence/AbsenceReminderBanner.tsx
@@ -1,0 +1,49 @@
+import { Alert, Button, useDate } from '@edifice.io/react';
+import { useI18n } from '~/hooks/useI18n';
+import { AbsenceModal } from './AbsenceModal';
+import { useAbsenceReminder } from './hooks';
+
+/**
+ * Reminder banner shown on the message list screens (inbox, folders,
+ * outbox, trash) while the user's absence message is active. Not rendered
+ * on the message detail/compose screens, which don't mount this component.
+ */
+export function AbsenceReminderBanner() {
+  const { t } = useI18n();
+  const { formatDate } = useDate();
+  const { isActive, endAt, isModalOpen, openModal, closeModal } =
+    useAbsenceReminder();
+
+  if (!isActive) return null;
+
+  return (
+    <>
+      <Alert
+        type="warning"
+        className="mx-16 mx-lg-24 mt-16"
+        button={
+          <Button
+            type="button"
+            color="tertiary"
+            variant="ghost"
+            data-testid="conversation-absence-banner-button-edit"
+            onClick={openModal}
+          >
+            {t('conversation.absence.banner.edit')}
+          </Button>
+        }
+      >
+        {t('conversation.absence.banner.text', {
+          endDate: formatDate(
+            endAt!,
+            t('conversation.absence.modal.dateFormat'),
+          ),
+        })}
+      </Alert>
+
+      {isModalOpen && (
+        <AbsenceModal isOpen={isModalOpen} onModalClose={closeModal} />
+      )}
+    </>
+  );
+}

--- a/conversation/frontend/src/features/absence/hooks/index.ts
+++ b/conversation/frontend/src/features/absence/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useAbsenceModal';
 export * from './useAbsenceModalData';
+export * from './useAbsenceReminder';

--- a/conversation/frontend/src/features/absence/hooks/useAbsenceReminder.test.ts
+++ b/conversation/frontend/src/features/absence/hooks/useAbsenceReminder.test.ts
@@ -1,0 +1,74 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { mockAbsenceSettings } from '~/mocks';
+import { wrapper } from '~/mocks/setup';
+import { queryClient } from '~/providers';
+import { absenceService } from '~/services';
+import { isAbsenceActive, useAbsenceReminder } from './useAbsenceReminder';
+
+const activeSettings = {
+  enabled: true,
+  startAt: '2026-01-01T00:00:00.000Z',
+  endAt: '2026-01-10T00:00:00.000Z',
+  bodyJson: { type: 'doc', content: [] },
+};
+
+describe('isAbsenceActive', () => {
+  it('is false when there are no settings', () => {
+    expect(isAbsenceActive(null)).toBe(false);
+    expect(isAbsenceActive(undefined)).toBe(false);
+  });
+
+  it('is false when disabled, even within the date range', () => {
+    expect(
+      isAbsenceActive(
+        { ...activeSettings, enabled: false },
+        new Date('2026-01-05T00:00:00.000Z'),
+      ),
+    ).toBe(false);
+  });
+
+  it('is false before startAt or after endAt', () => {
+    expect(
+      isAbsenceActive(activeSettings, new Date('2025-12-31T00:00:00.000Z')),
+    ).toBe(false);
+    expect(
+      isAbsenceActive(activeSettings, new Date('2026-01-11T00:00:00.000Z')),
+    ).toBe(false);
+  });
+
+  it('is true within [startAt, endAt] while enabled', () => {
+    expect(
+      isAbsenceActive(activeSettings, new Date('2026-01-05T00:00:00.000Z')),
+    ).toBe(true);
+  });
+});
+
+describe('useAbsenceReminder', () => {
+  beforeEach(() => {
+    queryClient.clear();
+  });
+
+  it('reflects an active absence from the settings, and toggles the modal state', async () => {
+    const { result } = renderHook(useAbsenceReminder, { wrapper });
+
+    await waitFor(() => expect(result.current.isActive).toBe(true));
+    expect(result.current.isModalOpen).toBe(false);
+
+    act(() => result.current.openModal());
+    expect(result.current.isModalOpen).toBe(true);
+
+    act(() => result.current.closeModal());
+    expect(result.current.isModalOpen).toBe(false);
+  });
+
+  it('is not active when the settings are disabled', async () => {
+    vi.spyOn(absenceService, 'getSettings').mockResolvedValueOnce({
+      ...mockAbsenceSettings,
+      enabled: false,
+    });
+
+    const { result } = renderHook(useAbsenceReminder, { wrapper });
+
+    await waitFor(() => expect(result.current.isActive).toBe(false));
+  });
+});

--- a/conversation/frontend/src/features/absence/hooks/useAbsenceReminder.ts
+++ b/conversation/frontend/src/features/absence/hooks/useAbsenceReminder.ts
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { AbsenceSettings } from '~/models/absence';
+import { useAbsenceSettings } from '~/services/queries';
+
+/**
+ * An absence message is only ever "active" between its bounds while
+ * enabled — deactivation and an elapsed `endAt` both make it inactive.
+ */
+export function isAbsenceActive(
+  settings: AbsenceSettings | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (!settings?.enabled) return false;
+  return now >= new Date(settings.startAt) && now <= new Date(settings.endAt);
+}
+
+/**
+ * Drives the absence reminder banner: whether it should be shown, and the
+ * open/close state of the settings modal opened from its "Edit" button.
+ */
+export function useAbsenceReminder() {
+  const { data: settings } = useAbsenceSettings();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  return {
+    isActive: isAbsenceActive(settings),
+    endAt: settings?.endAt,
+    isModalOpen,
+    openModal: () => setIsModalOpen(true),
+    closeModal: () => setIsModalOpen(false),
+  };
+}

--- a/conversation/frontend/src/features/index.ts
+++ b/conversation/frontend/src/features/index.ts
@@ -1,4 +1,5 @@
 export * from './absence/AbsenceModal';
+export * from './absence/AbsenceReminderBanner';
 export * from './menu';
 export * from './modals/CreateFolderModal';
 export * from './modals/RenameFolderModal';

--- a/conversation/frontend/src/routes/pages/Folder.tsx
+++ b/conversation/frontend/src/routes/pages/Folder.tsx
@@ -4,6 +4,7 @@ import {
   useParams,
   useSearchParams,
 } from 'react-router-dom';
+import { AbsenceReminderBanner } from '~/features/absence/AbsenceReminderBanner';
 import { MessageList } from '~/features/message-list/MessageList';
 import { MessageListSkeleton } from '~/features/message-list/MessageListSkeleton';
 import { MessageListEmpty } from '~/features/message-list/components/MessageListEmpty';
@@ -54,6 +55,7 @@ export function Component() {
 
   return (
     <>
+      <AbsenceReminderBanner />
       {(!!messages?.length ||
         searchParams.get('search') ||
         searchParams.get('unread')) && <MessageListHeader />}


### PR DESCRIPTION
# Description

Ajoute le bandeau de rappel permanent tant qu'un message d'absence est actif (US-4 de la FS-IMPULS-6109), sous-tâche technique IMPULS-6151 du cadrage. S'appuie sur la modale (IMPULS-6138) et les hooks TanStack Query (IMPULS-6139) déjà livrés, ainsi que sur le point d'entrée modale par portail (IMPULS-6140) — cette PR cible donc `feat-IMPULS-6140-menu-open-modal`, pas `master`.

- `useAbsenceReminder` (hook) : dérive l'état actif (activé + `now` dans `[startAt, endAt]`, comparaison d'instants UTC, insensible au fuseau de lecture) depuis `useAbsenceSettings`, et porte l'ouverture/fermeture de la modale.
- `AbsenceReminderBanner` (composant) : `Alert` du DS + bouton "Modifier" affichant la date de fin, ouvre `AbsenceModal` via un état local propre au bandeau (pas de state partagé avec l'entrée de menu).
- Inséré dans `Folder.tsx` (boîte de réception, dossiers, envoyés, corbeille), au-dessus de la barre de recherche — absent de `Message.tsx` (lecture/rédaction), conformément à la révision v5 de la FS (30/07/2026, maquette Figma node `7773-2968`).
- 2 clés i18n ajoutées (`conversation.absence.banner.edit`, `conversation.absence.banner.text`).

## Fixes

[IMPULS-6133](https://edifice-community.atlassian.net/browse/IMPULS-6133) (US-4) — sous-tâche [IMPULS-6151](https://edifice-community.atlassian.net/browse/IMPULS-6151)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [x] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Tests unitaires : `useAbsenceReminder` (calcul d'activité, wiring modale) et `AbsenceReminderBanner` (rendu conditionnel actif/inactif, ouverture de la modale au clic sur "Modifier") — `pnpm test`, `pnpm typecheck`, `pnpm lint`, `pnpm build` : tous au vert.
2. Vérification visuelle manuelle via `pnpm dev:mock` : bandeau visible avec la date de fin sur `/inbox`, clic sur "Modifier" ouvre la modale pré-remplie, bandeau absent sur l'écran de lecture d'un message (`/inbox/message/:id`).

# Reminder

- Security flaws : aucun — lecture de l'état déjà exposé par l'API existante (US-1), pas de nouvelle surface d'entrée.
- Performance impacts (think bulk !) : aucun — réutilise la query TanStack déjà en cache (`useAbsenceSettings`), pas de nouvel appel réseau par écran.
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley:

[IMPULS-6133]: https://edifice-community.atlassian.net/browse/IMPULS-6133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ