### PR TITLE
fix(directory): #IMPULS-6186 exclude CSV user from hasFederatedIdentity filter

### DIFF
--- a/admin/src/main/resources/i18n/fr.json
+++ b/admin/src/main/resources/i18n/fr.json
@@ -859,7 +859,7 @@
   "massmail.filename": "publipostage_pdf",
   "massmail.filters": "Filtrer la liste à publiposter",
   "massmail.firstsort": "Par",
-  "massmail.info.authMode": "Dans votre établissement, certains comptes sont paramétrés pour passer par une authentification externe à l'ENT (par exemple : ÉduConnect, Arena, LiÀ, FranceConnect…). Les utilisateurs concernés ne figureront pas dans la liste ci-dessous car il n’est pas prévu que vous leur donniez un identifiant/mot de passe ENT pour se connecter. Les utilisateurs concernés sont les comptes chargés automatiquement (AAF, csv) pour les profils suivants : {{profiles}}.",
+  "massmail.info.authMode": "Dans votre établissement, certains comptes sont paramétrés pour passer par une authentification externe à l'ENT (par exemple : ÉduConnect, Arena, LiÀ, FranceConnect…). Les utilisateurs concernés ne figureront pas dans la liste ci-dessous car il n’est pas prévu que vous leur donniez un identifiant/mot de passe ENT pour se connecter. Les utilisateurs concernés sont les comptes chargés automatiquement pour les profils suivants : {{profiles}}.",
   "massmail.link.user": "Accéder à la fiche utilisateur",
   "massmail.mail": "Envoyer par mail",
   "massmail.mail.done": "Publipostage mail effectué ",

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultClassService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultClassService.java
@@ -108,7 +108,7 @@ public class DefaultClassService implements ClassService {
 					: "") +
 				"p.name as type, m.blocked as blocked, m.source as source, relativeList, " +
 				" (HAS(m.federatedIDP) AND NOT(m.federatedIDP IS NULL) AND HAS(m.federated) AND m.federated = true) OR " +
-				"  (size(auths) > 0 AND (m.source in ['AAF', 'AAF1D', 'CSV']) AND m.activationCode IS NOT NULL) as hasFederatedIdentity " +
+				"  (size(auths) > 0 AND (m.source in ['AAF', 'AAF1D']) AND m.activationCode IS NOT NULL) as hasFederatedIdentity " +
 				"ORDER BY type, lastName ";
 		neo.execute(query, params, validResultHandler(results));
 	}

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultMassMailService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultMassMailService.java
@@ -420,7 +420,7 @@ public class DefaultMassMailService extends Renders implements MassMailService {
             +", classname, isInClass"
             +", CASE WHEN size(children) = 0 THEN null ELSE head(children) END as child"
             +", (HAS(u.federatedIDP) AND NOT(u.federatedIDP IS NULL) AND HAS(u.federated) AND u.federated = true) OR " +
-            " (size(auths) > 0 AND (u.source in ['AAF', 'AAF1D', 'CSV']) AND u.activationCode IS NOT NULL) as hasFederatedIdentity ";
+            " (size(auths) > 0 AND (u.source in ['AAF', 'AAF1D']) AND u.activationCode IS NOT NULL) as hasFederatedIdentity ";
 
         //Order by
         String sort = " ORDER BY ";
@@ -522,7 +522,7 @@ public class DefaultMassMailService extends Renders implements MassMailService {
 
         withStr += ", CASE count(child) WHEN 0 THEN null ELSE collect(distinct {firstName: child.firstName, lastName: child.lastName, classname: c.name}) END as children ";
         returnStr += ", filter(c IN children WHERE not(c.firstName is null)) as children, (HAS(u.federatedIDP) AND NOT(u.federatedIDP IS NULL) AND HAS(u.federated) AND u.federated = true) OR " +
-                " (size(auths) > 0 AND (u.source in ['AAF', 'AAF1D', 'CSV'] AND u.activationCode IS NOT NULL ))  as hasFederatedIdentity ";
+                " (size(auths) > 0 AND (u.source in ['AAF', 'AAF1D'] AND u.activationCode IS NOT NULL ))  as hasFederatedIdentity ";
 
         String sort = "ORDER BY lastName";
 

--- a/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
+++ b/directory/src/main/java/org/entcore/directory/services/impl/DefaultUserService.java
@@ -432,7 +432,7 @@ public class DefaultUserService implements UserService {
 		}
 
 		query += " (HAS(u.federatedIDP) AND NOT(u.federatedIDP IS NULL) AND HAS(u.federated) AND u.federated = true) OR " +
-				"  (size(auths) > 0 AND (u.source in ['AAF', 'AAF1D', 'CSV']) AND u.activationCode IS NOT NULL) as hasFederatedIdentity, ";
+				"  (size(auths) > 0 AND (u.source in ['AAF', 'AAF1D']) AND u.activationCode IS NOT NULL) as hasFederatedIdentity, ";
 
 		if (getManualGroups)
 			query += "CASE WHEN manualGroups IS NULL THEN [] ELSE manualGroups END as manualGroups, ";
@@ -1337,7 +1337,7 @@ public class DefaultUserService implements UserService {
 				"RETURN DISTINCT u.profiles as profiles, u.id as id, u.firstName as firstName, u.lastName as lastName, u.displayName as displayName, "+
 				"u.email as email, u.homePhone as homePhone, u.mobile as mobile, u.birthDate as birthDate, u.login as originalLogin, relativeList, " +
 				"motto, health, mood, hobbies, " +
-				" (HAS(u.federatedIDP) AND NOT(u.federatedIDP IS NULL) AND HAS(u.federated) AND u.federated = true) OR (size(auths) > 0 AND (u.source in ['AAF', 'AAF1D', 'CSV']) AND u.activationCode IS NOT NULL) as hasFederatedIdentity, " +
+				" (HAS(u.federatedIDP) AND NOT(u.federatedIDP IS NULL) AND HAS(u.federated) AND u.federated = true) OR (size(auths) > 0 AND (u.source in ['AAF', 'AAF1D']) AND u.activationCode IS NOT NULL) as hasFederatedIdentity, " +
 				"CASE WHEN u.totp IS NOT NULL AND u.totp <> '' THEN true ELSE false END as hasTotp, " +
 				"CASE WHEN schools IS NULL THEN [] ELSE schools END as schools ";
 		} catch (ValidationException exception) {


### PR DESCRIPTION
# Description

La spécification sur le grissage des comptes étaient erronées, il faut excelure les personnes provennant d'import CSV

## Fixes

https://edifice-community.atlassian.net/browse/IMPULS-6186

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [x] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: